### PR TITLE
Oppdatert exception handling i testnorge-arena

### DIFF
--- a/apps/testnorge-arena/arena-core/src/main/java/no/nav/registre/arena/core/service/VedtakshistorikkService.java
+++ b/apps/testnorge-arena/arena-core/src/main/java/no/nav/registre/arena/core/service/VedtakshistorikkService.java
@@ -180,14 +180,17 @@ public class VedtakshistorikkService {
 
         List<RettighetRequest> rettighetRequests;
 
-        if (senesteVedtak instanceof NyttVedtakAap) {
+        if (senesteVedtak == null){
+            log.info("Kunne ikke opprette rettigheter for ident: " + personident);
+            rettighetRequests = new ArrayList<>();
+        }else if (senesteVedtak instanceof NyttVedtakAap) {
             rettighetRequests = serviceUtils.opprettArbeidssoekerAap(rettigheter, miljoe, ((NyttVedtakAap) senesteVedtak).getAktivitetsfase());
         } else if (senesteVedtak instanceof NyttVedtakTiltak) {
             rettighetRequests = serviceUtils.opprettArbeidssoekerTiltak(rettigheter, miljoe);
         } else if (senesteVedtak instanceof NyttVedtakTillegg) {
             rettighetRequests = serviceUtils.opprettArbeidssoekerTillegg(rettigheter, miljoe);
         } else {
-            throw new VedtakshistorikkException("Ukjent vedtakstype: " + (senesteVedtak != null ? senesteVedtak.getClass() : null));
+            throw new VedtakshistorikkException("Ukjent vedtakstype: " + senesteVedtak.getClass());
         }
 
 


### PR DESCRIPTION
Hvis vedtakshistorikk originalt bare inneholder vedtak for tiltaksdeltakelse og tiltakspenger og et passenede tiltak ikke blir funnet så blir vedtakene fjernet fra historikken. Dette gir oss en tom historikk og det ender det opp med at VedtakshistorikkException blir kastet. Har oppdatert koden nå sånn at i sånn at det blir i stedet logget at vi ikke kunne opprette noen rettigheter for ident og ingen exception blir kastet. 