### PR TITLE
Endret opprettelse av JoarkMetadata

### DIFF
--- a/apps/testnorge-inntekt/src/main/java/no/nav/registre/inntekt/consumer/rs/dokmot/dto/RsJoarkMetadata.java
+++ b/apps/testnorge-inntekt/src/main/java/no/nav/registre/inntekt/consumer/rs/dokmot/dto/RsJoarkMetadata.java
@@ -1,31 +1,13 @@
 package no.nav.registre.inntekt.consumer.rs.dokmot.dto;
 
 import io.swagger.annotations.ApiModel;
-import lombok.Getter;
-import lombok.Setter;
-
-import java.util.Random;
+import lombok.Builder;
+import lombok.Value;
 
 @ApiModel
-@Getter
-@Setter
+@Value
+@Builder
 public class RsJoarkMetadata {
-
-    private static final Random RANDOM = new Random();
-
-    // Default values:
-    private static final String DEFAULT_JOURNALPOST_TYPE = "INNGAAENDE";
-    private static final String DEFAULT_AVSENDER_MOTTAKER_ID_TYPE = "ORGNR";
-    private static final String DEFAULT_BRUKER_ID_TYPE = "FNR";
-    private static final String DEFAULT_TEMA = "FOR";
-    private static final String DEFAULT_TITTEL = "Syntetisk Inntektsmelding";
-    private static final String DEFAULT_KANAL = "ALTINN";
-    private static final String DEFAULT_FILTYPE_XML = "XML";
-    private static final String DEFAULT_FILTYPE_PDF = "PDF";
-    private static final String DEFAULT_VARIANTFORMAT_ORIGINAL = "ORIGINAL";
-    private static final String DEFAULT_VARIANTFORMAT_ARKIV = "ARKIV";
-    private static final String DEFAULT_DOKUMENTER_BREVKODE = "4936";
-    private static final String DEFAULT_DOKUMENTER_BERVKATEGORI = "ES";
 
     private String journalpostType;
     private String avsenderMottakerIdType;
@@ -41,24 +23,4 @@ public class RsJoarkMetadata {
     private String brevkode;
     private String brevkategori;
 
-    public RsJoarkMetadata() {
-        this.journalpostType = DEFAULT_JOURNALPOST_TYPE;
-        this.avsenderMottakerIdType = DEFAULT_AVSENDER_MOTTAKER_ID_TYPE;
-        this.brukerIdType = DEFAULT_BRUKER_ID_TYPE;
-        this.tema = DEFAULT_TEMA;
-        this.tittel = DEFAULT_TITTEL;
-        this.kanal = DEFAULT_KANAL;
-        this.eksternReferanseId = "AR" + randomNumber(7);
-        this.filtypeOriginal = DEFAULT_FILTYPE_XML;
-        this.filtypeArkiv = DEFAULT_FILTYPE_PDF;
-        this.variantformatOriginal = DEFAULT_VARIANTFORMAT_ORIGINAL;
-        this.variantformatArkiv = DEFAULT_VARIANTFORMAT_ARKIV;
-        this.brevkode = DEFAULT_DOKUMENTER_BREVKODE;
-        this.brevkategori = DEFAULT_DOKUMENTER_BERVKATEGORI;
-    }
-
-    private static long randomNumber(int length) {
-        long min = (long) Math.pow(10, (length - 1));
-        return min + RANDOM.nextInt((int)(min * 9));
-    }
 }

--- a/apps/testnorge-inntekt/src/main/java/no/nav/registre/inntekt/consumer/rs/dokmot/dto/RsJoarkMetadata.java
+++ b/apps/testnorge-inntekt/src/main/java/no/nav/registre/inntekt/consumer/rs/dokmot/dto/RsJoarkMetadata.java
@@ -1,12 +1,16 @@
 package no.nav.registre.inntekt.consumer.rs.dokmot.dto;
 
 import io.swagger.annotations.ApiModel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Value;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @ApiModel
-@Value
 @Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class RsJoarkMetadata {
 
     private String journalpostType;

--- a/apps/testnorge-inntekt/src/main/java/no/nav/registre/inntekt/factories/RsJoarkMetadataFactory.java
+++ b/apps/testnorge-inntekt/src/main/java/no/nav/registre/inntekt/factories/RsJoarkMetadataFactory.java
@@ -1,0 +1,58 @@
+package no.nav.registre.inntekt.factories;
+
+import no.nav.registre.inntekt.consumer.rs.altinninntekt.dto.RsInntektsmeldingRequest;
+import no.nav.registre.inntekt.consumer.rs.altinninntekt.dto.enums.YtelseKodeListe;
+import no.nav.registre.inntekt.consumer.rs.dokmot.dto.RsJoarkMetadata;
+
+import java.util.Map;
+import java.util.Random;
+
+import static java.util.Objects.nonNull;
+
+public class RsJoarkMetadataFactory {
+    private RsJoarkMetadataFactory() {}
+
+    private static final Random RANDOM = new Random();
+    private static final Map<YtelseKodeListe, String> ytelseMap = Map.of(
+            YtelseKodeListe.FORELDREPENGER, "FOR",
+            YtelseKodeListe.SVANGERSKAPSPENGER, "FOR",
+            YtelseKodeListe.PLEIEPENGER, "OMS",
+            YtelseKodeListe.OMSORGSPENGER, "OMS",
+            YtelseKodeListe.OPPLAERINGSPENGER, "OMS",
+            YtelseKodeListe.SYKEPENGER, "SYK");
+
+    // Default values:
+    private static final String DEFAULT_JOURNALPOST_TYPE = "INNGAAENDE";
+    private static final String DEFAULT_BRUKER_ID_TYPE = "FNR";
+    private static final String DEFAULT_TITTEL = "Syntetisk Inntektsmelding";
+    private static final String DEFAULT_KANAL = "ALTINN";
+    private static final String DEFAULT_FILTYPE_XML = "XML";
+    private static final String DEFAULT_FILTYPE_PDF = "PDF";
+    private static final String DEFAULT_VARIANTFORMAT_ORIGINAL = "ORIGINAL";
+    private static final String DEFAULT_VARIANTFORMAT_ARKIV = "ARKIV";
+    private static final String DEFAULT_DOKUMENTER_BREVKODE = "4936";
+    private static final String DEFAULT_DOKUMENTER_BERVKATEGORI = "ES";
+
+    public static RsJoarkMetadata create(RsInntektsmeldingRequest inntektsmelding) {
+        return RsJoarkMetadata.builder()
+                .journalpostType(DEFAULT_JOURNALPOST_TYPE)
+                .avsenderMottakerIdType(nonNull(inntektsmelding.getArbeidsgiver()) ? "ORGNR" : "FNR")
+                .brukerIdType(DEFAULT_BRUKER_ID_TYPE)
+                .tema(ytelseMap.get(inntektsmelding.getYtelse()))
+                .tittel(DEFAULT_TITTEL)
+                .kanal(DEFAULT_KANAL)
+                .eksternReferanseId("AR" + randomNumber(7))
+                .filtypeOriginal(DEFAULT_FILTYPE_XML)
+                .filtypeArkiv(DEFAULT_FILTYPE_PDF)
+                .variantformatOriginal(DEFAULT_VARIANTFORMAT_ORIGINAL)
+                .variantformatArkiv(DEFAULT_VARIANTFORMAT_ARKIV)
+                .brevkode(DEFAULT_DOKUMENTER_BREVKODE)
+                .brevkategori(DEFAULT_DOKUMENTER_BERVKATEGORI)
+                .build();
+    }
+
+    private static long randomNumber(int length) {
+        long min = (long) Math.pow(10, (length - 1));
+        return min + RANDOM.nextInt((int)(min * 9));
+    }
+}

--- a/apps/testnorge-inntekt/src/main/java/no/nav/registre/inntekt/service/AltinnInntektService.java
+++ b/apps/testnorge-inntekt/src/main/java/no/nav/registre/inntekt/service/AltinnInntektService.java
@@ -9,6 +9,7 @@ import no.nav.registre.inntekt.consumer.rs.dokmot.dto.InntektDokument;
 import no.nav.registre.inntekt.consumer.rs.dokmot.dto.ProsessertInntektDokument;
 import no.nav.registre.inntekt.consumer.rs.dokmot.dto.RsJoarkMetadata;
 import no.nav.registre.inntekt.factories.RsAltinnInntektsmeldingFactory;
+import no.nav.registre.inntekt.factories.RsJoarkMetadataFactory;
 import no.nav.registre.inntekt.provider.rs.requests.AltinnInntektsmeldingRequest;
 import org.springframework.stereotype.Service;
 
@@ -35,7 +36,7 @@ public class AltinnInntektService {
 
         List<InntektDokument> dokumentListe = request.getInntekter()
                 .stream()
-                .map(melding -> lagInntektDokument(melding, request.getArbeidstakerFnr(), request.getJoarkMetadata()))
+                .map(melding -> lagInntektDokument(melding, request.getArbeidstakerFnr()))
                 .collect(Collectors.toList());
 
         return dokmotConsumer.opprettJournalpost(request.getMiljoe(), dokumentListe, navCallId);
@@ -43,8 +44,7 @@ public class AltinnInntektService {
 
     private InntektDokument lagInntektDokument(
             RsInntektsmeldingRequest rsInntektsmelding,
-            String ident,
-            RsJoarkMetadata metadata
+            String ident
     ) {
         var xmlString  = altinnInntektConsumer.getInntektsmeldingXml201812(RsAltinnInntektsmeldingFactory.create(rsInntektsmelding, ident));
         if (xmlString.equals("")) {
@@ -55,7 +55,7 @@ public class AltinnInntektService {
                 .datoMottatt(Date.from(rsInntektsmelding.getAvsendersystem().getInnsendingstidspunkt().atZone(ZoneId.systemDefault()).toInstant()))
                 .virksomhetsnavn(getVirksomhetsnavn(rsInntektsmelding))
                 .virksomhetsnummer(getVirksomhetsnummer(rsInntektsmelding))
-                .metadata(metadata)
+                .metadata(RsJoarkMetadataFactory.create(rsInntektsmelding))
                 .xml(xmlString)
                 .build();
     }


### PR DESCRIPTION
Det er unødvendig at JoarkMetadata blir sendt inn fra endepunktet, siden verdiene kan bestemmes ut fra innholdet i inntektsmeldingen. Metadata som blir sendt inn fra request blir nå overstyrt av logikk fra RsJoarkMetadataFactory.
Logikk som satte avsendermottakerIdType i dolly er duplisert i fabrikken.