### PR TITLE
Testnorge skd/vigsels bug

### DIFF
--- a/apps/testnorge-hodejegeren/README.md
+++ b/apps/testnorge-hodejegeren/README.md
@@ -25,3 +25,12 @@ Ha Nav-Tunnel kjørende og kjør LocalApplicationStarter med samme argumenter so
 - -DsocksProxyPort=14122
 - -DsocksNonProxyHosts=127.0.0.1|dl.bintray.com|repo.maven.apache.org|maven.adeo.no|packages.confluent.io|confluent.io|maven.xwiki.org|maven.repository.redhat.com
      
+#### Naisdevice
+Kjør LocalApplicationStarter med
+``` 
+-Dspring.cloud.vault.token=[Kopi av token fra vault]
+```
+i VM-options 
+
+**Notat:**  
+MongoDB nås ikke utenfor utviklerimage.

--- a/apps/testnorge-hodejegeren/README.md
+++ b/apps/testnorge-hodejegeren/README.md
@@ -10,9 +10,11 @@ Swagger finnes under [/api](https://testnorge-hodejegeren.nais.preprod.local/api
     
 ### Utviklerimage
 Kjør LocalApplicationStarter med følgende argumenter:
- - -Djavax.net.ssl.trustStore=[path til lokal truststore]
- - -Djavax.net.ssl.trustStorePassword=[passord til lokal truststore]
- - -Dspring.cloud.vault.token=[Kopier token fra vault]
+```
+-Djavax.net.ssl.trustStore=[path til lokal truststore]
+-Djavax.net.ssl.trustStorePassword=[passord til lokal truststore]
+-Dspring.cloud.vault.token=[Kopier token fra vault]
+```
      
 ### Utenfor utviklerimage
  
@@ -21,9 +23,11 @@ Ha BIG-IP Edge Client kjørende og kjør LocalApplicationStarter med samme argum
      
 #### Mac
 Ha Nav-Tunnel kjørende og kjør LocalApplicationStarter med samme argumenter som for utviklerimage og legg til følgende argumenter:
-- -DsocksProxyHost=127.0.0.1
-- -DsocksProxyPort=14122
-- -DsocksNonProxyHosts=127.0.0.1|dl.bintray.com|repo.maven.apache.org|maven.adeo.no|packages.confluent.io|confluent.io|maven.xwiki.org|maven.repository.redhat.com
+```
+-DsocksProxyHost=127.0.0.1
+-DsocksProxyPort=14122
+-DsocksNonProxyHosts=127.0.0.1|dl.bintray.com|repo.maven.apache.org|maven.adeo.no|packages.confluent.io|confluent.io|maven.xwiki.org|maven.repository.redhat.com
+```
      
 #### Naisdevice
 Kjør LocalApplicationStarter med

--- a/apps/testnorge-hodejegeren/hodejegeren-core/src/main/resources/application-prod.properties
+++ b/apps/testnorge-hodejegeren/hodejegeren-core/src/main/resources/application-prod.properties
@@ -4,17 +4,6 @@ spring.data.mongodb.password=${HODEJEGEREN_DB_PASSWORD}
 spring.data.mongodb.database=${SPRING_DATA_MONGODB_DATABASE}
 spring.data.mongodb.port=${SPRING_DATA_MONGODB_PORT}
 spring.data.mongodb.host=${SPRING_DATA_MONGODB_HOST}
-syntrest.rest.api.url=https://syntrest.nais.preprod.local/api
-sigrunstub.url=https://sigrun-skd-stub.nais.preprod.local/
-testnorge.inntektstub.rest.api.url=https://testnorge-inntektstub.nais.preprod.local/api
-testnorge.arena.rest.api.url=https://testnorge-arena.nais.preprod.local/api
-inst2.web.api.url=https://inst2-q2.nais.preprod.local/web/api
-dolly.rest.api.url=https://dolly-u2.nais.preprod.local/api
-freg.token.provider.url=https://freg-token-provider.nais.preprod.local/token/user
-aaregstub.rest.api.url=https://testnorge-aaregstub.nais.preprod.local/api
-inntekt.rest.api.url=https://testnorge-inntekt.nais.preprod.local/api
-inntektstub.rest.api.url=https://app-q2.adeo.no/inntektstub/api
-aktoerregister.api.url=https://app-%s.adeo.no/aktoerregister/api
 tps-forvalteren.rest-api.url=https://tps-forvalteren.nais.preprod.local/api
 
 testnorges.ida.credential.tpsf.username=${TESTNORGE_IDA_CREDENTIAL_TPSF_USERNAME}

--- a/apps/testnorge-hodejegeren/hodejegeren-local/src/main/resources/application-local.properties
+++ b/apps/testnorge-hodejegeren/hodejegeren-local/src/main/resources/application-local.properties
@@ -1,12 +1,1 @@
-tps-forvalteren.rest-api.url=https://tps-forvalteren.nais.preprod.local/api
-syntrest.rest.api.url=https://syntrest.nais.preprod.local/api
-sigrunstub.url=https://sigrun-skd-stub.nais.preprod.local/
-testnorge.inntektstub.rest.api.url=https://testnorge-inntektstub.nais.preprod.local/api
-testnorge.arena.rest.api.url=https://testnorge-arena.nais.preprod.local/api
-inst2.web.api.url=https://inst2-q2.nais.preprod.local/web/api
-dolly.rest.api.url=https://dolly-u2.nais.preprod.local/api
-freg.token.provider.url=https://freg-token-provider.nais.preprod.local/token/user
-aaregstub.rest.api.url=https://testnorge-aaregstub.nais.preprod.local/api
-inntekt.rest.api.url=https://testnorge-inntekt.nais.preprod.local/api
-inntektstub.rest.api.url=https://app-q2.adeo.no/inntektstub/api
-aktoerregister.api.url=https://app-%s.adeo.no/aktoerregister/api
+tps-forvalteren.rest-api.url=https://tps-forvalteren.dev.adeo.no/api

--- a/apps/testnorge-skd/README.md
+++ b/apps/testnorge-skd/README.md
@@ -10,10 +10,13 @@ Swagger finnes under [/api](https://testnorge-skd.nais.preprod.local/api) -endep
       
 ### Utviklerimage
 Kjør LocalApplicationStarter med følgende argumenter:
-- -Djavax.net.ssl.trustStore=[path til lokal truststore]
-- -Djavax.net.ssl.trustStorePassword=[passord til lokal truststore]
-- -Dspring.cloud.vault.token=[Kopier token fra vault]
-   
+
+```
+ -Djavax.net.ssl.trustStore=[path til lokal truststore]
+ -Djavax.net.ssl.trustStorePassword=[passord til lokal truststore]
+ -Dspring.cloud.vault.token=[Kopier token fra vault]
+```
+
 ### Utenfor utviklerimage
 
 #### Windows
@@ -21,7 +24,16 @@ Ha BIG-IP Edge Client kjørende og kjør LocalApplicationStarter med samme argum
        
 #### Mac
 Ha Nav-Tunnel kjørende og kjør LocalApplicationStarter med samme argumenter som for utviklerimage og legg til følgende argumenter:
-- -DsocksProxyHost=127.0.0.1
-- -DsocksProxyPort=14122
-- -DsocksNonProxyHosts=127.0.0.1|dl.bintray.com|repo.maven.apache.org|maven.adeo.no|packages.confluent.io|confluent.io|maven.xwiki.org|maven.repository.redhat.com
-       
+
+```
+ -DsocksProxyHost=127.0.0.1
+ -DsocksProxyPort=14122
+ -DsocksNonProxyHosts=127.0.0.1|dl.bintray.com|repo.maven.apache.org|maven.adeo.no|packages.confluent.io|confluent.io|maven.xwiki.org|maven.repository.redhat.com
+```
+
+#### Med naisdevice
+Trenger bare legge inn 
+```
+-Dspring.cloud.vault.token=[Kopi av token fra vault]
+```
+i VM options. Kjør med profil `local`.

--- a/apps/testnorge-skd/skd-core/src/main/java/no/nav/registre/skd/commands/HodejegerenStatusQuoCommand.java
+++ b/apps/testnorge-skd/skd-core/src/main/java/no/nav/registre/skd/commands/HodejegerenStatusQuoCommand.java
@@ -1,0 +1,34 @@
+package no.nav.registre.skd.commands;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.Map;
+import java.util.concurrent.Callable;
+
+@Slf4j
+@RequiredArgsConstructor
+public class HodejegerenStatusQuoCommand implements Callable<Map<String, String>> {
+    private final WebClient webClient;
+    private final String ident;
+    private final String endringskode;
+    private final String miljoe;
+    private static final ParameterizedTypeReference<Map<String, String>> RESPONSE_TYPE = new ParameterizedTypeReference<>() {};
+
+    @Override
+    public Map<String, String> call() {
+        return webClient
+                .get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/v1/status-quo")
+                        .queryParam("endringskode", endringskode)
+                        .queryParam("miljoe", miljoe)
+                        .queryParam("fnr", ident)
+                        .build())
+                .retrieve()
+                .bodyToMono(RESPONSE_TYPE)
+                .block();
+    }
+}

--- a/apps/testnorge-skd/skd-core/src/main/java/no/nav/registre/skd/consumer/HodejegerenConsumerSkd.java
+++ b/apps/testnorge-skd/skd-core/src/main/java/no/nav/registre/skd/consumer/HodejegerenConsumerSkd.java
@@ -1,0 +1,24 @@
+package no.nav.registre.skd.consumer;
+
+
+import lombok.extern.slf4j.Slf4j;
+import no.nav.registre.skd.commands.HodejegerenStatusQuoCommand;
+import org.springframework.stereotype.Component;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.Map;
+
+@Slf4j
+@Component
+public class HodejegerenConsumerSkd {
+    private final WebClient webClient;
+
+    public HodejegerenConsumerSkd(@Value("${testnorge-hodejegeren.rest-api.url}") String url) {
+        this.webClient = WebClient.builder().baseUrl(url).build();
+    }
+
+    public Map<String, String> getStatusQuoTilhoerendeEndringskode(String endringskode, String miljoe, String ident) {
+        return new HodejegerenStatusQuoCommand(webClient, ident, endringskode, miljoe).call();
+    }
+}

--- a/apps/testnorge-skd/skd-core/src/main/java/no/nav/registre/skd/service/EksisterendeIdenterService.java
+++ b/apps/testnorge-skd/skd-core/src/main/java/no/nav/registre/skd/service/EksisterendeIdenterService.java
@@ -59,6 +59,9 @@ public class EksisterendeIdenterService {
     static final String STATSBORGER = "statsborger";
 
     @Autowired
+    private no.nav.registre.skd.consumer.HodejegerenConsumerSkd hodejegerenConsumerSkd;
+
+    @Autowired
     private HodejegerenConsumer hodejegerenConsumer;
 
     @Autowired
@@ -434,7 +437,7 @@ public class EksisterendeIdenterService {
             String environment,
             String fnr
     ) {
-        return new HashMap<>(hodejegerenConsumer.getStatusQuoTilhoerendeEndringskode(endringskode.getEndringskode(), environment, fnr));
+        return hodejegerenConsumerSkd.getStatusQuoTilhoerendeEndringskode(endringskode.getEndringskode(), environment, fnr);
     }
 
     private RsMeldingstype1Felter opprettSivilstandsendringsmelding(

--- a/apps/testnorge-skd/skd-core/src/main/java/no/nav/registre/skd/service/EksisterendeIdenterService.java
+++ b/apps/testnorge-skd/skd-core/src/main/java/no/nav/registre/skd/service/EksisterendeIdenterService.java
@@ -50,7 +50,7 @@ public class EksisterendeIdenterService {
     private static final String IDENT = "ident";
     private static final String STATSBORGER_NORGE = "NORGE";
     private static final String SIVILSTANDSENDRING_AARSAKSKODE = "85";
-    private static final int ANTALL_FORSOEK_PER_AARSAK = 3;
+    private static final int ANTALL_FORSOEK_PER_AARSAK = 10;
     static final String RELASJON_FAR = "FARA";
     static final String RELASJON_MOR = "MORA";
     static final String DATO_DO = "datoDo";
@@ -154,6 +154,7 @@ public class EksisterendeIdenterService {
             Endringskoder endringskode,
             String environment
     ) {
+        log.info("Oppretter {} vigsler", meldinger.size());
         List<RsMeldingstype> meldingerForPartnere = new ArrayList<>();
 
         for (int i = 0; i < meldinger.size(); i++) {

--- a/apps/testnorge-skd/skd-core/src/test/java/no/nav/registre/skd/service/EksisterendeIdenterServiceTest.java
+++ b/apps/testnorge-skd/skd-core/src/test/java/no/nav/registre/skd/service/EksisterendeIdenterServiceTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.when;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
 import lombok.extern.slf4j.Slf4j;
+import no.nav.registre.skd.consumer.HodejegerenConsumerSkd;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -60,6 +61,9 @@ public class EksisterendeIdenterServiceTest {
 
     @Mock
     private HodejegerenConsumer hodejegerenConsumer;
+
+    @Mock
+    private HodejegerenConsumerSkd hodejegerenConsumerSkd;
 
     @Mock
     private FoedselService foedselService;
@@ -111,7 +115,7 @@ public class EksisterendeIdenterServiceTest {
 
         eksisterendeIdenterService.behandleGenerellAarsak(meldinger, identer, brukteIdenter, endringskode, environment);
 
-        verify(hodejegerenConsumer, times(2)).getStatusQuoTilhoerendeEndringskode(anyString(), anyString(), anyString());
+        verify(hodejegerenConsumerSkd, times(2)).getStatusQuoTilhoerendeEndringskode(anyString(), anyString(), anyString());
         assertEquals(1, meldinger.size());
         assertEquals(fnr2, ((RsMeldingstype1Felter) meldinger.get(0)).getFodselsdato() + ((RsMeldingstype1Felter) meldinger.get(0)).getPersonnummer());
 
@@ -133,7 +137,7 @@ public class EksisterendeIdenterServiceTest {
 
         eksisterendeIdenterService.behandleGenerellAarsak(meldinger, identer, brukteIdenter, endringskode, environment);
 
-        verify(hodejegerenConsumer, times(3)).getStatusQuoTilhoerendeEndringskode(anyString(), anyString(), anyString());
+        verify(hodejegerenConsumerSkd, times(3)).getStatusQuoTilhoerendeEndringskode(anyString(), anyString(), anyString());
         assertEquals(1, meldinger.size());
         assertEquals(fnr3, ((RsMeldingstype1Felter) meldinger.get(0)).getFodselsdato() + ((RsMeldingstype1Felter) meldinger.get(0)).getPersonnummer());
     }
@@ -156,7 +160,7 @@ public class EksisterendeIdenterServiceTest {
 
         eksisterendeIdenterService.behandleVigsel(meldinger, identer, brukteIdenter, endringskode, environment);
 
-        verify(hodejegerenConsumer, times(4)).getStatusQuoTilhoerendeEndringskode(anyString(), anyString(), anyString());
+        verify(hodejegerenConsumerSkd, times(4)).getStatusQuoTilhoerendeEndringskode(anyString(), anyString(), anyString());
         assertEquals(2, meldinger.size());
         assertEquals(fnr1, ((RsMeldingstype1Felter) meldinger.get(0)).getFodselsdato() + ((RsMeldingstype1Felter) meldinger.get(0)).getPersonnummer());
         assertEquals(fnr3, ((RsMeldingstype1Felter) meldinger.get(1)).getFodselsdato() + ((RsMeldingstype1Felter) meldinger.get(1)).getPersonnummer());
@@ -191,23 +195,23 @@ public class EksisterendeIdenterServiceTest {
         Map<String, String> statusQuo = new HashMap<>();
         statusQuo.put(SIVILSTAND, GIFT.getSivilstandKodeSKD());
         statusQuo.put(FNR_RELASJON, fnr2);
-        when(hodejegerenConsumer.getStatusQuoTilhoerendeEndringskode(anyString(), eq(environment), eq(fnr1))).thenReturn(statusQuo);
+        when(hodejegerenConsumerSkd.getStatusQuoTilhoerendeEndringskode(anyString(), eq(environment), eq(fnr1))).thenReturn(statusQuo);
 
         // fnr2 er feilregistrert i TPS til ugift sivilstand.
         statusQuo = new HashMap<>();
         statusQuo.put(SIVILSTAND, KoderForSivilstand.UGIFT.getSivilstandKodeSKD());
         statusQuo.put(FNR_RELASJON, fnr5);
-        when(hodejegerenConsumer.getStatusQuoTilhoerendeEndringskode(anyString(), eq(environment), eq(fnr2))).thenReturn(statusQuo);
+        when(hodejegerenConsumerSkd.getStatusQuoTilhoerendeEndringskode(anyString(), eq(environment), eq(fnr2))).thenReturn(statusQuo);
 
         // Et fungerende ektepar
         statusQuo = new HashMap<>();
         statusQuo.put(SIVILSTAND, GIFT.getSivilstandKodeSKD());
         statusQuo.put(FNR_RELASJON, fnr3);
-        when(hodejegerenConsumer.getStatusQuoTilhoerendeEndringskode(anyString(), eq(environment), eq(fnr4))).thenReturn(statusQuo);
+        when(hodejegerenConsumerSkd.getStatusQuoTilhoerendeEndringskode(anyString(), eq(environment), eq(fnr4))).thenReturn(statusQuo);
         statusQuo = new HashMap<>();
         statusQuo.put(SIVILSTAND, GIFT.getSivilstandKodeSKD());
         statusQuo.put(FNR_RELASJON, fnr4);
-        when(hodejegerenConsumer.getStatusQuoTilhoerendeEndringskode(anyString(), eq(environment), eq(fnr3))).thenReturn(statusQuo);
+        when(hodejegerenConsumerSkd.getStatusQuoTilhoerendeEndringskode(anyString(), eq(environment), eq(fnr3))).thenReturn(statusQuo);
         return new ArrayList(Arrays.asList(fnr1, fnr2, fnr3, fnr4));
     }
 
@@ -226,7 +230,7 @@ public class EksisterendeIdenterServiceTest {
 
         eksisterendeIdenterService.behandleSeperasjonSkilsmisse(meldinger, identer, brukteIdenter, SKILSMISSE, environment);
 
-        verify(hodejegerenConsumer, times(3)).getStatusQuoTilhoerendeEndringskode(anyString(), anyString(), anyString());
+        verify(hodejegerenConsumerSkd, times(3)).getStatusQuoTilhoerendeEndringskode(anyString(), anyString(), anyString());
         assertEquals(2, meldinger.size());
         assertEquals(SKILSMISSE.getAarsakskode(), meldinger.get(0).getAarsakskode());
         assertEquals(fnr2, ((RsMeldingstype1Felter) meldinger.get(0)).getFodselsdato() + ((RsMeldingstype1Felter) meldinger.get(0)).getPersonnummer());
@@ -287,7 +291,7 @@ public class EksisterendeIdenterServiceTest {
 
         eksisterendeIdenterService.behandleSeperasjonSkilsmisse(meldinger, identer, brukteIdenter, SKILSMISSE, environment);
 
-        verify(hodejegerenConsumer, times(4)).getStatusQuoTilhoerendeEndringskode(anyString(), anyString(), anyString());
+        verify(hodejegerenConsumerSkd, times(4)).getStatusQuoTilhoerendeEndringskode(anyString(), anyString(), anyString());
         assertEquals(2, meldinger.size());
         assertEquals(SKILSMISSE.getAarsakskode(), meldinger.get(0).getAarsakskode());
         assertEquals(fnr3, ((RsMeldingstype1Felter) meldinger.get(0)).getFodselsdato() + ((RsMeldingstype1Felter) meldinger.get(0)).getPersonnummer());
@@ -315,7 +319,7 @@ public class EksisterendeIdenterServiceTest {
 
         eksisterendeIdenterService.behandleDoedsmelding(meldinger, identer, brukteIdenter, endringskode, environment);
 
-        verify(hodejegerenConsumer, times(2)).getStatusQuoTilhoerendeEndringskode(anyString(), anyString(), anyString());
+        verify(hodejegerenConsumerSkd, times(2)).getStatusQuoTilhoerendeEndringskode(anyString(), anyString(), anyString());
         assertEquals(2, meldinger.size());
         assertEquals("8510", meldinger.get(1).getAarsakskode() + ((RsMeldingstype1Felter) meldinger.get(1)).getStatuskode() + ((RsMeldingstype1Felter) meldinger.get(1)).getTildelingskode());
         assertEquals(fnr1, ((RsMeldingstype1Felter) meldinger.get(0)).getFodselsdato() + ((RsMeldingstype1Felter) meldinger.get(0)).getPersonnummer());
@@ -346,24 +350,24 @@ public class EksisterendeIdenterServiceTest {
         Map<String, String> statusQuo = new HashMap<>();
         statusQuo.put(DATO_DO, "010203");
         statusQuo.put(STATSBORGER, "NORGE");
-        when(hodejegerenConsumer.getStatusQuoTilhoerendeEndringskode(anyString(), anyString(), eq(fnr1))).thenReturn(statusQuo);
+        when(hodejegerenConsumerSkd.getStatusQuoTilhoerendeEndringskode(anyString(), anyString(), eq(fnr1))).thenReturn(statusQuo);
 
         statusQuo = new HashMap<>();
         statusQuo.put(DATO_DO, "");
         statusQuo.put(STATSBORGER, "NORGE");
-        when(hodejegerenConsumer.getStatusQuoTilhoerendeEndringskode(anyString(), anyString(), eq(fnr2))).thenReturn(statusQuo);
+        when(hodejegerenConsumerSkd.getStatusQuoTilhoerendeEndringskode(anyString(), anyString(), eq(fnr2))).thenReturn(statusQuo);
     }
 
     private void opprettIdenterMedManglendeFeltMock() {
         Map<String, String> statusQuo = new HashMap<>();
-        when(hodejegerenConsumer.getStatusQuoTilhoerendeEndringskode(anyString(), anyString(), eq(fnr1))).thenReturn(statusQuo);
+        when(hodejegerenConsumerSkd.getStatusQuoTilhoerendeEndringskode(anyString(), anyString(), eq(fnr1))).thenReturn(statusQuo);
 
         statusQuo.put(DATO_DO, "010203");
-        when(hodejegerenConsumer.getStatusQuoTilhoerendeEndringskode(anyString(), anyString(), eq(fnr2))).thenReturn(statusQuo);
+        when(hodejegerenConsumerSkd.getStatusQuoTilhoerendeEndringskode(anyString(), anyString(), eq(fnr2))).thenReturn(statusQuo);
 
         statusQuo = new HashMap<>();
         statusQuo.put(STATSBORGER, "NORGE");
-        when(hodejegerenConsumer.getStatusQuoTilhoerendeEndringskode(anyString(), anyString(), eq(fnr3))).thenReturn(statusQuo);
+        when(hodejegerenConsumerSkd.getStatusQuoTilhoerendeEndringskode(anyString(), anyString(), eq(fnr3))).thenReturn(statusQuo);
     }
 
     private void opprettMultipleUgifteIdenterMock() {
@@ -375,35 +379,35 @@ public class EksisterendeIdenterServiceTest {
 
         Map<String, String> statusQuo = new HashMap<>();
         statusQuo.put(SIVILSTAND, KoderForSivilstand.UGIFT.getSivilstandKodeSKD());
-        when(hodejegerenConsumer.getStatusQuoTilhoerendeEndringskode(anyString(), eq(environment), eq(fnrUmyndig))).thenReturn(statusQuo);
+        when(hodejegerenConsumerSkd.getStatusQuoTilhoerendeEndringskode(anyString(), eq(environment), eq(fnrUmyndig))).thenReturn(statusQuo);
 
         statusQuo = new HashMap<>();
         statusQuo.put(SIVILSTAND, KoderForSivilstand.UGIFT.getSivilstandKodeSKD());
-        when(hodejegerenConsumer.getStatusQuoTilhoerendeEndringskode(anyString(), eq(environment), eq(fnr1))).thenReturn(statusQuo);
+        when(hodejegerenConsumerSkd.getStatusQuoTilhoerendeEndringskode(anyString(), eq(environment), eq(fnr1))).thenReturn(statusQuo);
 
         statusQuo = new HashMap<>();
         statusQuo.put(SIVILSTAND, GIFT.getSivilstandKodeSKD());
-        when(hodejegerenConsumer.getStatusQuoTilhoerendeEndringskode(anyString(), eq(environment), eq(fnr2))).thenReturn(statusQuo);
+        when(hodejegerenConsumerSkd.getStatusQuoTilhoerendeEndringskode(anyString(), eq(environment), eq(fnr2))).thenReturn(statusQuo);
 
         statusQuo = new HashMap<>();
         statusQuo.put(SIVILSTAND, KoderForSivilstand.UGIFT.getSivilstandKodeSKD());
-        when(hodejegerenConsumer.getStatusQuoTilhoerendeEndringskode(anyString(), eq(environment), eq(fnr3))).thenReturn(statusQuo);
+        when(hodejegerenConsumerSkd.getStatusQuoTilhoerendeEndringskode(anyString(), eq(environment), eq(fnr3))).thenReturn(statusQuo);
     }
 
     private void opprettMultipleGifteIdenterMock() {
         Map<String, String> statusQuo = new HashMap<>();
         statusQuo.put(SIVILSTAND, KoderForSivilstand.UGIFT.getSivilstandKodeSKD());
-        when(hodejegerenConsumer.getStatusQuoTilhoerendeEndringskode(anyString(), eq(environment), eq(fnr1))).thenReturn(statusQuo);
+        when(hodejegerenConsumerSkd.getStatusQuoTilhoerendeEndringskode(anyString(), eq(environment), eq(fnr1))).thenReturn(statusQuo);
 
         statusQuo = new HashMap<>();
         statusQuo.put(SIVILSTAND, GIFT.getSivilstandKodeSKD());
         statusQuo.put(FNR_RELASJON, fnr3);
-        when(hodejegerenConsumer.getStatusQuoTilhoerendeEndringskode(anyString(), eq(environment), eq(fnr2))).thenReturn(statusQuo);
+        when(hodejegerenConsumerSkd.getStatusQuoTilhoerendeEndringskode(anyString(), eq(environment), eq(fnr2))).thenReturn(statusQuo);
 
         statusQuo = new HashMap<>();
         statusQuo.put(SIVILSTAND, GIFT.getSivilstandKodeSKD());
         statusQuo.put(FNR_RELASJON, fnr2);
-        when(hodejegerenConsumer.getStatusQuoTilhoerendeEndringskode(anyString(), eq(environment), eq(fnr3))).thenReturn(statusQuo);
+        when(hodejegerenConsumerSkd.getStatusQuoTilhoerendeEndringskode(anyString(), eq(environment), eq(fnr3))).thenReturn(statusQuo);
     }
 
     private void opprettMultipleGifteIdenterWithStatusQuoErrorMock() {
@@ -411,19 +415,19 @@ public class EksisterendeIdenterServiceTest {
 
         Map<String, String> statusQuo = new HashMap<>();
         statusQuo.put(SIVILSTAND, KoderForSivilstand.UGIFT.getSivilstandKodeSKD());
-        when(hodejegerenConsumer.getStatusQuoTilhoerendeEndringskode(anyString(), eq(environment), eq(fnr1))).thenReturn(statusQuo);
+        when(hodejegerenConsumerSkd.getStatusQuoTilhoerendeEndringskode(anyString(), eq(environment), eq(fnr1))).thenReturn(statusQuo);
 
-        when(hodejegerenConsumer.getStatusQuoTilhoerendeEndringskode(anyString(), eq(environment), eq(fnr2))).thenThrow(new ManglendeInfoITpsException());
+        when(hodejegerenConsumerSkd.getStatusQuoTilhoerendeEndringskode(anyString(), eq(environment), eq(fnr2))).thenThrow(new ManglendeInfoITpsException());
 
         statusQuo = new HashMap<>();
         statusQuo.put(SIVILSTAND, GIFT.getSivilstandKodeSKD());
         statusQuo.put(FNR_RELASJON, fnr4);
-        when(hodejegerenConsumer.getStatusQuoTilhoerendeEndringskode(anyString(), eq(environment), eq(fnr3))).thenReturn(statusQuo);
+        when(hodejegerenConsumerSkd.getStatusQuoTilhoerendeEndringskode(anyString(), eq(environment), eq(fnr3))).thenReturn(statusQuo);
 
         statusQuo = new HashMap<>();
         statusQuo.put(SIVILSTAND, GIFT.getSivilstandKodeSKD());
         statusQuo.put(FNR_RELASJON, fnr3);
-        when(hodejegerenConsumer.getStatusQuoTilhoerendeEndringskode(anyString(), eq(environment), eq(fnr4))).thenReturn(statusQuo);
+        when(hodejegerenConsumerSkd.getStatusQuoTilhoerendeEndringskode(anyString(), eq(environment), eq(fnr4))).thenReturn(statusQuo);
     }
 
     private void opprettEkteparMock() {
@@ -432,13 +436,13 @@ public class EksisterendeIdenterServiceTest {
         statusQuo.put(DATO_DO, "");
         statusQuo.put(SIVILSTAND, GIFT.getSivilstandKodeSKD());
         statusQuo.put(FNR_RELASJON, fnr2);
-        when(hodejegerenConsumer.getStatusQuoTilhoerendeEndringskode(anyString(), eq(environment), eq(fnr1))).thenReturn(statusQuo);
+        when(hodejegerenConsumerSkd.getStatusQuoTilhoerendeEndringskode(anyString(), eq(environment), eq(fnr1))).thenReturn(statusQuo);
 
         statusQuo = new HashMap<>();
         statusQuo.put(STATSBORGER, "NORGE");
         statusQuo.put(DATO_DO, "");
         statusQuo.put(SIVILSTAND, GIFT.getSivilstandKodeSKD());
         statusQuo.put(FNR_RELASJON, fnr1);
-        when(hodejegerenConsumer.getStatusQuoTilhoerendeEndringskode(anyString(), eq(environment), eq(fnr2))).thenReturn(statusQuo);
+        when(hodejegerenConsumerSkd.getStatusQuoTilhoerendeEndringskode(anyString(), eq(environment), eq(fnr2))).thenReturn(statusQuo);
     }
 }

--- a/apps/testnorge-skd/skd-local/src/main/resources/application.properties
+++ b/apps/testnorge-skd/skd-local/src/main/resources/application.properties
@@ -9,3 +9,4 @@ syntrest.rest.api.url=https://syntrest.dev.adeo.no/api
 testnorge-tp.rest-api.url=https://testnorge-tp.dev.adeo.no/api
 ident-pool.rest-api.url=https://ident-pool.dev.adeo.no/api
 testnorge-hodejegeren.rest-api.url=https://testnorge-hodejegeren.dev.adeo.no/api
+tps-forvalteren.rest-api.url=https://tps-forvalteren.dev.adeo.no/api

--- a/apps/testnorge-skd/skd-local/src/main/resources/application.properties
+++ b/apps/testnorge-skd/skd-local/src/main/resources/application.properties
@@ -3,3 +3,9 @@ person.rest.api.url=https://testnorge-person-api-dev.dev.adeo.no
 person.rest.api.client_id=${PERSON_API_CLIENT_ID}
 person.rest.api.client_secret=${PERSON_API_CLIENT_SECRET}
 AAD_ISSUER_URI=https://login.microsoftonline.com/62366534-1ec3-4962-8869-9b5535279d0b
+
+# tilgjengelige urls for naisdevice
+syntrest.rest.api.url=https://syntrest.dev.adeo.no/api
+testnorge-tp.rest-api.url=https://testnorge-tp.dev.adeo.no/api
+ident-pool.rest-api.url=https://ident-pool.dev.adeo.no/api
+testnorge-hodejegeren.rest-api.url=https://testnorge-hodejegeren.dev.adeo.no/api


### PR DESCRIPTION
Gjenstår fortsatt arbeid på å evt. få flere av kallene til hodejegeren til å bruke kommando-patternet og etterhvert fjerne HodejegerenConsumer-artifakten.
Denne branchen fikser dog vigsels-meldingen og andre som henter status-quo ved samme metode.