### PR TITLE
Satt tiltakytelse lik J i tiltaksdeltakelse

### DIFF
--- a/apps/testnorge-arena/arena-core/src/main/java/no/nav/registre/arena/core/service/VedtakshistorikkService.java
+++ b/apps/testnorge-arena/arena-core/src/main/java/no/nav/registre/arena/core/service/VedtakshistorikkService.java
@@ -409,9 +409,10 @@ public class VedtakshistorikkService {
             var rettighetRequest = new RettighetTiltaksdeltakelseRequest(tiltaksdeltakelse);
             rettighetRequest.setPersonident(personident);
             rettighetRequest.setMiljoe(miljoe);
-            rettighetRequest.getNyeTiltaksdeltakelse().forEach(rettighet ->
-                    rettighet.setBegrunnelse(BEGRUNNELSE)
-            );
+            rettighetRequest.getNyeTiltaksdeltakelse().forEach(rettighet -> {
+                rettighet.setBegrunnelse(BEGRUNNELSE);
+                rettighet.setTiltakYtelse("J");
+            });
             rettigheter.add(rettighetRequest);
         }
     }


### PR DESCRIPTION
For at tiltaksdeltakelse skal gi støtte for tiltakspenger og barnetillegg må tiltakYtelse være lik J. 