### PR TITLE
Fjernet throw exception statement

### DIFF
--- a/apps/testnorge-arena/arena-core/src/main/java/no/nav/registre/arena/core/service/RettighetTiltakService.java
+++ b/apps/testnorge-arena/arena-core/src/main/java/no/nav/registre/arena/core/service/RettighetTiltakService.java
@@ -289,7 +289,8 @@ public class RettighetTiltakService {
         List<RettighetRequest> tiltaksaktiviteter = new ArrayList<>(rettigheter.size());
         for (var rettighet : rettigheter) {
             if (!(rettighet instanceof RettighetTilleggRequest)) {
-                throw new RuntimeException("Opprettelse av tiltaksaktivitet er kun støttet for tilleggsstønad");
+                log.error("Opprettelse av tiltaksaktivitet er kun støttet for tilleggsstønad");
+                continue;
             }
             RettighetTiltaksaktivitetRequest rettighetRequest = new RettighetTiltaksaktivitetRequest();
             rettighetRequest.setPersonident(rettighet.getPersonident());


### PR DESCRIPTION
Fjernet throw exception statement og la til log.error i stedet for at generering av vedtakshistorikk skal fortsette selv om det er en feil. 