### PR TITLE
Konfigurering av logback

### DIFF
--- a/apps/person-api/src/main/resources/application.yml
+++ b/apps/person-api/src/main/resources/application.yml
@@ -13,3 +13,6 @@ system:
     threads: 5
   tpsf:
     tpsForvalterenUrl: https://tps-forvalteren.nais.preprod.local/api
+
+logging:
+  config: "classpath:logback.xml"

--- a/apps/testnorge-spion/src/main/resources/application.properties
+++ b/apps/testnorge-spion/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 application.version=@application.version@
 application.name=testnorge-spion
+logging.config: "classpath:logback-spring.xml"


### PR DESCRIPTION
La til logback i logging config for testnorge-spion og person-api. Litt usikker på om dette hjelper for peson-api, da spring bør hente logback fila når den heter nettopp "logback.xml".