### PR TITLE
Bugfix/reg 8593 testnorge arena ung ufoer avviklet fra dato

### DIFF
--- a/apps/testnorge-arena/arena-core/src/main/java/no/nav/registre/arena/core/consumer/rs/AapSyntConsumer.java
+++ b/apps/testnorge-arena/arena-core/src/main/java/no/nav/registre/arena/core/consumer/rs/AapSyntConsumer.java
@@ -27,6 +27,7 @@ import no.nav.registre.testnorge.domain.dto.arena.testnorge.vedtak.NyttVedtakAap
 public class AapSyntConsumer {
 
     private static final LocalDate MINIMUM_DATE = LocalDate.of(2010, 10, 1); // krav i arena
+    public static final LocalDate ARENA_AAP_UNG_UFOER_DATE_LIMIT = LocalDate.of(2020, 1, 31);
 
     private RestTemplate restTemplate;
     private ConsumerUtils consumerUtils;
@@ -101,7 +102,7 @@ public class AapSyntConsumer {
     }
 
     public List<NyttVedtakAap> syntetiserRettighetUngUfoer(int antallMeldinger) {
-        var postRequest = consumerUtils.createPostRequest(arenaAapUngUfoerUrl, antallMeldinger);
+        var postRequest = consumerUtils.createPostRequest(arenaAapUngUfoerUrl, antallMeldinger, ARENA_AAP_UNG_UFOER_DATE_LIMIT);
         return restTemplate.exchange(postRequest, new ParameterizedTypeReference<List<NyttVedtakAap>>() {
         }).getBody();
     }

--- a/apps/testnorge-arena/arena-core/src/main/java/no/nav/registre/arena/core/consumer/rs/TilleggSyntConsumer.java
+++ b/apps/testnorge-arena/arena-core/src/main/java/no/nav/registre/arena/core/consumer/rs/TilleggSyntConsumer.java
@@ -39,7 +39,7 @@ public class TilleggSyntConsumer {
     private UriTemplate arenaTilleggReiseObligatoriskSamlingArbeidssoekereUrl;
     private UriTemplate arenaTilleggReisestoenadArbeidssoekereUrl;
 
-    private static final LocalDate arenaTilleggTilsynFamiliemedlemmerDateLimit = LocalDate.of(2020, 02, 29);
+    public static final LocalDate ARENA_TILLEGG_TILSYN_FAMILIEMEDLEMMER_DATE_LIMIT = LocalDate.of(2020, 02, 29);
 
     public TilleggSyntConsumer(
             RestTemplateBuilder restTemplateBuilder,
@@ -98,7 +98,7 @@ public class TilleggSyntConsumer {
     }
 
     public List<NyttVedtakTillegg> opprettTilsynFamiliemedlemmer(int antallMeldinger) {
-        return opprettTilleggstoenad(antallMeldinger, arenaTilleggTilsynFamiliemedlemmerUrl, arenaTilleggTilsynFamiliemedlemmerDateLimit);
+        return opprettTilleggstoenad(antallMeldinger, arenaTilleggTilsynFamiliemedlemmerUrl, ARENA_TILLEGG_TILSYN_FAMILIEMEDLEMMER_DATE_LIMIT);
     }
 
     public List<NyttVedtakTillegg> opprettTilsynBarnArbeidssoekere(int antallMeldinger) {

--- a/apps/testnorge-arena/arena-core/src/test/java/no/nav/registre/arena/core/service/VedtakshistorikkServiceTest.java
+++ b/apps/testnorge-arena/arena-core/src/test/java/no/nav/registre/arena/core/service/VedtakshistorikkServiceTest.java
@@ -10,6 +10,8 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import static no.nav.registre.arena.core.consumer.rs.AapSyntConsumer.ARENA_AAP_UNG_UFOER_DATE_LIMIT;
+
 import no.nav.registre.testnorge.domain.dto.arena.testnorge.aap.gensaksopplysninger.Saksopplysning;
 import no.nav.registre.testnorge.domain.dto.arena.testnorge.historikk.Vedtakshistorikk;
 import no.nav.registre.testnorge.domain.dto.arena.testnorge.vedtak.NyttVedtakAap;
@@ -60,6 +62,7 @@ public class VedtakshistorikkServiceTest {
     private List<Vedtakshistorikk> vedtakshistorikkListe;
     private List<NyttVedtakAap> aapRettigheter;
     private List<NyttVedtakAap> ungUfoerRettigheter;
+    private List<NyttVedtakAap> ungUfoerRettigheterUgyldig;
     private List<NyttVedtakAap> tvungenForvaltningRettigheter;
     private List<NyttVedtakAap> fritakMeldekortRettigheter;
 
@@ -70,19 +73,24 @@ public class VedtakshistorikkServiceTest {
         Saksopplysning saksopplysning = new Saksopplysning();
         var nyRettighetAap = NyttVedtakAap.builder()
                 .build();
-        nyRettighetAap.setFraDato(LocalDate.now().minusDays(7));
-        nyRettighetAap.setTilDato(LocalDate.now());
+        nyRettighetAap.setFraDato(ARENA_AAP_UNG_UFOER_DATE_LIMIT.minusDays(7));
+        nyRettighetAap.setTilDato(ARENA_AAP_UNG_UFOER_DATE_LIMIT);
         nyRettighetAap.setGenSaksopplysninger(Collections.singletonList(saksopplysning));
         var nyRettighetUngUfoer = NyttVedtakAap.builder()
                 .build();
-        nyRettighetUngUfoer.setFraDato(LocalDate.now().minusDays(7));
+        nyRettighetUngUfoer.setFraDato(ARENA_AAP_UNG_UFOER_DATE_LIMIT.minusDays(7));
         var nyRettighetTvungenForvaltning = NyttVedtakAap.builder()
                 .build();
         var nyRettighetFritakMeldekort = NyttVedtakAap.builder()
                 .build();
 
+        var nyRettighetUngUfoerUgyldig = NyttVedtakAap.builder()
+                .build();
+        nyRettighetUngUfoerUgyldig.setFraDato(LocalDate.now().minusDays(7));
+
         aapRettigheter = new ArrayList<>(Collections.singletonList(nyRettighetAap));
         ungUfoerRettigheter = new ArrayList<>(Collections.singletonList(nyRettighetUngUfoer));
+        ungUfoerRettigheterUgyldig = new ArrayList<>(Collections.singletonList(nyRettighetUngUfoerUgyldig));
         tvungenForvaltningRettigheter = new ArrayList<>(Collections.singletonList(nyRettighetTvungenForvaltning));
         fritakMeldekortRettigheter = new ArrayList<>(Collections.singletonList(nyRettighetFritakMeldekort));
 
@@ -163,5 +171,43 @@ public class VedtakshistorikkServiceTest {
         assertThat(response.get(fnr1).get(3).getNyeRettigheterAap().size(), equalTo(1));
         assertThat(response.get(fnr1).get(3).getNyeRettigheterAap().get(0).getBegrunnelse(), equalTo("Syntetisert rettighet"));
         assertThat(response.get(fnr1).get(3).getFeiledeRettigheter().size(), equalTo(0));
+    }
+
+    @Test
+    public void shouldGenerereVedtakshistorikkOgFjerneUgyldigUngUfoer() {
+        var kontonummer = "12131843564";
+        var forvalterFnr = "02020202020";
+        when(serviceUtils.getIdenterMedKontoinformasjon(avspillergruppeId, miljoe, antallIdenter))
+                .thenReturn(new ArrayList<>(Collections.singletonList(KontoinfoResponse.builder()
+                        .fnr(forvalterFnr)
+                        .kontonummer(kontonummer)
+                        .build())));
+        when(aapSyntConsumer.syntetiserVedtakshistorikk(antallIdenter)).thenReturn(vedtakshistorikkListe);
+
+        var nyRettighetAapResponse = NyttVedtakResponse.builder()
+                .nyeRettigheterAap(aapRettigheter)
+                .feiledeRettigheter(new ArrayList<>())
+                .build();
+        var expectedResponsesFromArenaForvalter = new ArrayList<>(
+                Arrays.asList(
+                        nyRettighetAapResponse
+                ));
+        Map<String, List<NyttVedtakResponse>> responseAsMap = new HashMap<>();
+        responseAsMap.put(fnr1, expectedResponsesFromArenaForvalter);
+
+        when(rettighetArenaForvalterConsumer.opprettRettighet(anyList())).thenReturn(responseAsMap);
+
+        var response = vedtakshistorikkService.genererVedtakshistorikk(avspillergruppeId, miljoe, antallIdenter);
+
+        verify(serviceUtils).getUtvalgteIdenterIAldersgruppe(eq(avspillergruppeId), eq(1), anyInt(), anyInt(), eq(miljoe));
+        verify(aapSyntConsumer).syntetiserVedtakshistorikk(antallIdenter);
+        verify(rettighetAapService).opprettPersonOgInntektIPopp(anyString(), anyString(), any(NyttVedtakAap.class));
+        verify(rettighetArenaForvalterConsumer).opprettRettighet(anyList());
+
+        assertThat(response.get(fnr1).size(), equalTo(1));
+
+        assertThat(response.get(fnr1).get(0).getNyeRettigheterAap().size(), equalTo(1));
+        assertThat(response.get(fnr1).get(0).getNyeRettigheterAap().get(0).getBegrunnelse(), equalTo("Syntetisert rettighet"));
+        assertThat(response.get(fnr1).get(0).getFeiledeRettigheter().size(), equalTo(0));
     }
 }


### PR DESCRIPTION
Fjerner vedtak for ung ufør i vedtakshistorikk hvis fra dato er etter avviklet dato (31.1.2020)