### PR TITLE
Sjekker om addresse1 i skd-meldinger er satt til den ugyldige verdien…

### DIFF
--- a/apps/testnorge-skd/skd-core/src/main/java/no/nav/registre/skd/service/EksisterendeIdenterService.java
+++ b/apps/testnorge-skd/skd-core/src/main/java/no/nav/registre/skd/service/EksisterendeIdenterService.java
@@ -10,6 +10,7 @@ import static no.nav.registre.skd.service.utilities.IdentUtility.getFoedselsdato
 import static no.nav.registre.skd.service.utilities.RedigereSkdmeldingerUtility.opprettKopiAvSkdMelding;
 import static no.nav.registre.skd.service.utilities.RedigereSkdmeldingerUtility.putEktefellePartnerFnrInnIMelding;
 import static no.nav.registre.skd.service.utilities.RedigereSkdmeldingerUtility.putFnrInnIMelding;
+import static no.nav.registre.skd.service.utilities.RedigereSkdmeldingerUtility.korrigerUtenFastBosted;
 
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
@@ -371,6 +372,9 @@ public class EksisterendeIdenterService {
 
             if (ident != null) {
                 putFnrInnIMelding((RsMeldingstype1Felter) meldinger.get(i), ident);
+                if ("UTENFASTBOSTED".equals(((RsMeldingstype1Felter) meldinger.get(i)).getAdresse1())) {
+                    korrigerUtenFastBosted((RsMeldingstype1Felter) meldinger.get(i));
+                }
                 oppdaterBolk(brukteIdenterIDenneBolken, Collections.singletonList(ident));
             }
         }

--- a/apps/testnorge-skd/skd-core/src/main/java/no/nav/registre/skd/service/NyeIdenterService.java
+++ b/apps/testnorge-skd/skd-core/src/main/java/no/nav/registre/skd/service/NyeIdenterService.java
@@ -2,6 +2,7 @@ package no.nav.registre.skd.service;
 
 import static no.nav.registre.skd.service.utilities.RedigereSkdmeldingerUtility.opprettStatsborgerendringsmelding;
 import static no.nav.registre.skd.service.utilities.RedigereSkdmeldingerUtility.putFnrInnIMelding;
+import static no.nav.registre.skd.service.utilities.RedigereSkdmeldingerUtility.korrigerUtenFastBosted;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -39,6 +40,9 @@ public class NyeIdenterService {
             putFnrInnIMelding((RsMeldingstype1Felter) meldinger.get(i), identer.get(i));
             if (Endringskoder.INNVANDRING.getAarsakskode().equals(meldinger.get(i).getAarsakskode())) {
                 meldinger.add(opprettStatsborgerendringsmelding((RsMeldingstype1Felter) meldinger.get(i)));
+            }
+            if ("UTENFASTBOSTED".equals(((RsMeldingstype1Felter) meldinger.get(i)).getAdresse1())) {
+                korrigerUtenFastBosted((RsMeldingstype1Felter) meldinger.get(i));
             }
         }
         return identer;

--- a/apps/testnorge-skd/skd-core/src/main/java/no/nav/registre/skd/service/SyntetiseringService.java
+++ b/apps/testnorge-skd/skd-core/src/main/java/no/nav/registre/skd/service/SyntetiseringService.java
@@ -102,7 +102,7 @@ public class SyntetiseringService {
         for (var endringskode : sorterteEndringskoder) {
             List<Long> ids = new ArrayList<>();
             try {
-                var syntetiserteSkdmeldinger = tpsSyntetisererenConsumer.getSyntetiserteSkdmeldinger(endringskode.getEndringskode(),
+                List<RsMeldingstype> syntetiserteSkdmeldinger = tpsSyntetisererenConsumer.getSyntetiserteSkdmeldinger(endringskode.getEndringskode(),
                         antallMeldingerPerEndringskode.get(endringskode.getEndringskode()));
                 validationService.logAndRemoveInvalidMessages(syntetiserteSkdmeldinger, endringskode);
 
@@ -117,7 +117,6 @@ public class SyntetiseringService {
                 } else {
                     eksisterendeIdenterService.behandleEksisterendeIdenter(syntetiserteSkdmeldinger, listerMedIdenter, endringskode, miljoe);
                 }
-
                 ids = lagreSkdEndringsmeldingerITpsf(endringskode, syntetiserteSkdmeldinger, genereringsOrdreRequest);
                 idsLagretITpsfMenIkkeTps.addAll(ids);
 

--- a/apps/testnorge-skd/skd-core/src/main/java/no/nav/registre/skd/service/utilities/RedigereSkdmeldingerUtility.java
+++ b/apps/testnorge-skd/skd-core/src/main/java/no/nav/registre/skd/service/utilities/RedigereSkdmeldingerUtility.java
@@ -10,6 +10,11 @@ public class RedigereSkdmeldingerUtility {
 
     private static final String STATSBORGER_KODE_NORGE = "000";
 
+    public static void korrigerUtenFastBosted(RsMeldingstype1Felter melding) {
+        melding.setAdresse1("UTEN FAST BOSTED");
+        melding.setGateGaard("0000");
+    }
+    
     public static void putFnrInnIMelding(RsMeldingstype1Felter melding, String fnr) {
         melding.setFodselsdato(fnr.substring(0, 6));
         melding.setPersonnummer(fnr.substring(6));


### PR DESCRIPTION
… "UTENFASTBOSTED" fra synt-pakken. Dersom den er det, korrigeres addressen til gyldige verdier. Dette gjøres både for identer som får en generellAarsak og når nye identer opprettes.