### PR TITLE
Feature/testnorge frikort ta i bruk syntrest

### DIFF
--- a/apps/syntrest/src/main/java/no/nav/registre/syntrest/controllers/SyntController.java
+++ b/apps/syntrest/src/main/java/no/nav/registre/syntrest/controllers/SyntController.java
@@ -329,7 +329,6 @@ public class SyntController {
             @ApiParam(value = "Map der key=fødselsnummer og value er antall kvitteringer man ønsker å lage for denne identen.", required = true)
             @RequestBody Map<String, Integer> fnrAntMeldingMap
     ) {
-        InputValidator.validateInput(new ArrayList<>(fnrAntMeldingMap.keySet()));
         fnrAntMeldingMap.forEach((key, value) -> InputValidator.validateInput(value));
         Map<String, List<FrikortKvittering>> response = (Map<String, List<FrikortKvittering>>)
                 frikortConsumer.synthesizeData(UriExpander.createRequestEntity(frikortUrl, fnrAntMeldingMap));

--- a/apps/testnorge-frikort/src/main/java/no/nav/registre/frikort/consumer/rs/SyntrestConsumer.java
+++ b/apps/testnorge-frikort/src/main/java/no/nav/registre/frikort/consumer/rs/SyntrestConsumer.java
@@ -42,7 +42,7 @@ public class SyntrestConsumer {
             return restTemplate.exchange(postRequest, new ParameterizedTypeReference<Map<String, List<SyntFrikortResponse>>>() {
             }).getBody();
         } catch (Exception e) {
-            log.error("Uventet feil ved henting av syntetiske egenandeler fra synt-frikort.", e);
+            log.error("Uventet feil ved henting av syntetiske egenandeler fra syntrest.", e);
             throw e;
         }
     }

--- a/apps/testnorge-frikort/src/main/java/no/nav/registre/frikort/consumer/rs/SyntrestConsumer.java
+++ b/apps/testnorge-frikort/src/main/java/no/nav/registre/frikort/consumer/rs/SyntrestConsumer.java
@@ -19,14 +19,14 @@ import no.nav.registre.testnorge.libs.dependencyanalysis.DependencyOn;
 
 @Component
 @Slf4j
-@DependencyOn(value = "nais-synthdata-frikort", external = true)
-public class FrikortSyntetisererenConsumer {
+@DependencyOn(value = "syntrest", external = true)
+public class SyntrestConsumer {
 
     private RestTemplate restTemplate;
     private String syntServerUrl;
 
-    public FrikortSyntetisererenConsumer(
-            @Value("${synthdata.frikort.url}") String syntServerUrl,
+    public SyntrestConsumer(
+            @Value("${syntrest.api.url}") String syntServerUrl,
             RestTemplate restTemplate
     ) {
         this.syntServerUrl = syntServerUrl;
@@ -34,7 +34,7 @@ public class FrikortSyntetisererenConsumer {
     }
 
     public Map<String, List<SyntFrikortResponse>> hentSyntetiskeEgenandelerFraSyntRest(Map<String, Integer> request) {
-        var postRequest = RequestEntity.post(URI.create(syntServerUrl + "/api/v1/generate"))
+        var postRequest = RequestEntity.post(URI.create(syntServerUrl + "/v1/generate/frikort"))
                 .header(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON_VALUE)
                 .body(request);
 

--- a/apps/testnorge-frikort/src/main/java/no/nav/registre/frikort/service/util/ServiceUtils.java
+++ b/apps/testnorge-frikort/src/main/java/no/nav/registre/frikort/service/util/ServiceUtils.java
@@ -22,7 +22,7 @@ import com.google.common.io.Resources;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-import no.nav.registre.frikort.consumer.rs.FrikortSyntetisererenConsumer;
+import no.nav.registre.frikort.consumer.rs.SyntrestConsumer;
 import no.nav.registre.frikort.consumer.rs.response.SyntFrikortResponse;
 import no.nav.registre.frikort.domain.xml.Egenandelskode;
 import no.nav.registre.frikort.exception.UgyldigSamhandlerdataException;
@@ -43,7 +43,7 @@ public class ServiceUtils {
     private static final Long AVSPILLERGRUPPE_SAMHANDLERE = 100001163L;
     private static final String MILJOE_SAMHANDLERE = "q2";
 
-    private final FrikortSyntetisererenConsumer frikortSyntetisererenConsumer;
+    private final SyntrestConsumer syntrestConsumer;
     private final KonverteringService konverteringService;
     private final MqService mqService;
     private final HodejegerenConsumer hodejegerenConsumer;
@@ -106,7 +106,7 @@ public class ServiceUtils {
             paginertMap.put(entry.getKey(), entry.getValue());
             if (parsedSize == PAGE_SIZE || counter == identMap.size()) {
                 try {
-                    egenandeler.putAll(frikortSyntetisererenConsumer.hentSyntetiskeEgenandelerFraSyntRest(paginertMap));
+                    egenandeler.putAll(syntrestConsumer.hentSyntetiskeEgenandelerFraSyntRest(paginertMap));
                 } catch (Exception e) {
                     log.error("Kunne ikke opprette syntetiske egenandeler på identer. Fortsetter med neste batch.", e);
                 }

--- a/apps/testnorge-frikort/src/main/resources/application.properties
+++ b/apps/testnorge-frikort/src/main/resources/application.properties
@@ -1,2 +1,4 @@
 application.version=@application.version@
 application.name=testnorge-frikort
+
+syntrest.api.url=https://syntrest.nais.preprod.local/api

--- a/apps/testnorge-frikort/src/test/java/no/nav/registre/frikort/provider/rs/IdentControllerSyntrestIntegrationTest.java
+++ b/apps/testnorge-frikort/src/test/java/no/nav/registre/frikort/provider/rs/IdentControllerSyntrestIntegrationTest.java
@@ -36,7 +36,7 @@ import no.nav.registre.testnorge.libs.test.JsonWiremockHelper;
 @TestPropertySource(
         locations = { "classpath:application-test.properties" }
 )
-public class IdentControllerSyntFrikortIntegrationTest {
+public class IdentControllerSyntrestIntegrationTest {
 
     @Autowired
     private MockMvc mvc;
@@ -48,7 +48,7 @@ public class IdentControllerSyntFrikortIntegrationTest {
     private final String samhandlerIdent = "01010101010";
 
     @Test
-    public void shouldGetResponseFromSyntFrikort() throws Exception {
+    public void shouldGetResponseFromSyntrest() throws Exception {
         var request = IdentRequest.builder()
                 .identer(Collections.singletonList(IdentMedAntallFrikort.builder()
                         .ident(testIdent)
@@ -83,7 +83,7 @@ public class IdentControllerSyntFrikortIntegrationTest {
 
         JsonWiremockHelper
                 .builder(objectMapper)
-                .withUrlPathMatching("/synt-frikort/api/v1/generate")
+                .withUrlPathMatching("/syntrest/api/v1/generate/frikort")
                 .withRequestBody(syntRequest)
                 .withResponseBody(syntResponse)
                 .stubPost();
@@ -107,7 +107,7 @@ public class IdentControllerSyntFrikortIntegrationTest {
 
         JsonWiremockHelper
                 .builder(objectMapper)
-                .withUrlPathMatching("/synt-frikort/api/v1/generate")
+                .withUrlPathMatching("/syntrest/api/v1/generate/frikort")
                 .withRequestBody(syntRequest)
                 .verifyPost();
     }

--- a/apps/testnorge-frikort/src/test/resources/application-test.properties
+++ b/apps/testnorge-frikort/src/test/resources/application-test.properties
@@ -1,6 +1,6 @@
 application.version=@application.version@
 application.name=testnorge-frikort
-synthdata.frikort.url=http://localhost:${wiremock.server.port:0}/synt-frikort
+syntrest.api.url=http://localhost:${wiremock.server.port:0}/syntrest/api
 testnorge.hodejegeren.url=http://localhost:${wiremock.server.port:0}/testnorge-hodejegeren/api
 spring.cloud.vault.token=dummy
 mq.q2.queue.name=dummy


### PR DESCRIPTION
Har oppdatert testnorge-frikort til å bruke syntrest som proxy til syntdata-frikort i stedet for å kalle på syntdata-frikort direkte. Ble også nødt til å fjerne input validering på innsendt fnrs i syntrest endepunktet siden testnorge-frikort skal kunne be om kun syntetiske egenandeler uten å ta i bruk fnr (i stedet for spesifikk fnr sendes inn string på format "IDENT_X"). 