### PR TITLE
Sjekke om ident ligger i faste data-db

### DIFF
--- a/apps/testnorge-statisk-data-forvalter/src/main/java/no/nav/registre/sdforvalter/adapter/TpsIdenterAdapter.java
+++ b/apps/testnorge-statisk-data-forvalter/src/main/java/no/nav/registre/sdforvalter/adapter/TpsIdenterAdapter.java
@@ -51,12 +51,23 @@ public class TpsIdenterAdapter extends FasteDataAdapter {
 
         List<TpsIdentModel> tpsIdentModels = tpsIdenterRepository.findByGruppeModel(getGruppe(gruppe));
         List<TpsIdent> liste = tpsIdentModels.stream().map(tpsIdentModel -> {
-            List<TagModel> tagModels = tpsIdentTagAdapter.findAllTagsByIdent(tpsIdentModel.getFnr());
+            List<TagModel> tagModels = fetchTagsByIdent(tpsIdentModel.getFnr());
             return new TpsIdent(tpsIdentModel, tagModels);
         }).collect(Collectors.toList());
 
         log.info("Fant {} personer fra gruppe {}", liste.size(), gruppe);
         return new TpsIdentListe(liste);
+    }
+
+    public TpsIdent fetchByIdent(String ident) {
+        log.info("Henter tps-ident {}", ident);
+        var tpsIdent = tpsIdenterRepository.findByFnr(ident);
+        var tags = fetchTagsByIdent(ident);
+        return tpsIdent != null ? new TpsIdent(tpsIdent, tags) : null;
+    }
+
+    public List<TagModel> fetchTagsByIdent(String ident) {
+        return tpsIdentTagAdapter.findAllTagsByIdent(ident);
     }
 
     public TpsIdentListe save(TpsIdentListe liste) {

--- a/apps/testnorge-statisk-data-forvalter/src/main/java/no/nav/registre/sdforvalter/database/repository/TpsIdenterRepository.java
+++ b/apps/testnorge-statisk-data-forvalter/src/main/java/no/nav/registre/sdforvalter/database/repository/TpsIdenterRepository.java
@@ -11,4 +11,6 @@ import no.nav.registre.sdforvalter.database.model.TpsIdentModel;
 @Repository
 public interface TpsIdenterRepository extends CrudRepository<TpsIdentModel, String> {
     List<TpsIdentModel> findByGruppeModel(GruppeModel gruppeModel);
+
+    TpsIdentModel findByFnr(String fnr);
 }

--- a/apps/testnorge-statisk-data-forvalter/src/main/java/no/nav/registre/sdforvalter/provider/rs/PersonController.java
+++ b/apps/testnorge-statisk-data-forvalter/src/main/java/no/nav/registre/sdforvalter/provider/rs/PersonController.java
@@ -1,9 +1,11 @@
 package no.nav.registre.sdforvalter.provider.rs;
 
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -13,6 +15,7 @@ import java.util.List;
 import no.nav.registre.sdforvalter.domain.person.Person;
 import no.nav.registre.sdforvalter.domain.person.PersonStatusMap;
 import no.nav.registre.sdforvalter.service.PersonService;
+import no.nav.registre.testnorge.libs.dto.person.v1.PersonDTO;
 
 @Slf4j
 @RestController
@@ -35,5 +38,15 @@ public class PersonController {
             @RequestParam(value = "gruppe") String gruppe
     ) {
         return ResponseEntity.ok(personService.getStatusMap(gruppe, equal));
+    }
+
+    @Operation(summary = "Hent person fra Team Dollys database (faste data)")
+    @GetMapping("/{ident}")
+    public ResponseEntity<PersonDTO> getPersonByIdent(@PathVariable String ident) {
+        var person = personService.getPersonByIdent(ident);
+        if (person == null) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(person.toDTO());
     }
 }

--- a/apps/testnorge-statisk-data-forvalter/src/main/java/no/nav/registre/sdforvalter/service/PersonService.java
+++ b/apps/testnorge-statisk-data-forvalter/src/main/java/no/nav/registre/sdforvalter/service/PersonService.java
@@ -41,8 +41,12 @@ public class PersonService {
         );
     }
 
-    public List<Person> getPerson(String gruppe){
+    public List<Person> getPerson(String gruppe) {
         TpsIdentListe tpsIdentListe = tpsIdenterAdapter.fetchBy(gruppe);
         return tpsIdentListe.stream().map(Person::new).collect(Collectors.toList());
+    }
+
+    public TpsIdent getPersonByIdent(String ident) {
+        return tpsIdenterAdapter.fetchByIdent(ident);
     }
 }


### PR DESCRIPTION
Endepunkt for å sjekke om fnr/dnr finnes i blant de faste dataene. Hent orgnr fantes allerede, men gir 500 i stedenfor 404 hvis den ikke finnes.