### PR TITLE
REG-8496 satt en startdatolimit for tilsyn_familiemedlemmer

### DIFF
--- a/apps/testnorge-arena/arena-core/src/main/java/no/nav/registre/arena/core/consumer/rs/TilleggSyntConsumer.java
+++ b/apps/testnorge-arena/arena-core/src/main/java/no/nav/registre/arena/core/consumer/rs/TilleggSyntConsumer.java
@@ -39,7 +39,7 @@ public class TilleggSyntConsumer {
     private UriTemplate arenaTilleggReiseObligatoriskSamlingArbeidssoekereUrl;
     private UriTemplate arenaTilleggReisestoenadArbeidssoekereUrl;
 
-    private LocalDate arenaTilleggTilsynFamiliemedlemmerDateLimit = LocalDate.of(2020, 02, 29);
+    private static final LocalDate arenaTilleggTilsynFamiliemedlemmerDateLimit = LocalDate.of(2020, 02, 29);
 
     public TilleggSyntConsumer(
             RestTemplateBuilder restTemplateBuilder,

--- a/apps/testnorge-arena/arena-core/src/main/java/no/nav/registre/arena/core/consumer/rs/TilleggSyntConsumer.java
+++ b/apps/testnorge-arena/arena-core/src/main/java/no/nav/registre/arena/core/consumer/rs/TilleggSyntConsumer.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriTemplate;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import no.nav.registre.arena.core.consumer.rs.util.ConsumerUtils;
@@ -37,6 +38,8 @@ public class TilleggSyntConsumer {
     private UriTemplate arenaTilleggHjemreiseArbeidssoekereUrl;
     private UriTemplate arenaTilleggReiseObligatoriskSamlingArbeidssoekereUrl;
     private UriTemplate arenaTilleggReisestoenadArbeidssoekereUrl;
+
+    private LocalDate arenaTilleggTilsynFamiliemedlemmerDateLimit = LocalDate.of(2020, 02, 29);
 
     public TilleggSyntConsumer(
             RestTemplateBuilder restTemplateBuilder,
@@ -95,7 +98,7 @@ public class TilleggSyntConsumer {
     }
 
     public List<NyttVedtakTillegg> opprettTilsynFamiliemedlemmer(int antallMeldinger) {
-        return opprettTilleggstoenad(antallMeldinger, arenaTilleggTilsynFamiliemedlemmerUrl);
+        return opprettTilleggstoenad(antallMeldinger, arenaTilleggTilsynFamiliemedlemmerUrl, arenaTilleggTilsynFamiliemedlemmerDateLimit);
     }
 
     public List<NyttVedtakTillegg> opprettTilsynBarnArbeidssoekere(int antallMeldinger) {
@@ -139,6 +142,16 @@ public class TilleggSyntConsumer {
             UriTemplate uri
     ) {
         var postRequest = consumerUtils.createPostRequest(uri, antallMeldinger);
+        return restTemplate.exchange(postRequest, new ParameterizedTypeReference<List<NyttVedtakTillegg>>() {
+        }).getBody();
+    }
+
+    private List<NyttVedtakTillegg> opprettTilleggstoenad(
+            int antallMeldinger,
+            UriTemplate uri,
+            LocalDate startDatoLimit
+    ) {
+        var postRequest = consumerUtils.createPostRequest(uri, antallMeldinger, startDatoLimit);
         return restTemplate.exchange(postRequest, new ParameterizedTypeReference<List<NyttVedtakTillegg>>() {
         }).getBody();
     }

--- a/apps/testnorge-arena/arena-core/src/main/java/no/nav/registre/arena/core/consumer/rs/util/ConsumerUtils.java
+++ b/apps/testnorge-arena/arena-core/src/main/java/no/nav/registre/arena/core/consumer/rs/util/ConsumerUtils.java
@@ -33,14 +33,7 @@ public class ConsumerUtils {
         List<RettighetSyntRequest> requester = new ArrayList<>(antallMeldinger);
         for (int i = 0; i < antallMeldinger; i++) {
             LocalDate startDato = LocalDate.now().minusMonths(rand.nextInt(12));
-            LocalDate sluttDato = startDato.plusDays(rand.nextInt(365 / 2) + (365 / (long) 2));
-            requester.add(RettighetSyntRequest.builder()
-                    .fraDato(startDato)
-                    .tilDato(sluttDato)
-                    .utfall(UTFALL_JA)
-                    .vedtakTypeKode(VEDTAK_TYPE_KODE_O)
-                    .vedtakDato(startDato)
-                    .build());
+            opprettRequest(startDato, requester);
         }
         return RequestEntity
                 .post(uri.expand())
@@ -55,19 +48,25 @@ public class ConsumerUtils {
         List<RettighetSyntRequest> requester = new ArrayList<>(antallMeldinger);
         for (int i = 0; i < antallMeldinger; i++) {
             LocalDate startDato = startDatoLimit.minusMonths(rand.nextInt(12));
-            LocalDate sluttDato = startDato.plusDays(rand.nextInt(365 / 2) + (365 / (long) 2));
-            requester.add(RettighetSyntRequest.builder()
-                    .fraDato(startDato)
-                    .tilDato(sluttDato)
-                    .utfall(UTFALL_JA)
-                    .vedtakTypeKode(VEDTAK_TYPE_KODE_O)
-                    .vedtakDato(startDato)
-                    .build());
+            opprettRequest(startDato, requester);
         }
+
         return RequestEntity
                 .post(uri.expand())
                 .body(requester);
     }
+
+    private void opprettRequest(LocalDate startDato, List<RettighetSyntRequest> requester) {
+        LocalDate sluttDato = startDato.plusDays(rand.nextInt(365 / 2) + (365 / (long) 2));
+        requester.add(RettighetSyntRequest.builder()
+                .fraDato(startDato)
+                .tilDato(sluttDato)
+                .utfall(UTFALL_JA)
+                .vedtakTypeKode(VEDTAK_TYPE_KODE_O)
+                .vedtakDato(startDato)
+                .build());
+    }
+
 
     public static LocalDate getFoedselsdatoFraFnr(String ident) {
         var year = getFullYear(ident);

--- a/apps/testnorge-arena/arena-core/src/main/java/no/nav/registre/arena/core/consumer/rs/util/ConsumerUtils.java
+++ b/apps/testnorge-arena/arena-core/src/main/java/no/nav/registre/arena/core/consumer/rs/util/ConsumerUtils.java
@@ -26,7 +26,7 @@ public class ConsumerUtils {
     public static final String VEDTAK_TYPE_KODE_O = "O";
     public static final String UTFALL_JA = "JA";
 
-    public RequestEntity createPostRequest(
+    public RequestEntity<List<RettighetSyntRequest>> createPostRequest(
             UriTemplate uri,
             int antallMeldinger
     ) {
@@ -40,7 +40,7 @@ public class ConsumerUtils {
                 .body(requester);
     }
 
-    public RequestEntity createPostRequest(
+    public RequestEntity<List<RettighetSyntRequest>> createPostRequest(
             UriTemplate uri,
             int antallMeldinger,
             LocalDate startDatoLimit

--- a/apps/testnorge-arena/arena-core/src/main/java/no/nav/registre/arena/core/consumer/rs/util/ConsumerUtils.java
+++ b/apps/testnorge-arena/arena-core/src/main/java/no/nav/registre/arena/core/consumer/rs/util/ConsumerUtils.java
@@ -47,6 +47,28 @@ public class ConsumerUtils {
                 .body(requester);
     }
 
+    public RequestEntity createPostRequest(
+            UriTemplate uri,
+            int antallMeldinger,
+            LocalDate startDatoLimit
+    ) {
+        List<RettighetSyntRequest> requester = new ArrayList<>(antallMeldinger);
+        for (int i = 0; i < antallMeldinger; i++) {
+            LocalDate startDato = startDatoLimit.minusMonths(rand.nextInt(12));
+            LocalDate sluttDato = startDato.plusDays(rand.nextInt(365 / 2) + (365 / (long) 2));
+            requester.add(RettighetSyntRequest.builder()
+                    .fraDato(startDato)
+                    .tilDato(sluttDato)
+                    .utfall(UTFALL_JA)
+                    .vedtakTypeKode(VEDTAK_TYPE_KODE_O)
+                    .vedtakDato(startDato)
+                    .build());
+        }
+        return RequestEntity
+                .post(uri.expand())
+                .body(requester);
+    }
+
     public static LocalDate getFoedselsdatoFraFnr(String ident) {
         var year = getFullYear(ident);
         var month = parseInt(ident.substring(2, 4));

--- a/apps/testnorge-arena/arena-local/src/main/resources/application.properties
+++ b/apps/testnorge-arena/arena-local/src/main/resources/application.properties
@@ -1,5 +1,5 @@
-testnorge-hodejegeren.rest-api.url="dummy"
-arena-forvalteren.rest-api.url="dummy"
+testnorge-hodejegeren.rest-api.url=${TESTNORGE_HODEJEGEREN_API_URL}
+arena-forvalteren.rest-api.url=${ARENA_FORVALTEREN_API_URL}
 
 synt-arena.rest-api.url=https://nais-synthdata-arena-aap.nais.preprod.local/api
 synt-arena-vedtakshistorikk.rest-api.url=https://nais-synthdata-arena-vedtakshistorikk.nais.preprod.local/api
@@ -7,3 +7,10 @@ synt-arena-vedtakshistorikk.rest-api.url=https://nais-synthdata-arena-vedtakshis
 synt-arena-tiltak.rest-api.url=https://nais-synthdata-arena-tiltak.nais.preprod.local/api
 
 synt-arena-tillegg.rest-api.url=https://nais-synthdata-arena-tilleggsstonad.nais.preprod.local/api
+application.version=@application.version@
+
+ida.username=${IDA_USERNAME}
+ida.password=${IDA_PASSWORD}
+pensjon-testdata-facade.rest-api.url=https://pensjon-testdata-facade.nais.preprod.local/api
+testnorge-token-provider.url=https://testnorge-token-provider.nais.preprod.local/token/user
+synt.rest-api.url=https://syntrest.nais.preprod.local/api


### PR DESCRIPTION
Satt en startdato limit for tilleggstønad tilsyn familiemedlemmer. Det er fordi det er ingen gyldige målgrupper for tilsyn familiemedlemmer etter 29.02.2020 (har blitt avviklet).