### PR TITLE
La til en JsonSerializer for AltinnEnum

### DIFF
--- a/apps/testnorge-inntekt/README.md
+++ b/apps/testnorge-inntekt/README.md
@@ -4,6 +4,10 @@ Adapter for inntekt
 Tilbyr endepunkter for å opprette et gitt antall syntetiske inntekter, AltinnInntektmedlinger.
 Arbeidsforholdene til inntektsmeldingene blir validert mot Aareg i miljø.
 
+### Altinn Inntekt
+Altinn inntekt gjør kall til [inntektsmelding-stub](https://github.com/navikt/testnorge/tree/master/apps/inntektsmelding-stub), som oversetter inntektsmeldinger basert på 
+[kodeverk](https://github.com/navikt/tjenestespesifikasjoner/tree/master/nav-altinn-inntektsmelding/src/main/xsd) og legger dem så inn i Joark.
+
 ## Swagger
 Swagger finnes under [/api](https://testnorge-inntekt.nais.preprod.local/api) -endepunktet til applikasjonen.
 

--- a/apps/testnorge-inntekt/src/main/java/no/nav/registre/inntekt/consumer/rs/altinnInntekt/dto/enums/AltinnEnum.java
+++ b/apps/testnorge-inntekt/src/main/java/no/nav/registre/inntekt/consumer/rs/altinnInntekt/dto/enums/AltinnEnum.java
@@ -1,5 +1,9 @@
 package no.nav.registre.inntekt.consumer.rs.altinnInntekt.dto.enums;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import no.nav.registre.inntekt.utils.JsonAltinnEnumSerializer;
+
+@JsonSerialize(using = JsonAltinnEnumSerializer.class)
 public interface AltinnEnum {
     String getValue();
 }

--- a/apps/testnorge-inntekt/src/main/java/no/nav/registre/inntekt/utils/JsonAltinnEnumSerializer.java
+++ b/apps/testnorge-inntekt/src/main/java/no/nav/registre/inntekt/utils/JsonAltinnEnumSerializer.java
@@ -1,0 +1,29 @@
+package no.nav.registre.inntekt.utils;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import no.nav.registre.inntekt.consumer.rs.altinnInntekt.dto.enums.AltinnEnum;
+
+import java.io.IOException;
+
+public class JsonAltinnEnumSerializer extends StdSerializer<AltinnEnum> {
+
+    public JsonAltinnEnumSerializer() {
+        super(AltinnEnum.class);
+    }
+
+    public JsonAltinnEnumSerializer(Class t) {
+        super(t);
+    }
+
+    @Override
+    public void serialize(
+            AltinnEnum altinnEnum,
+            JsonGenerator generator,
+            SerializerProvider provider
+    ) throws IOException, JsonProcessingException {
+        generator.writeString(altinnEnum.getValue());
+    }
+}


### PR DESCRIPTION
La til en JsonSerializer for AltinnEnum, slik at verdiene til enum blir oversatt til riktig kodeverk når de sendes forå bli oversatt til xml.