### PR TITLE
Bugfix/reg 8623 testnorge arena for lang varighet paa aap spe

### DIFF
--- a/apps/testnorge-arena/arena-core/src/main/java/no/nav/registre/arena/core/service/RettighetAapService.java
+++ b/apps/testnorge-arena/arena-core/src/main/java/no/nav/registre/arena/core/service/RettighetAapService.java
@@ -45,6 +45,8 @@ public class RettighetAapService {
     private final PensjonTestdataFacadeConsumer pensjonTestdataFacadeConsumer;
     private final Random rand;
 
+    private final static String SYKEPENGEERSTATNING = "SPE";
+
     public Map<String, List<NyttVedtakResponse>> genererAapMedTilhoerende115(
             Long avspillergruppeId,
             String miljoe,
@@ -72,6 +74,12 @@ public class RettighetAapService {
             rettighetRequest.setPersonident(ident);
             rettighetRequest.setMiljoe(miljoe);
 
+            rettighetRequest.getNyeAap().forEach(rettighet -> {
+                if(rettighet.getAktivitetsfase().equals(SYKEPENGEERSTATNING)){
+
+                }
+            });
+
             rettigheter.add(rettighetRequest);
         }
 
@@ -81,6 +89,10 @@ public class RettighetAapService {
         serviceUtils.lagreIHodejegeren(identerMedOpprettedeRettigheter);
 
         return identerMedOpprettedeRettigheter;
+    }
+
+    public RettighetRequest sjekkDatoOgOppdater(RettighetRequest rettighetRequest){
+
     }
 
     public Map<String, List<NyttVedtakResponse>> genererAapMedTilhoerende115(

--- a/apps/testnorge-arena/arena-core/src/main/java/no/nav/registre/arena/core/service/RettighetAapService.java
+++ b/apps/testnorge-arena/arena-core/src/main/java/no/nav/registre/arena/core/service/RettighetAapService.java
@@ -13,12 +13,7 @@ import no.nav.registre.testnorge.domain.dto.arena.testnorge.vedtak.NyttVedtakAap
 import no.nav.registre.testnorge.domain.dto.arena.testnorge.vedtak.NyttVedtakResponse;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Random;
+import java.util.*;
 
 import no.nav.registre.arena.core.consumer.rs.AapSyntConsumer;
 import no.nav.registre.arena.core.consumer.rs.RettighetArenaForvalterConsumer;
@@ -45,7 +40,8 @@ public class RettighetAapService {
     private final PensjonTestdataFacadeConsumer pensjonTestdataFacadeConsumer;
     private final Random rand;
 
-    private final static String SYKEPENGEERSTATNING = "SPE";
+    public final static String SYKEPENGEERSTATNING = "SPE";
+    public final static int SYKEPENGEERSTATNING_MAKS_PERIODE = 6;
 
     public Map<String, List<NyttVedtakResponse>> genererAapMedTilhoerende115(
             Long avspillergruppeId,
@@ -75,8 +71,8 @@ public class RettighetAapService {
             rettighetRequest.setMiljoe(miljoe);
 
             rettighetRequest.getNyeAap().forEach(rettighet -> {
-                if(rettighet.getAktivitetsfase().equals(SYKEPENGEERSTATNING)){
-
+                if(SYKEPENGEERSTATNING.equals(rettighet.getAktivitetsfase())){
+                    serviceUtils.setDatoPeriodeVedtakInnenforMaxAntallMaaneder(rettighet, SYKEPENGEERSTATNING_MAKS_PERIODE);
                 }
             });
 
@@ -89,10 +85,6 @@ public class RettighetAapService {
         serviceUtils.lagreIHodejegeren(identerMedOpprettedeRettigheter);
 
         return identerMedOpprettedeRettigheter;
-    }
-
-    public RettighetRequest sjekkDatoOgOppdater(RettighetRequest rettighetRequest){
-
     }
 
     public Map<String, List<NyttVedtakResponse>> genererAapMedTilhoerende115(
@@ -113,6 +105,10 @@ public class RettighetAapService {
         var rettighetRequest = new RettighetAapRequest(Collections.singletonList(syntetisertRettighet));
         rettighetRequest.setPersonident(ident);
         rettighetRequest.setMiljoe(miljoe);
+
+        if(SYKEPENGEERSTATNING.equals(rettighetRequest.getNyeAap().get(0).getAktivitetsfase())){
+            serviceUtils.setDatoPeriodeVedtakInnenforMaxAntallMaaneder(rettighetRequest.getNyeAap().get(0), SYKEPENGEERSTATNING_MAKS_PERIODE);
+        }
 
         rettighetArenaForvalterConsumer.opprettRettighet(serviceUtils.opprettArbeidssoekerAap(new ArrayList<>(Collections.singletonList(aap115Rettighet)), miljoe));
         return rettighetArenaForvalterConsumer.opprettRettighet(serviceUtils.opprettArbeidssoekerAap(new ArrayList<>(Collections.singletonList(rettighetRequest)), miljoe));

--- a/apps/testnorge-arena/arena-core/src/main/java/no/nav/registre/arena/core/service/RettighetAapService.java
+++ b/apps/testnorge-arena/arena-core/src/main/java/no/nav/registre/arena/core/service/RettighetAapService.java
@@ -13,7 +13,12 @@ import no.nav.registre.testnorge.domain.dto.arena.testnorge.vedtak.NyttVedtakAap
 import no.nav.registre.testnorge.domain.dto.arena.testnorge.vedtak.NyttVedtakResponse;
 import org.springframework.stereotype.Service;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
 
 import no.nav.registre.arena.core.consumer.rs.AapSyntConsumer;
 import no.nav.registre.arena.core.consumer.rs.RettighetArenaForvalterConsumer;

--- a/apps/testnorge-arena/arena-core/src/main/java/no/nav/registre/arena/core/service/RettighetAapService.java
+++ b/apps/testnorge-arena/arena-core/src/main/java/no/nav/registre/arena/core/service/RettighetAapService.java
@@ -45,8 +45,8 @@ public class RettighetAapService {
     private final PensjonTestdataFacadeConsumer pensjonTestdataFacadeConsumer;
     private final Random rand;
 
-    public final static String SYKEPENGEERSTATNING = "SPE";
-    public final static int SYKEPENGEERSTATNING_MAKS_PERIODE = 6;
+    public static final String SYKEPENGEERSTATNING = "SPE";
+    public static final int SYKEPENGEERSTATNING_MAKS_PERIODE = 6;
 
     public Map<String, List<NyttVedtakResponse>> genererAapMedTilhoerende115(
             Long avspillergruppeId,

--- a/apps/testnorge-arena/arena-core/src/main/java/no/nav/registre/arena/core/service/VedtakshistorikkService.java
+++ b/apps/testnorge-arena/arena-core/src/main/java/no/nav/registre/arena/core/service/VedtakshistorikkService.java
@@ -14,7 +14,6 @@ import static no.nav.registre.arena.core.service.RettighetAapService.SYKEPENGEER
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import no.nav.registre.testnorge.domain.dto.arena.testnorge.vedtak.*;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
@@ -43,6 +42,10 @@ import no.nav.registre.arena.core.service.util.ServiceUtils;
 import no.nav.registre.testnorge.consumers.hodejegeren.response.KontoinfoResponse;
 import no.nav.registre.testnorge.domain.dto.arena.testnorge.aap.gensaksopplysninger.GensakKoder;
 import no.nav.registre.testnorge.domain.dto.arena.testnorge.historikk.Vedtakshistorikk;
+import no.nav.registre.testnorge.domain.dto.arena.testnorge.vedtak.NyttVedtakAap;
+import no.nav.registre.testnorge.domain.dto.arena.testnorge.vedtak.NyttVedtakResponse;
+import no.nav.registre.testnorge.domain.dto.arena.testnorge.vedtak.NyttVedtakTillegg;
+import no.nav.registre.testnorge.domain.dto.arena.testnorge.vedtak.NyttVedtakTiltak;
 
 
 @Slf4j
@@ -67,7 +70,7 @@ public class VedtakshistorikkService {
         for (var vedtakshistorikken : vedtakshistorikk) {
             vedtakshistorikken.setTilsynFamiliemedlemmer(fjernTilsynFamiliemedlemmerVedtakMedUgyldigeDatoer(vedtakshistorikken.getTilsynFamiliemedlemmer()));
             vedtakshistorikken.setUngUfoer(fjernAapUngUfoerMedUgyldigeDatoer(vedtakshistorikken.getUngUfoer()));
-            vedtakshistorikken.setAap(oppdaterAapSykepengeerstatningDatoer(vedtakshistorikken.getAap()));
+            oppdaterAapSykepengeerstatningDatoer(vedtakshistorikken.getAap());
 
             var tidligsteDato = LocalDate.now();
             var aap = finnUtfyltAap(vedtakshistorikken);
@@ -196,7 +199,7 @@ public class VedtakshistorikkService {
         return nyUngUfoer.isEmpty() ? null : nyUngUfoer;
     }
 
-    private List<NyttVedtakAap> oppdaterAapSykepengeerstatningDatoer(List<NyttVedtakAap> aapVedtak) {
+    private void oppdaterAapSykepengeerstatningDatoer(List<NyttVedtakAap> aapVedtak) {
         int antallDagerEndret = 0;
         for (var vedtak : aapVedtak) {
             if(SYKEPENGEERSTATNING.equals(vedtak.getAktivitetsfase())){
@@ -210,8 +213,6 @@ public class VedtakshistorikkService {
                 antallDagerEndret += ChronoUnit.DAYS.between(nyTilDato, originalTilDato);
             }
         }
-
-        return aapVedtak;
     }
 
     private LocalDate finnTidligsteDatoAap(List<NyttVedtakAap> vedtak) {

--- a/apps/testnorge-arena/arena-core/src/main/java/no/nav/registre/arena/core/service/VedtakshistorikkService.java
+++ b/apps/testnorge-arena/arena-core/src/main/java/no/nav/registre/arena/core/service/VedtakshistorikkService.java
@@ -9,6 +9,8 @@ import static no.nav.registre.arena.core.service.util.ServiceUtils.MIN_ALDER_AAP
 import static no.nav.registre.arena.core.service.util.ServiceUtils.MIN_ALDER_UNG_UFOER;
 import static no.nav.registre.arena.core.consumer.rs.AapSyntConsumer.ARENA_AAP_UNG_UFOER_DATE_LIMIT;
 import static no.nav.registre.arena.core.consumer.rs.TilleggSyntConsumer.ARENA_TILLEGG_TILSYN_FAMILIEMEDLEMMER_DATE_LIMIT;
+import static no.nav.registre.arena.core.service.RettighetAapService.SYKEPENGEERSTATNING;
+import static no.nav.registre.arena.core.service.RettighetAapService.SYKEPENGEERSTATNING_MAKS_PERIODE;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -284,7 +286,9 @@ public class VedtakshistorikkService {
             rettighetRequest.setMiljoe(miljoe);
             rettighetRequest.getNyeAap().forEach(rettighet -> {
                 rettighet.setBegrunnelse(BEGRUNNELSE);
-
+                if(SYKEPENGEERSTATNING.equals(rettighet.getAktivitetsfase())){
+                    serviceUtils.setDatoPeriodeVedtakInnenforMaxAntallMaaneder(rettighet, SYKEPENGEERSTATNING_MAKS_PERIODE);
+                }
             });
             rettigheter.add(rettighetRequest);
         }

--- a/apps/testnorge-arena/arena-core/src/main/java/no/nav/registre/arena/core/service/VedtakshistorikkService.java
+++ b/apps/testnorge-arena/arena-core/src/main/java/no/nav/registre/arena/core/service/VedtakshistorikkService.java
@@ -282,7 +282,10 @@ public class VedtakshistorikkService {
             var rettighetRequest = new RettighetAapRequest(aap);
             rettighetRequest.setPersonident(personident);
             rettighetRequest.setMiljoe(miljoe);
-            rettighetRequest.getNyeAap().forEach(rettighet -> rettighet.setBegrunnelse(BEGRUNNELSE));
+            rettighetRequest.getNyeAap().forEach(rettighet -> {
+                rettighet.setBegrunnelse(BEGRUNNELSE);
+
+            });
             rettigheter.add(rettighetRequest);
         }
     }

--- a/apps/testnorge-arena/arena-core/src/main/java/no/nav/registre/arena/core/service/VedtakshistorikkService.java
+++ b/apps/testnorge-arena/arena-core/src/main/java/no/nav/registre/arena/core/service/VedtakshistorikkService.java
@@ -200,17 +200,19 @@ public class VedtakshistorikkService {
     }
 
     private void oppdaterAapSykepengeerstatningDatoer(List<NyttVedtakAap> aapVedtak) {
-        int antallDagerEndret = 0;
-        for (var vedtak : aapVedtak) {
-            if(SYKEPENGEERSTATNING.equals(vedtak.getAktivitetsfase())){
-                vedtak.setFraDato(vedtak.getFraDato().minusDays(antallDagerEndret));
-                vedtak.setTilDato(vedtak.getTilDato().minusDays(antallDagerEndret));
+        if( aapVedtak!= null){
+            int antallDagerEndret = 0;
+            for (var vedtak : aapVedtak) {
+                if(SYKEPENGEERSTATNING.equals(vedtak.getAktivitetsfase())){
+                    vedtak.setFraDato(vedtak.getFraDato().minusDays(antallDagerEndret));
+                    vedtak.setTilDato(vedtak.getTilDato().minusDays(antallDagerEndret));
 
-                var originalTilDato = vedtak.getTilDato();
-                serviceUtils.setDatoPeriodeVedtakInnenforMaxAntallMaaneder(vedtak, SYKEPENGEERSTATNING_MAKS_PERIODE);
-                var nyTilDato = vedtak.getTilDato();
+                    var originalTilDato = vedtak.getTilDato();
+                    serviceUtils.setDatoPeriodeVedtakInnenforMaxAntallMaaneder(vedtak, SYKEPENGEERSTATNING_MAKS_PERIODE);
+                    var nyTilDato = vedtak.getTilDato();
 
-                antallDagerEndret += ChronoUnit.DAYS.between(nyTilDato, originalTilDato);
+                    antallDagerEndret += ChronoUnit.DAYS.between(nyTilDato, originalTilDato);
+                }
             }
         }
     }

--- a/apps/testnorge-arena/arena-core/src/main/java/no/nav/registre/arena/core/service/util/ServiceUtils.java
+++ b/apps/testnorge-arena/arena-core/src/main/java/no/nav/registre/arena/core/service/util/ServiceUtils.java
@@ -5,6 +5,7 @@ import static no.nav.registre.arena.core.consumer.rs.util.ConsumerUtils.EIER;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import no.nav.registre.testnorge.consumers.hodejegeren.response.Relasjon;
+import no.nav.registre.testnorge.domain.dto.arena.testnorge.vedtak.NyttVedtak;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
@@ -328,5 +329,16 @@ public class ServiceUtils {
             }
         }
         return firstResponses;
+    }
+
+    public void setDatoPeriodeVedtakInnenforMaxAntallMaaneder(NyttVedtak vedtak, int antallMaaneder){
+        var tilDato = vedtak.getTilDato();
+        if(tilDato != null){
+            var tilDatoLimit = vedtak.getFraDato().plusMonths(antallMaaneder);
+
+            if(tilDato.isAfter(tilDatoLimit)){
+                vedtak.setTilDato(tilDatoLimit);
+            }
+        }
     }
 }

--- a/apps/testnorge-arena/arena-core/src/test/java/no/nav/registre/arena/core/service/util/ServiceUtilsTest.java
+++ b/apps/testnorge-arena/arena-core/src/test/java/no/nav/registre/arena/core/service/util/ServiceUtilsTest.java
@@ -1,0 +1,48 @@
+package no.nav.registre.arena.core.service.util;
+
+import java.time.LocalDate;
+
+import no.nav.registre.testnorge.domain.dto.arena.testnorge.vedtak.NyttVedtakAap;
+
+import org.junit.Before;
+import org.junit.runner.RunWith;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static no.nav.registre.arena.core.service.RettighetAapService.SYKEPENGEERSTATNING_MAKS_PERIODE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ServiceUtilsTest {
+
+    @InjectMocks
+    private ServiceUtils serviceUtils;
+
+    @Test
+    public void shouldSetDatoPeriodeVedtakInnenforMaxAntallMaaneder(){
+        var ugyldigTilDato = LocalDate.now().plusMonths(SYKEPENGEERSTATNING_MAKS_PERIODE + 1);
+        var gyldigTilDato = LocalDate.now().plusMonths(SYKEPENGEERSTATNING_MAKS_PERIODE - 1);
+        var tilDatoEtterEndring = LocalDate.now().plusMonths(6);
+
+        var vedtakMedUgyldigTilDato = new NyttVedtakAap();
+        vedtakMedUgyldigTilDato.setFraDato(LocalDate.now());
+        vedtakMedUgyldigTilDato.setTilDato(ugyldigTilDato);
+
+        var vedtakMedGyldigTilDato = new NyttVedtakAap();
+        vedtakMedGyldigTilDato.setFraDato(LocalDate.now());
+        vedtakMedGyldigTilDato.setTilDato(gyldigTilDato);
+
+        var vedtakMedNullTilDato = new NyttVedtakAap();
+        vedtakMedNullTilDato.setFraDato(LocalDate.now());
+        vedtakMedNullTilDato.setTilDato(null);
+
+        serviceUtils.setDatoPeriodeVedtakInnenforMaxAntallMaaneder(vedtakMedUgyldigTilDato, SYKEPENGEERSTATNING_MAKS_PERIODE);
+        serviceUtils.setDatoPeriodeVedtakInnenforMaxAntallMaaneder(vedtakMedGyldigTilDato, SYKEPENGEERSTATNING_MAKS_PERIODE);
+        serviceUtils.setDatoPeriodeVedtakInnenforMaxAntallMaaneder(vedtakMedNullTilDato, SYKEPENGEERSTATNING_MAKS_PERIODE);
+
+        assertThat(vedtakMedUgyldigTilDato.getTilDato()).isEqualTo(tilDatoEtterEndring);
+        assertThat(vedtakMedGyldigTilDato.getTilDato()).isEqualTo(gyldigTilDato);
+        assertThat(vedtakMedNullTilDato.getTilDato()).isNull();
+    }
+}

--- a/libs/testnorge-domain/src/main/java/no/nav/registre/testnorge/domain/dto/arena/testnorge/vedtak/NyttVedtak.java
+++ b/libs/testnorge-domain/src/main/java/no/nav/registre/testnorge/domain/dto/arena/testnorge/vedtak/NyttVedtak.java
@@ -26,7 +26,7 @@ import java.util.List;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class NyttVedtak {
 
-    @JsonAlias({ "AVBRUDDSKODE", "avbruddKode" })
+    @JsonAlias({ "AVBRUDDSKODE", "AVBRUDD_KODE", "avbruddKode" })
     private String avbruddKode;
 
     @JsonAlias({ "BEGRUNNELSE", "begrunnelse" })

--- a/libs/testnorge-domain/src/main/java/no/nav/registre/testnorge/domain/dto/arena/testnorge/vedtak/NyttVedtakTiltak.java
+++ b/libs/testnorge-domain/src/main/java/no/nav/registre/testnorge/domain/dto/arena/testnorge/vedtak/NyttVedtakTiltak.java
@@ -57,9 +57,6 @@ public class NyttVedtakTiltak extends NyttVedtak {
     @JsonAlias({"AARSAK_KODE", "aarsakKode"})
     private String aarsakKode;
 
-    @JsonAlias({"AVBRUDD_KODE", "avbruddKode"})
-    private String avbruddKode;
-
     @JsonAlias({ "DATO", "dato" })
     private LocalDate dato;
 
@@ -68,9 +65,6 @@ public class NyttVedtakTiltak extends NyttVedtak {
 
     @JsonAlias({"KOMMENTAR","kommentar"})
     private String kommentar;
-
-    @JsonAlias({"SAKSBEHANDLER", "saksbehandler"})
-    private String saksbehandler;
 
     @JsonAlias({ "TILTAKSKODE", "tiltakskode" })
     private String tiltakskode;


### PR DESCRIPTION
AAP-SPE(sykepengeerstatning) kan ikke ha varighet mer enn 6 mnd. Sjekker derfor perioden på alle SPE-vedtak og oppdaterer dem hvis det trengs. For eks. hvis det er feil på første vedtak blir tilDato satt til fraDato pluss 6 måneder. Datoene til neste SPE-vedtak blir da først oppdatert basert på antall dager som ble endret på tilDato for første vedtak, og så blir den nye perioden sjekket og oppdatert hvis den er mer enn 6 måneder. Også samme for neste vedtak osv.

Fjernet også noen felt i NyttVedtakTiltak siden jeg så feltene allerede var i NyttVedtak.