### PR TITLE
Oppdatert meldekort endepunkt med arbeidstimer request param

### DIFF
--- a/apps/syntrest/src/main/java/no/nav/registre/syntrest/controllers/SyntController.java
+++ b/apps/syntrest/src/main/java/no/nav/registre/syntrest/controllers/SyntController.java
@@ -204,8 +204,9 @@ public class SyntController {
     ) {
         InputValidator.validateInput(numToGenerate);
         InputValidator.validateInput(InputValidator.INPUT_STRING_TYPE.MELDEGRUPPE, meldegruppe);
-        String url = Objects.isNull(arbeidstimer) ? arenaMeldekortUrl :
-                arenaMeldekortUrl + "?arbeidstimer=" + arbeidstimer;
+        String url = Objects.isNull(arbeidstimer)
+                ? arenaMeldekortUrl
+                : arenaMeldekortUrl + "?arbeidstimer=" + arbeidstimer;
 
         List<String> response = (List<String>)
                 meldekortConsumer.synthesizeData(UriExpander.createRequestEntity(url, meldegruppe, numToGenerate));

--- a/apps/syntrest/src/main/java/no/nav/registre/syntrest/controllers/SyntController.java
+++ b/apps/syntrest/src/main/java/no/nav/registre/syntrest/controllers/SyntController.java
@@ -198,12 +198,17 @@ public class SyntController {
             @ApiParam(value = "Meldegruppe", required = true)
             @PathVariable String meldegruppe,
             @ApiParam(value = "Antall meldinger", required = true)
-            @RequestParam int numToGenerate
+            @RequestParam int numToGenerate,
+            @ApiParam(value = "Verdi som vil overskrive alle ArbeidetTimerSum i meldekort")
+            @RequestParam(required = false) Double arbeidstimer
     ) {
         InputValidator.validateInput(numToGenerate);
         InputValidator.validateInput(InputValidator.INPUT_STRING_TYPE.MELDEGRUPPE, meldegruppe);
+        String url = Objects.isNull(arbeidstimer) ? arenaMeldekortUrl :
+                arenaMeldekortUrl + "?arbeidstimer=" + arbeidstimer;
+
         List<String> response = (List<String>)
-                meldekortConsumer.synthesizeData(UriExpander.createRequestEntity(arenaMeldekortUrl, meldegruppe, numToGenerate));
+                meldekortConsumer.synthesizeData(UriExpander.createRequestEntity(url, meldegruppe, numToGenerate));
         doResponseValidation(response);
 
         return ResponseEntity.ok(response);

--- a/apps/syntrest/src/test/java/no/nav/registre/syntrest/controllers/SyntControllerTest.java
+++ b/apps/syntrest/src/test/java/no/nav/registre/syntrest/controllers/SyntControllerTest.java
@@ -158,7 +158,7 @@ public class SyntControllerTest {
 
         when(consumer.synthesizeData(any(RequestEntity.class))).thenReturn(expectedResponse);
 
-        ResponseEntity<List<String>> listResponseEntity = syntController.generateMeldekort("ATTF", numToGenerate);
+        ResponseEntity<List<String>> listResponseEntity = syntController.generateMeldekort("ATTF", numToGenerate, null);
         verify(consumer).synthesizeData(any(RequestEntity.class));
         assertThat(listResponseEntity.getBody(), equalTo(expectedResponse));
     }
@@ -171,7 +171,7 @@ public class SyntControllerTest {
         expectedResponse.add("<XML/>");
         expectedResponse.add("<XML/>");
 
-        ResponseEntity<List<String>> listResponseEntity = syntController.generateMeldekort("Feil", numToGenerate);
+        ResponseEntity<List<String>> listResponseEntity = syntController.generateMeldekort("Feil", numToGenerate, null);
         verify(consumer).synthesizeData(any(RequestEntity.class));
         assertThat(listResponseEntity.getBody(), equalTo(expectedResponse));
     }


### PR DESCRIPTION
Det kommet et ønske fra arena om å gjøre det mulig å sende inn meldekort uten arbeidstimer for gitte personer/tilfeller. Dermed er synt-meldekort blitt oppdatert sånn at det er blitt mulig å sende in request param `arbeidstimer` som da overskriver alle `ArbeidetTimerSum` i meldekortene. Har nå oppdatert syntrest til å også ta inn og videresende denne verdien. 