### PR TITLE
Testnorge arena/legge til mer variasjon deltakerstatus

### DIFF
--- a/apps/testnorge-arena/arena-core/src/main/java/no/nav/registre/arena/core/service/RettighetTiltakService.java
+++ b/apps/testnorge-arena/arena-core/src/main/java/no/nav/registre/arena/core/service/RettighetTiltakService.java
@@ -325,14 +325,14 @@ public class RettighetTiltakService {
     ) {
         List<RettighetRequest> rettigheter = new ArrayList<>();
         for (var vedtak : tiltaksdeltakelser) {
-                List<String> endringer = getEndringerMedGyldigRekkefoelge(vedtak);
+            List<String> endringer = getEndringerMedGyldigRekkefoelge(vedtak);
 
-                for (var endring : endringer) {
-                    var rettighetRequest = vedtakUtils.opprettRettighetEndreDeltakerstatusRequest(vedtak.getFodselsnr(),
-                            miljoe, vedtak, endring);
+            for (var endring : endringer) {
+                var rettighetRequest = vedtakUtils.opprettRettighetEndreDeltakerstatusRequest(vedtak.getFodselsnr(),
+                        miljoe, vedtak, endring);
 
-                    rettigheter.add(rettighetRequest);
-                }
+                rettigheter.add(rettighetRequest);
+            }
         }
         return rettigheter;
     }
@@ -342,11 +342,11 @@ public class RettighetTiltakService {
     ) {
         var adminKode = tiltaksdeltakelse.getTiltakAdminKode();
         List<String> endringer = new ArrayList<>();
-        if (vedtakUtils.canSetDeltakelseTilGjennomfoeres(tiltaksdeltakelse)){
+        if (vedtakUtils.canSetDeltakelseTilGjennomfoeres(tiltaksdeltakelse)) {
             endringer = vedtakUtils.getFoersteEndringerDeltakerstatus(adminKode);
         }
 
-        if (!endringer.isEmpty() && endringer.contains(Deltakerstatuser.GJENN.toString()) && vedtakUtils.canSetDeltakelseTilFinished(tiltaksdeltakelse)){
+        if (!endringer.isEmpty() && endringer.contains(Deltakerstatuser.GJENN.toString()) && vedtakUtils.canSetDeltakelseTilFinished(tiltaksdeltakelse)) {
             endringer.add(vedtakUtils.getAvsluttendeDeltakerstatus(adminKode).toString());
         }
 

--- a/apps/testnorge-arena/arena-core/src/main/java/no/nav/registre/arena/core/service/VedtakshistorikkService.java
+++ b/apps/testnorge-arena/arena-core/src/main/java/no/nav/registre/arena/core/service/VedtakshistorikkService.java
@@ -14,6 +14,7 @@ import static no.nav.registre.arena.core.service.util.ServiceUtils.MIN_ALDER_UNG
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import no.nav.registre.arena.core.service.util.ServiceUtils;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
@@ -39,7 +40,6 @@ import no.nav.registre.arena.core.consumer.rs.request.RettighetTiltakspengerRequ
 import no.nav.registre.arena.core.consumer.rs.request.RettighetTvungenForvaltningRequest;
 import no.nav.registre.arena.core.consumer.rs.request.RettighetUngUfoerRequest;
 import no.nav.registre.arena.core.service.exception.VedtakshistorikkException;
-import no.nav.registre.arena.core.service.util.ServiceUtils;
 import no.nav.registre.arena.core.service.util.ArbeidssoekerUtils;
 import no.nav.registre.arena.core.service.util.IdenterUtils;
 import no.nav.registre.arena.core.service.util.VedtakUtils;
@@ -61,7 +61,6 @@ public class VedtakshistorikkService {
 
     private final AapSyntConsumer aapSyntConsumer;
     private final RettighetArenaForvalterConsumer rettighetArenaForvalterConsumer;
-    private final ServiceUtils serviceUtils;
     private final IdenterUtils identerUtils;
     private final ArbeidssoekerUtils arbeidsoekerUtils;
     private final VedtakUtils vedtakUtils;
@@ -509,7 +508,8 @@ public class VedtakshistorikkService {
         if (tiltaksdeltakelser != null && !tiltaksdeltakelser.isEmpty()) {
             for (var deltakelse : tiltaksdeltakelser) {
                 if (vedtakUtils.canSetDeltakelseTilFinished(deltakelse)) {
-                    var deltakerstatuskode = vedtakUtils.getAvsluttendeDeltakerstatus(deltakelse.getTiltakAdminKode()).toString();
+                    var deltakerstatuskode = vedtakUtils.getAvsluttendeDeltakerstatus(deltakelse
+                            .getTiltakAdminKode()).toString();
 
                     var rettighetRequest = vedtakUtils.opprettRettighetEndreDeltakerstatusRequest(personident, miljoe,
                             deltakelse, deltakerstatuskode);

--- a/apps/testnorge-arena/arena-core/src/main/java/no/nav/registre/arena/core/service/VedtakshistorikkService.java
+++ b/apps/testnorge-arena/arena-core/src/main/java/no/nav/registre/arena/core/service/VedtakshistorikkService.java
@@ -112,7 +112,7 @@ public class VedtakshistorikkService {
     }
 
     private void opprettVedtaksHistorikkResponse(Long avspillergruppeId, String miljoe, Map<String, List<NyttVedtakResponse>> responses, Vedtakshistorikk vedtakshistorikken, LocalDate tidligsteDatoBarnetillegg,
-            int minimumAlder, int maksimumAlder) {
+                                                 int minimumAlder, int maksimumAlder) {
         List<String> identerIAldersgruppe = Collections.emptyList();
         try {
             if (tidligsteDatoBarnetillegg != null) {

--- a/apps/testnorge-arena/arena-core/src/main/java/no/nav/registre/arena/core/service/VedtakshistorikkService.java
+++ b/apps/testnorge-arena/arena-core/src/main/java/no/nav/registre/arena/core/service/VedtakshistorikkService.java
@@ -422,12 +422,12 @@ public class VedtakshistorikkService {
     }
 
     private void opprettVedtakTiltaksdeltakelse(
-            Vedtakshistorikk vedtak,
+            Vedtakshistorikk historikk,
             String personident,
             String miljoe,
             List<RettighetRequest> rettigheter
     ) {
-        var tiltaksdeltakelser = vedtak.getTiltaksdeltakelse();
+        var tiltaksdeltakelser = historikk.getTiltaksdeltakelse();
         if (tiltaksdeltakelser != null && !tiltaksdeltakelser.isEmpty()) {
             arbeidsoekerUtils.opprettArbeidssoekerTiltakdeltakelse(personident, miljoe);
 
@@ -448,7 +448,7 @@ public class VedtakshistorikkService {
             var nyeTiltaksdeltakelser = tiltaksdeltakelser.stream()
                     .filter(deltakelse -> deltakelse.getTiltakId() != null).collect(Collectors.toList());
 
-            nyeTiltaksdeltakelser = vedtakUtils.removeOverlappingTiltakVedtak(nyeTiltaksdeltakelser, vedtak.getAap());
+            nyeTiltaksdeltakelser = vedtakUtils.removeOverlappingTiltakVedtak(nyeTiltaksdeltakelser, historikk.getAap());
 
             if (nyeTiltaksdeltakelser != null && !nyeTiltaksdeltakelser.isEmpty()) {
                 List<NyttVedtakTiltak> nyeVedtakRequests = new ArrayList<>();
@@ -462,7 +462,7 @@ public class VedtakshistorikkService {
                 rettighetRequest.setMiljoe(miljoe);
                 rettigheter.add(rettighetRequest);
             }
-            vedtak.setTiltaksdeltakelse(nyeTiltaksdeltakelser);
+            historikk.setTiltaksdeltakelse(nyeTiltaksdeltakelser);
         }
     }
 

--- a/apps/testnorge-arena/arena-core/src/main/java/no/nav/registre/arena/core/service/VedtakshistorikkService.java
+++ b/apps/testnorge-arena/arena-core/src/main/java/no/nav/registre/arena/core/service/VedtakshistorikkService.java
@@ -476,25 +476,27 @@ public class VedtakshistorikkService {
 
         var nyeTiltaksedeltakelser = new ArrayList<NyttVedtakTiltak>();
 
-        if (tiltaksdeltakelser != null && !tiltaksdeltakelser.isEmpty()) {
-            for (var deltakelse : tiltaksdeltakelser) {
-                if (vedtakUtils.canSetDeltakelseTilGjennomfoeres(deltakelse)) {
-                    List<String> endringer = vedtakUtils.getFoersteEndringerDeltakerstatus(deltakelse.getTiltakAdminKode());
+        if (tiltaksdeltakelser == null || tiltaksdeltakelser.isEmpty()) {
+            return;
+        }
+        for (var deltakelse : tiltaksdeltakelser) {
+            if (vedtakUtils.canSetDeltakelseTilGjennomfoeres(deltakelse)) {
+                List<String> endringer = vedtakUtils.getFoersteEndringerDeltakerstatus(deltakelse.getTiltakAdminKode());
 
-                    for (var endring : endringer) {
-                        var rettighetRequest = vedtakUtils.opprettRettighetEndreDeltakerstatusRequest(personident, miljoe,
-                                deltakelse, endring);
+                for (var endring : endringer) {
+                    var rettighetRequest = vedtakUtils.opprettRettighetEndreDeltakerstatusRequest(personident, miljoe,
+                            deltakelse, endring);
 
-                        rettigheter.add(rettighetRequest);
-                    }
+                    rettigheter.add(rettighetRequest);
+                }
 
-                    // Hvis siste endring ikke er lik GJENN kan ikke andre tiltak-vedtak (BASI/BTIL) knyttes til tiltaksdeltakelsen.
-                    if (!endringer.isEmpty() && endringer.get(endringer.size() - 1).equals(Deltakerstatuser.GJENN.toString())) {
-                        nyeTiltaksedeltakelser.add(deltakelse);
-                    }
+                // Hvis siste endring ikke er lik GJENN kan ikke andre tiltak-vedtak (BASI/BTIL) knyttes til tiltaksdeltakelsen.
+                if (!endringer.isEmpty() && endringer.get(endringer.size() - 1).equals(Deltakerstatuser.GJENN.toString())) {
+                    nyeTiltaksedeltakelser.add(deltakelse);
                 }
             }
         }
+
         historikk.setTiltaksdeltakelse(nyeTiltaksedeltakelser);
     }
 

--- a/apps/testnorge-arena/arena-core/src/main/java/no/nav/registre/arena/core/service/util/ServiceUtils.java
+++ b/apps/testnorge-arena/arena-core/src/main/java/no/nav/registre/arena/core/service/util/ServiceUtils.java
@@ -26,7 +26,6 @@ import no.nav.registre.testnorge.libs.dependencyanalysis.DependencyOn;
 public class ServiceUtils {
 
     public static final String BEGRUNNELSE = "Syntetisert rettighet";
-    public static final String DELTAKERSTATUS_GJENNOMFOERES = "GJENN";
     public static final int MIN_ALDER_AAP = 18;
     public static final int MAX_ALDER_AAP = 67;
     public static final int MIN_ALDER_UNG_UFOER = 18;

--- a/apps/testnorge-arena/arena-core/src/main/java/no/nav/registre/arena/core/service/util/VedtakUtils.java
+++ b/apps/testnorge-arena/arena-core/src/main/java/no/nav/registre/arena/core/service/util/VedtakUtils.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.io.Resources;

--- a/apps/testnorge-arena/arena-core/src/main/java/no/nav/registre/arena/core/service/util/VedtakUtils.java
+++ b/apps/testnorge-arena/arena-core/src/main/java/no/nav/registre/arena/core/service/util/VedtakUtils.java
@@ -5,15 +5,27 @@ import static no.nav.registre.arena.core.service.util.ServiceUtils.BEGRUNNELSE;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import no.nav.registre.arena.core.consumer.rs.TiltakArenaForvalterConsumer;
+import no.nav.registre.arena.core.consumer.rs.request.RettighetEndreDeltakerstatusRequest;
 import no.nav.registre.arena.core.consumer.rs.request.RettighetFinnTiltakRequest;
+import no.nav.registre.testnorge.domain.dto.arena.testnorge.brukere.Deltakerstatuser;
 import no.nav.registre.testnorge.domain.dto.arena.testnorge.vedtak.NyttVedtak;
 import no.nav.registre.testnorge.domain.dto.arena.testnorge.vedtak.NyttVedtakTiltak;
+
 import org.springframework.stereotype.Service;
 
+import java.io.IOException;
+import java.net.URL;
+import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
-
+import java.util.Map;
+import java.util.Random;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.io.Resources;
 
 @Slf4j
 @Service
@@ -21,7 +33,31 @@ import java.util.List;
 public class VedtakUtils {
 
     private final TiltakArenaForvalterConsumer tiltakArenaForvalterConsumer;
+    private final ServiceUtils serviceUtils;
+    private final Random rand;
 
+    private static final Map<String, List<String>> deltakerstatuskoderMedAarsakkoder;
+    private static final Map<String, List<KodeMedSannsynlighet>> adminkodeTilDeltakerstatus;
+
+    static {
+        deltakerstatuskoderMedAarsakkoder = new HashMap<>();
+        deltakerstatuskoderMedAarsakkoder.put(Deltakerstatuser.NEITAKK.toString(), Arrays.asList("ANN", "BEGA", "FRISM", "FTOAT", "HENLU", "SYK", "UTV"));
+        deltakerstatuskoderMedAarsakkoder.put(Deltakerstatuser.IKKEM.toString(), Arrays.asList("ANN", "BEGA", "SYK"));
+        deltakerstatuskoderMedAarsakkoder.put(Deltakerstatuser.DELAVB.toString(), Arrays.asList("ANN", "BEGA", "FTOAT", "SYK"));
+
+        adminkodeTilDeltakerstatus = new HashMap<>();
+
+        URL resourceDeltakerstatus = Resources.getResource("adminkode_til_deltakerstatus_endring.json");
+        ObjectMapper objectMapper = new ObjectMapper();
+        try {
+            Map<String, List<KodeMedSannsynlighet>> map = objectMapper.readValue(resourceDeltakerstatus, new TypeReference<>() {
+            });
+
+            adminkodeTilDeltakerstatus.putAll(map);
+        } catch (IOException e) {
+            log.error("Kunne ikke laste inn deltakerstatus fordeling.", e);
+        }
+    }
 
     public void setDatoPeriodeVedtakInnenforMaxAntallMaaneder(
             NyttVedtak vedtak,
@@ -197,5 +233,70 @@ public class VedtakUtils {
         }
 
         return vedtakSequences;
+    }
+
+    public boolean canSetDeltakelseTilGjennomfoeres(NyttVedtakTiltak tiltaksdeltakelse) {
+        var fraDato = tiltaksdeltakelse.getFraDato();
+        return (fraDato != null && fraDato.isBefore(LocalDate.now().plusDays(1)));
+    }
+
+    public boolean canSetDeltakelseTilFinished(NyttVedtakTiltak tiltaksdeltakelse) {
+        var fraDato = tiltaksdeltakelse.getFraDato();
+        var tilDato = tiltaksdeltakelse.getTilDato();
+
+        if (fraDato == null || tilDato == null) {
+            return false;
+        }
+        return fraDato.isBefore(LocalDate.now().plusDays(1)) && tilDato.isBefore(LocalDate.now().plusDays(1));
+    }
+
+    public List<String> getFoersteEndringerDeltakerstatus(String adminkode) {
+        if (adminkodeTilDeltakerstatus.containsKey(adminkode)) {
+            var sisteEndring = serviceUtils.velgKodeBasertPaaSannsynlighet(adminkodeTilDeltakerstatus.get(adminkode)).getKode();
+            if (adminkode.equals("AMO")) {
+                if (sisteEndring.equals(Deltakerstatuser.GJENN.toString()) || sisteEndring.equals(Deltakerstatuser.IKKEM.toString())) {
+                    return Arrays.asList(Deltakerstatuser.TILBUD.toString(), Deltakerstatuser.JATAKK.toString(), sisteEndring);
+                } else if (sisteEndring.equals(Deltakerstatuser.NEITAKK.toString())) {
+                    return Arrays.asList(Deltakerstatuser.TILBUD.toString(), sisteEndring);
+                }
+            }
+            return sisteEndring.equals("") ? new ArrayList<>() : Collections.singletonList(sisteEndring);
+        } else {
+            log.info("Ugylding tiltak adminkode.");
+            return new ArrayList<>();
+        }
+    }
+
+    public Deltakerstatuser getAvsluttendeDeltakerstatus(String adminkode) {
+        if (adminkode.equals("INST")) {
+            return rand.nextDouble() > 0.28 ? Deltakerstatuser.FULLF : Deltakerstatuser.DELAVB;
+        } else {
+            return Deltakerstatuser.FULLF;
+        }
+    }
+
+    public RettighetEndreDeltakerstatusRequest opprettRettighetEndreDeltakerstatusRequest(
+            String ident,
+            String miljoe,
+            NyttVedtakTiltak tiltaksdeltakelse,
+            String deltakerstatuskode
+    ) {
+
+        NyttVedtakTiltak vedtak = new NyttVedtakTiltak();
+        vedtak.setTiltakskarakteristikk(tiltaksdeltakelse.getTiltakAdminKode());
+        vedtak.setDato(tiltaksdeltakelse.getFraDato());
+        vedtak.setDeltakerstatusKode(deltakerstatuskode);
+
+        if (deltakerstatuskoderMedAarsakkoder.containsKey(deltakerstatuskode)) {
+            List<String> aarsakkoder = deltakerstatuskoderMedAarsakkoder.get(deltakerstatuskode);
+            String aarsakkode = aarsakkoder.get(rand.nextInt(aarsakkoder.size()));
+            vedtak.setAarsakKode(aarsakkode);
+        }
+
+        var rettighetRequest = new RettighetEndreDeltakerstatusRequest(Collections.singletonList(vedtak));
+
+        rettighetRequest.setPersonident(ident);
+        rettighetRequest.setMiljoe(miljoe);
+        return rettighetRequest;
     }
 }

--- a/apps/testnorge-arena/arena-core/src/main/java/no/nav/registre/arena/core/service/util/VedtakUtils.java
+++ b/apps/testnorge-arena/arena-core/src/main/java/no/nav/registre/arena/core/service/util/VedtakUtils.java
@@ -256,9 +256,9 @@ public class VedtakUtils {
             var sisteEndring = serviceUtils.velgKodeBasertPaaSannsynlighet(adminkodeTilDeltakerstatus.get(adminkode)).getKode();
             if (adminkode.equals("AMO")) {
                 if (sisteEndring.equals(Deltakerstatuser.GJENN.toString()) || sisteEndring.equals(Deltakerstatuser.IKKEM.toString())) {
-                    return Arrays.asList(Deltakerstatuser.TILBUD.toString(), Deltakerstatuser.JATAKK.toString(), sisteEndring);
+                    return new ArrayList<>(Arrays.asList(Deltakerstatuser.TILBUD.toString(), Deltakerstatuser.JATAKK.toString(), sisteEndring));
                 } else if (sisteEndring.equals(Deltakerstatuser.NEITAKK.toString())) {
-                    return Arrays.asList(Deltakerstatuser.TILBUD.toString(), sisteEndring);
+                    return new ArrayList<>(Arrays.asList(Deltakerstatuser.TILBUD.toString(), sisteEndring));
                 }
             }
             return sisteEndring.equals("") ? new ArrayList<>() : Collections.singletonList(sisteEndring);

--- a/apps/testnorge-arena/arena-core/src/main/resources/adminkode_til_deltakerstatus_endring.json
+++ b/apps/testnorge-arena/arena-core/src/main/resources/adminkode_til_deltakerstatus_endring.json
@@ -1,0 +1,56 @@
+{
+  "AMO": [
+      {
+        "kode" : "GJENN",
+        "sannsynlighet" : 4673
+      },
+      {
+        "kode" : "IKKEM",
+        "sannsynlighet" : 98
+      },
+      {
+        "kode" : "NEITAKK",
+        "sannsynlighet": 98
+      },
+      {
+        "kode" : "IKKEAKTUELL",
+        "sannsynlighet": 98
+      },
+      {
+        "kode" : "VENTELISTE",
+        "sannsynlighet": 145
+      },
+      {
+        "kode" : "TILBUD",
+        "sannsynlighet": 1078
+      }
+    ] ,
+  "IND": [
+      {
+        "kode" : "GJENN",
+        "sannsynlighet" : 32128
+      },
+      {
+        "kode" : "",
+        "sannsynlighet": 1714
+      }
+    ],
+  "INST":  [
+      {
+        "kode" : "GJENN",
+        "sannsynlighet" : 28274
+      },
+      {
+        "kode" : "",
+        "sannsynlighet": 6237
+      },
+      {
+        "kode" : "IKKEAKTUELL",
+        "sannsynlighet":  2576
+      },
+      {
+        "kode" : "IKKEM",
+        "sannsynlighet": 2576
+      }
+    ]
+}

--- a/apps/testnorge-arena/arena-core/src/main/resources/adminkode_til_deltakerstatus_endring.json
+++ b/apps/testnorge-arena/arena-core/src/main/resources/adminkode_til_deltakerstatus_endring.json
@@ -19,30 +19,18 @@
       {
         "kode" : "VENTELISTE",
         "sannsynlighet": 145
-      },
-      {
-        "kode" : "TILBUD",
-        "sannsynlighet": 1078
       }
     ] ,
   "IND": [
       {
         "kode" : "GJENN",
         "sannsynlighet" : 32128
-      },
-      {
-        "kode" : "",
-        "sannsynlighet": 1714
       }
     ],
   "INST":  [
       {
         "kode" : "GJENN",
         "sannsynlighet" : 28274
-      },
-      {
-        "kode" : "",
-        "sannsynlighet": 6237
       },
       {
         "kode" : "IKKEAKTUELL",

--- a/apps/testnorge-arena/arena-core/src/main/resources/adminkode_til_deltakerstatus_endring.json
+++ b/apps/testnorge-arena/arena-core/src/main/resources/adminkode_til_deltakerstatus_endring.json
@@ -19,18 +19,30 @@
       {
         "kode" : "VENTELISTE",
         "sannsynlighet": 145
+      },
+      {
+        "kode" : "TILBUD",
+        "sannsynlighet": 1078
       }
     ] ,
   "IND": [
       {
         "kode" : "GJENN",
         "sannsynlighet" : 32128
+      },
+      {
+        "kode" : "",
+        "sannsynlighet": 1714
       }
     ],
   "INST":  [
       {
         "kode" : "GJENN",
         "sannsynlighet" : 28274
+      },
+      {
+        "kode" : "",
+        "sannsynlighet": 6237
       },
       {
         "kode" : "IKKEAKTUELL",

--- a/apps/testnorge-arena/arena-core/src/main/resources/application.properties
+++ b/apps/testnorge-arena/arena-core/src/main/resources/application.properties
@@ -2,16 +2,16 @@ application.name=testnorge-arena
 application.version=application.version.todo #TODO Finn ut hvordan denne kan settes fra gradle
 spring.main.banner-mode=off
 
-testnorge-hodejegeren.rest-api.url=https://testnorge-hodejegeren.dev.adeo.no/api
-arena-forvalteren.rest-api.url=https://arena-forvalteren.dev.adeo.no/api
-pensjon-testdata-facade.rest-api.url=https://pensjon-testdata-facade.dev.adeo.no/api
-testnorge-token-provider.url=https://testnorge-token-provider.dev.adeo.no/token/user
-synt.rest-api.url=https://syntrest.dev.adeo.no/api
-synt-arena.rest-api.url=https://nais-synthdata-arena-aap.dev.adeo.no/api
-synt-arena-vedtakshistorikk.rest-api.url=https://nais-synthdata-arena-vedtakshistorikk.dev.adeo.no/api
-synt-arena-tiltak.rest-api.url=https://nais-synthdata-arena-tiltak.dev.adeo.no/api
-synt-arena-tillegg.rest-api.url=https://nais-synthdata-arena-tilleggsstonad.dev.adeo.no/api
-aktoerregister.api.url=https://app-%s.adeo.no/aktoerregister/api
+testnorge-hodejegeren.rest-api.url=${TESTNORGE_HODEJEGEREN_API_URL}
+arena-forvalteren.rest-api.url=${ARENA_FORVALTEREN_API_URL}
+pensjon-testdata-facade.rest-api.url=${PENSJON_TESTDATA_FACADE_API_URL}
+testnorge-token-provider.url=${TESTNORGE_TOKEN_PROVIDER_URL}
+synt.rest-api.url=${SYNT_REST_API_URL}
+synt-arena.rest-api.url=${SYNT_ARENA_API_URL}
+synt-arena-vedtakshistorikk.rest-api.url=${SYNT_ARENA_VEDTAKSHISTORIKK_API_URL}
+synt-arena-tiltak.rest-api.url=${SYNT_ARENA_TILTAK_API_URL}
+synt-arena-tillegg.rest-api.url=${SYNT_ARENA_TILLEGG_API_URL}
+aktoerregister.api.url=${AKTOERREGISTER_API_URL}
 
 ida.username=${IDA_USERNAME}
 ida.password=${IDA_PASSWORD}

--- a/apps/testnorge-arena/arena-core/src/main/resources/vedtak_til_statuskode.json
+++ b/apps/testnorge-arena/arena-core/src/main/resources/vedtak_til_statuskode.json
@@ -32,33 +32,5 @@
       "kode": "TILBU",
       "sannsynlighet": 1
     }
-  ],
-  "DELTAKER": [
-    {
-      "kode": "DELAVB",
-      "sannsynlighet": 101
-    },
-    {
-      "kode": "FULLF",
-      "sannsynlighet": 892
-    },
-    {
-      "kode": "GJENN",
-      "sannsynlighet": 5
-    },
-    {
-      "kode": "TILBUD",
-      "sannsynlighet": 2
-    }
-  ],
-  "AVSLUTTET_DELTAKER": [
-    {
-      "kode": "DELAVB",
-      "sannsynlighet": 101
-    },
-    {
-      "kode": "FULLF",
-      "sannsynlighet": 892
-    }
   ]
 }

--- a/apps/testnorge-arena/arena-core/src/test/java/no/nav/registre/arena/core/consumer/rs/AapSyntConsumerTest.java
+++ b/apps/testnorge-arena/arena-core/src/test/java/no/nav/registre/arena/core/consumer/rs/AapSyntConsumerTest.java
@@ -30,7 +30,7 @@ import no.nav.registre.arena.core.consumer.rs.util.ConsumerUtils;
 @RunWith(SpringRunner.class)
 @AutoConfigureWireMock(port = 0)
 @TestPropertySource(locations = "classpath:application-test.properties")
-@ContextConfiguration(classes = { AapSyntConsumer.class, AppConfig.class, ConsumerUtils.class })
+@ContextConfiguration(classes = {AapSyntConsumer.class, AppConfig.class, ConsumerUtils.class})
 @RestClientTest(AapSyntConsumer.class)
 public class AapSyntConsumerTest {
 

--- a/apps/testnorge-arena/arena-core/src/test/java/no/nav/registre/arena/core/consumer/rs/BrukereArenaForvalterConsumerTest.java
+++ b/apps/testnorge-arena/arena-core/src/test/java/no/nav/registre/arena/core/consumer/rs/BrukereArenaForvalterConsumerTest.java
@@ -38,7 +38,7 @@ import no.nav.registre.arena.core.config.AppConfig;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureWireMock(port = 0)
 @TestPropertySource(locations = "classpath:application-test.properties")
-@ContextConfiguration(classes = { BrukereArenaForvalterConsumer.class, AppConfig.class, ArbeidssoekerCacheUtil.class })
+@ContextConfiguration(classes = {BrukereArenaForvalterConsumer.class, AppConfig.class, ArbeidssoekerCacheUtil.class})
 @EnableAutoConfiguration
 public class BrukereArenaForvalterConsumerTest {
 

--- a/apps/testnorge-arena/arena-core/src/test/java/no/nav/registre/arena/core/provider/rs/AapControllerIntegrationTest.java
+++ b/apps/testnorge-arena/arena-core/src/test/java/no/nav/registre/arena/core/provider/rs/AapControllerIntegrationTest.java
@@ -55,19 +55,19 @@ public class AapControllerIntegrationTest {
 
     private static final String ident = "01019049900";
     private static final String miljoe = "test";
-    private static final Long avspillergruppeId=123456789L;
+    private static final Long avspillergruppeId = 123456789L;
 
-    private static final String tokenProviderUrl="(.*)/token-provider";
-    private static final String hentLevendeIdenterIAldersgruppeUrl="(.*)/hodejegeren/api/v1/levende-identer-i-aldersgruppe/"+avspillergruppeId;
-    private static final String hentIdenterIAktoerregisteretUrl="(.*)/aktoerregister/v1/identer";
-    private static final String brukereArenaUrl="(.*)/arena-forvalteren/api/v1/bruker";
-    private static final String hentSyntetisertRettighetAapUrl="(.*)/syntetisereren/api/v1/arena/aap";
-    private static final String hentSyntetisertRettighetAap115Url="(.*)/syntetisereren/api/v1/arena/aap/11_5";
-    private static final String opprettPersonIPoppUrl="(.*)/pensjon-testdata-facade/api/v1/person";
-    private static final String opprettInntektIPoppUrl="(.*)/pensjon-testdata-facade/api/v1/inntekt";
+    private static final String tokenProviderUrl = "(.*)/token-provider";
+    private static final String hentLevendeIdenterIAldersgruppeUrl = "(.*)/hodejegeren/api/v1/levende-identer-i-aldersgruppe/" + avspillergruppeId;
+    private static final String hentIdenterIAktoerregisteretUrl = "(.*)/aktoerregister/v1/identer";
+    private static final String brukereArenaUrl = "(.*)/arena-forvalteren/api/v1/bruker";
+    private static final String hentSyntetisertRettighetAapUrl = "(.*)/syntetisereren/api/v1/arena/aap";
+    private static final String hentSyntetisertRettighetAap115Url = "(.*)/syntetisereren/api/v1/arena/aap/11_5";
+    private static final String opprettPersonIPoppUrl = "(.*)/pensjon-testdata-facade/api/v1/person";
+    private static final String opprettInntektIPoppUrl = "(.*)/pensjon-testdata-facade/api/v1/inntekt";
     private static final String opprettRettigheterAap115Url = "(.*)/arena-forvalteren/api/v1/aap115";
     private static final String opprettRettigheterAapUrl = "(.*)/arena-forvalteren/api/v1/aap";
-    private static final String saveHistorikkUrl="(.*)/hodejegeren/api/v1/historikk";
+    private static final String saveHistorikkUrl = "(.*)/hodejegeren/api/v1/historikk";
 
     private NyttVedtakAap vedtak;
     private NyttVedtakResponse nyttVedtakResponse;
@@ -76,7 +76,7 @@ public class AapControllerIntegrationTest {
     private PensjonTestdataResponse pensjonTestdataResponse;
 
     @Before
-    public void setUp(){
+    public void setUp() {
         vedtak = NyttVedtakAap.builder().aktivitetsfase("TEST").build();
         vedtak.setFraDato(LocalDate.now().minusMonths(3));
         vedtak.setTilDato(LocalDate.now());
@@ -92,8 +92,8 @@ public class AapControllerIntegrationTest {
 
         identerIAktoerRegisteret = new HashMap<>();
         var aktoerResponse = new AktoerResponse();
-        aktoerResponse.setIdenter(Collections.singletonList(new AktoerInnhold(ident,"test", true)));
-        identerIAktoerRegisteret.put(ident, aktoerResponse );
+        aktoerResponse.setIdenter(Collections.singletonList(new AktoerInnhold(ident, "test", true)));
+        identerIAktoerRegisteret.put(ident, aktoerResponse);
 
         pensjonTestdataResponse = PensjonTestdataResponse.builder()
                 .status(Collections.singletonList(PensjonTestdataStatus.builder()
@@ -185,10 +185,12 @@ public class AapControllerIntegrationTest {
                 .andExpect(status().isOk())
                 .andReturn()
                 .getResponse()
-                .getContentAsString();;
+                .getContentAsString();
+        ;
 
         Map<String, List<NyttVedtakResponse>> resultat = objectMapper.readValue(mvcResultat,
-                new TypeReference<>() {});
+                new TypeReference<>() {
+                });
 
         assertThat(resultat.keySet()).contains(ident).hasSize(1);
     }

--- a/apps/testnorge-arena/arena-core/src/test/java/no/nav/registre/arena/core/provider/rs/BrukereControllerIntegrationTest.java
+++ b/apps/testnorge-arena/arena-core/src/test/java/no/nav/registre/arena/core/provider/rs/BrukereControllerIntegrationTest.java
@@ -42,17 +42,17 @@ public class BrukereControllerIntegrationTest {
 
     private static final String ident = "01019049900";
     private static final String miljoe = "test";
-    private static final Long avspillergruppeId=123456789L;
+    private static final Long avspillergruppeId = 123456789L;
 
-    private static final String hentLevendeIdenterIAldersgruppeUrl="(.*)/hodejegeren/api/v1/levende-identer-i-aldersgruppe/"+avspillergruppeId;
-    private static final String arenaForvalterenUrl="(.*)/arena-forvalteren/api/v1/bruker";
+    private static final String hentLevendeIdenterIAldersgruppeUrl = "(.*)/hodejegeren/api/v1/levende-identer-i-aldersgruppe/" + avspillergruppeId;
+    private static final String arenaForvalterenUrl = "(.*)/arena-forvalteren/api/v1/bruker";
 
     private SyntetiserArenaRequest syntetiserArenaRequest;
     private NyeBrukereResponse hentBrukereResponse;
     private NyeBrukereResponse sendBrukerResponse;
 
     @Before
-    public void setUp(){
+    public void setUp() {
         syntetiserArenaRequest = new SyntetiserArenaRequest(avspillergruppeId, miljoe, 1);
 
         hentBrukereResponse = new NyeBrukereResponse();
@@ -116,7 +116,8 @@ public class BrukereControllerIntegrationTest {
                 .verifyPost();
 
         NyeBrukereResponse resultat = objectMapper.readValue(mvcResultat,
-                new TypeReference<>() {});
+                new TypeReference<>() {
+                });
 
         assertThat(resultat.getArbeidsoekerList()).hasSize(1);
         assertThat(resultat.getArbeidsoekerList().get(0).getPersonident()).isEqualTo(ident);
@@ -171,7 +172,8 @@ public class BrukereControllerIntegrationTest {
                 .verifyPost();
 
         NyeBrukereResponse resultat = objectMapper.readValue(mvcResultat,
-                new TypeReference<>() {});
+                new TypeReference<>() {
+                });
 
         assertThat(resultat.getArbeidsoekerList()).hasSize(1);
         assertThat(resultat.getArbeidsoekerList().get(0).getPersonident()).isEqualTo(ident);

--- a/apps/testnorge-arena/arena-core/src/test/java/no/nav/registre/arena/core/provider/rs/IdentControllerIntegrationTest.java
+++ b/apps/testnorge-arena/arena-core/src/test/java/no/nav/registre/arena/core/provider/rs/IdentControllerIntegrationTest.java
@@ -48,7 +48,7 @@ public class IdentControllerIntegrationTest {
     private NyeBrukereResponse nyeBrukereResponse;
 
     @Before
-    public void setUp(){
+    public void setUp() {
         var arbeidsoekere = Collections.singletonList(Arbeidsoeker.builder()
                 .personident(ident)
                 .miljoe(miljoe)

--- a/apps/testnorge-arena/arena-core/src/test/java/no/nav/registre/arena/core/provider/rs/TilleggsstoenadControllerIntegrationTest.java
+++ b/apps/testnorge-arena/arena-core/src/test/java/no/nav/registre/arena/core/provider/rs/TilleggsstoenadControllerIntegrationTest.java
@@ -53,12 +53,12 @@ public class TilleggsstoenadControllerIntegrationTest {
 
     private static final String ident = "01019049900";
     private static final String miljoe = "test";
-    private static final Long avspillergruppeId=123456789L;
+    private static final Long avspillergruppeId = 123456789L;
 
-    private static final String tokenProviderUrl="(.*)/token-provider";
-    private static final String hentLevendeIdenterUrl="(.*)/hodejegeren/api/v1/alle-levende-identer/"+avspillergruppeId;
-    private static final String hentIdenterIAktoerregisteretUrl="(.*)/aktoerregister/v1/identer";
-    private static final String arenaForvalterenUrl="(.*)/arena-forvalteren/api/v1/bruker";
+    private static final String tokenProviderUrl = "(.*)/token-provider";
+    private static final String hentLevendeIdenterUrl = "(.*)/hodejegeren/api/v1/alle-levende-identer/" + avspillergruppeId;
+    private static final String hentIdenterIAktoerregisteretUrl = "(.*)/aktoerregister/v1/identer";
+    private static final String arenaForvalterenUrl = "(.*)/arena-forvalteren/api/v1/bruker";
     private static final String arenaTilleggBoutgiftUrl = "(.*)/synt-tillegg/api/v1/arena/tilleggsstonad/boutgift";
     private static final String opprettRettigheterTilleggUrl = "(.*)/arena-forvalteren/api/v1/tilleggsstonad";
     private static final String opprettRettigheterTiltaksaktivitetUrl = "(.*)/arena-forvalteren/api/v1/tiltaksaktivitet";
@@ -74,13 +74,13 @@ public class TilleggsstoenadControllerIntegrationTest {
     private NyttVedtakResponse nyttVedtakTiltakResponse;
 
     @Before
-    public void setUp(){
+    public void setUp() {
         syntetiserArenaRequest = new SyntetiserArenaRequest(avspillergruppeId, miljoe, 1);
 
         identerIAktoerRegisteret = new HashMap<>();
         var aktoerResponse = new AktoerResponse();
-        aktoerResponse.setIdenter(Collections.singletonList(new AktoerInnhold(ident,"test", true)));
-        identerIAktoerRegisteret.put(ident, aktoerResponse );
+        aktoerResponse.setIdenter(Collections.singletonList(new AktoerInnhold(ident, "test", true)));
+        identerIAktoerRegisteret.put(ident, aktoerResponse);
 
         vedtakTillegg = new NyttVedtakTillegg();
         vedtakTillegg.setVedtaksperiode(new Vedtaksperiode(LocalDate.now().minusMonths(3), LocalDate.now()));
@@ -177,7 +177,8 @@ public class TilleggsstoenadControllerIntegrationTest {
                 .getContentAsString();
 
         Map<String, List<NyttVedtakResponse>> resultat = objectMapper.readValue(mvcResultat,
-                new TypeReference<>() {});
+                new TypeReference<>() {
+                });
 
         assertThat(resultat.keySet()).contains(ident).hasSize(1);
     }

--- a/apps/testnorge-arena/arena-core/src/test/java/no/nav/registre/arena/core/provider/rs/TiltakControllerIntegrationTest.java
+++ b/apps/testnorge-arena/arena-core/src/test/java/no/nav/registre/arena/core/provider/rs/TiltakControllerIntegrationTest.java
@@ -53,20 +53,20 @@ public class TiltakControllerIntegrationTest {
 
     private static final String ident = "01019049900";
     private static final String miljoe = "test";
-    private static final Long avspillergruppeId=123456789L;
+    private static final Long avspillergruppeId = 123456789L;
 
-    private static final String tokenProviderUrl="(.*)/token-provider";
-    private static final String hentIdenterMedKontonummerUrl="(.*)/hodejegeren/api/v1/identer-med-kontonummer/"+avspillergruppeId;
-    private static final String hentLevendeIdenterUrl="(.*)/hodejegeren/api/v1/alle-levende-identer/"+avspillergruppeId;
-    private static final String hentIdenterIAktoerregisteretUrl="(.*)/aktoerregister/v1/identer";
-    private static final String hentBrukereArenaUrl="(.*)/arena-forvalteren/api/v1/bruker";
+    private static final String tokenProviderUrl = "(.*)/token-provider";
+    private static final String hentIdenterMedKontonummerUrl = "(.*)/hodejegeren/api/v1/identer-med-kontonummer/" + avspillergruppeId;
+    private static final String hentLevendeIdenterUrl = "(.*)/hodejegeren/api/v1/alle-levende-identer/" + avspillergruppeId;
+    private static final String hentIdenterIAktoerregisteretUrl = "(.*)/aktoerregister/v1/identer";
+    private static final String hentBrukereArenaUrl = "(.*)/arena-forvalteren/api/v1/bruker";
     private static final String arenaTiltakspengerUrl = "(.*)/synt-tiltak/api/v1/arena/tiltak/basi";
     private static final String arenaTiltaksdeltakelseUrl = "(.*)/synt-tiltak/api/v1/arena/tiltak/deltakelse/1";
     private static final String arenaEndreDeltakerstatusUrl = "(.*)/synt-tiltak/api/v1/arena/tiltak/deltakerstatus";
     private static final String opprettRettigheterTiltaksdeltakelseUrl = "(.*)/arena-forvalteren/api/v1/tiltaksdeltakelse";
     private static final String opprettRettigheterTiltaksaktivitetUrl = "(.*)/arena-forvalteren/api/v1/tiltakspenger";
     private static final String opprettRettigheterEndreDeltakerstatusUrl = "(.*)/arena-forvalteren/api/v1/endreDeltakerstatus";
-    private static final String brukereArenaUrl="(.*)/arena-forvalteren/api/v1/bruker";
+    private static final String brukereArenaUrl = "(.*)/arena-forvalteren/api/v1/bruker";
 
     private SyntetiserArenaRequest syntetiserArenaRequest;
     private Map<String, AktoerResponse> identerIAktoerRegisteret;
@@ -75,13 +75,13 @@ public class TiltakControllerIntegrationTest {
     private NyttVedtakResponse nyttVedtakTiltakResponse;
 
     @Before
-    public void setUp(){
+    public void setUp() {
         syntetiserArenaRequest = new SyntetiserArenaRequest(avspillergruppeId, miljoe, 1);
 
         identerIAktoerRegisteret = new HashMap<>();
         var aktoerResponse = new AktoerResponse();
-        aktoerResponse.setIdenter(Collections.singletonList(new AktoerInnhold(ident,"test", true)));
-        identerIAktoerRegisteret.put(ident, aktoerResponse );
+        aktoerResponse.setIdenter(Collections.singletonList(new AktoerInnhold(ident, "test", true)));
+        identerIAktoerRegisteret.put(ident, aktoerResponse);
 
         nyeBrukereResponse = new NyeBrukereResponse();
         nyeBrukereResponse.setAntallSider(0);
@@ -201,7 +201,8 @@ public class TiltakControllerIntegrationTest {
                 .verifyPost();
 
         Map<String, List<NyttVedtakResponse>> resultat = objectMapper.readValue(mvcResultat,
-                new TypeReference<>() {});
+                new TypeReference<>() {
+                });
 
         assertThat(resultat.keySet()).contains(ident).hasSize(1);
     }

--- a/apps/testnorge-arena/arena-core/src/test/java/no/nav/registre/arena/core/service/RettighetTiltakServiceTest.java
+++ b/apps/testnorge-arena/arena-core/src/test/java/no/nav/registre/arena/core/service/RettighetTiltakServiceTest.java
@@ -3,19 +3,19 @@ package no.nav.registre.arena.core.service;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.HashMap;
 
 import no.nav.registre.arena.core.consumer.rs.RettighetArenaForvalterConsumer;
 import no.nav.registre.arena.core.consumer.rs.TiltakSyntConsumer;
-import no.nav.registre.arena.core.consumer.rs.request.RettighetRequest;
 import no.nav.registre.arena.core.consumer.rs.request.RettighetTilleggRequest;
 import no.nav.registre.arena.core.service.util.IdenterUtils;
 import no.nav.registre.arena.core.service.util.ArbeidssoekerUtils;
 import no.nav.registre.arena.core.service.util.ServiceUtils;
 import no.nav.registre.arena.core.service.util.VedtakUtils;
 import no.nav.registre.arena.core.service.util.KodeMedSannsynlighet;
+import no.nav.registre.testnorge.domain.dto.arena.testnorge.brukere.Deltakerstatuser;
 import no.nav.registre.testnorge.domain.dto.arena.testnorge.tilleggsstoenad.Vedtaksperiode;
 import no.nav.registre.testnorge.domain.dto.arena.testnorge.vedtak.NyttVedtakResponse;
 import no.nav.registre.testnorge.domain.dto.arena.testnorge.vedtak.NyttVedtakTillegg;
@@ -102,6 +102,9 @@ public class RettighetTiltakServiceTest {
         when(identerUtils.getUtvalgteIdenter(avspillergruppeId, antallNyeIdenter, miljoe)).thenReturn(identer);
         when(rettighetArenaForvalterConsumer.opprettRettighet(anyList())).thenReturn(new HashMap<>());
         when(vedtakUtils.finnTiltak(identer.get(0), miljoe, tiltakMedTilDatoFremITid)).thenReturn(tiltakMedTilDatoFremITid);
+        when(vedtakUtils.canSetDeltakelseTilGjennomfoeres(tiltakMedTilDatoFremITid)).thenReturn(true);
+        when(vedtakUtils.getVedtakForTiltaksdeltakelseRequest(tiltakMedTilDatoFremITid)).thenReturn(tiltakMedTilDatoFremITid);
+        when(vedtakUtils.getFoersteEndringerDeltakerstatus(anyString())).thenReturn(Collections.singletonList(Deltakerstatuser.GJENN.toString()));
         when(arbeidssoekerUtils.opprettArbeidssoekerTiltak(anyList(), anyString())).thenReturn(Collections.emptyList());
 
         rettighetTiltakService.opprettTiltaksdeltakelse(avspillergruppeId, miljoe, antallNyeIdenter);
@@ -110,6 +113,8 @@ public class RettighetTiltakServiceTest {
         verify(identerUtils).getUtvalgteIdenter(avspillergruppeId, antallNyeIdenter, miljoe);
         verify(rettighetArenaForvalterConsumer, times(2)).opprettRettighet(anyList());
         verify(vedtakUtils).finnTiltak(identer.get(0), miljoe, tiltakMedTilDatoFremITid);
+        verify(vedtakUtils).getVedtakForTiltaksdeltakelseRequest(tiltakMedTilDatoFremITid);
+        verify(vedtakUtils).getFoersteEndringerDeltakerstatus(anyString());
     }
 
     @Test
@@ -119,7 +124,11 @@ public class RettighetTiltakServiceTest {
         when(identerUtils.getUtvalgteIdenter(avspillergruppeId, antallNyeIdenter, miljoe)).thenReturn(identer);
         when(rettighetArenaForvalterConsumer.opprettRettighet(anyList())).thenReturn(new HashMap<>());
         when(vedtakUtils.finnTiltak(identer.get(0), miljoe, tiltakMedTilDatoLikDagens)).thenReturn(tiltakMedTilDatoLikDagens);
-        when(serviceUtils.velgKodeBasertPaaSannsynlighet(anyList())).thenReturn(new KodeMedSannsynlighet("FULLF", 100));
+        when(vedtakUtils.canSetDeltakelseTilGjennomfoeres(tiltakMedTilDatoLikDagens)).thenReturn(true);
+        when(vedtakUtils.canSetDeltakelseTilFinished(tiltakMedTilDatoLikDagens)).thenReturn(true);
+        when(vedtakUtils.getVedtakForTiltaksdeltakelseRequest(tiltakMedTilDatoLikDagens)).thenReturn(tiltakMedTilDatoLikDagens);
+        when(vedtakUtils.getFoersteEndringerDeltakerstatus(anyString())).thenReturn(new ArrayList<>(Collections.singletonList(Deltakerstatuser.GJENN.toString())));
+        when(vedtakUtils.getAvsluttendeDeltakerstatus(anyString())).thenReturn(Deltakerstatuser.FULLF);
         when(arbeidssoekerUtils.opprettArbeidssoekerTiltak(anyList(), anyString())).thenReturn(Collections.emptyList());
 
         rettighetTiltakService.opprettTiltaksdeltakelse(avspillergruppeId, miljoe, antallNyeIdenter);
@@ -128,7 +137,6 @@ public class RettighetTiltakServiceTest {
         verify(identerUtils).getUtvalgteIdenter(avspillergruppeId, antallNyeIdenter, miljoe);
         verify(rettighetArenaForvalterConsumer, times(2)).opprettRettighet(anyList());
         verify(vedtakUtils).finnTiltak(identer.get(0), miljoe, tiltakMedTilDatoLikDagens);
-        verify(serviceUtils).velgKodeBasertPaaSannsynlighet(anyList());
     }
 
     @Test

--- a/apps/testnorge-arena/arena-core/src/test/java/no/nav/registre/arena/core/service/VedtakshistorikkServiceTest.java
+++ b/apps/testnorge-arena/arena-core/src/test/java/no/nav/registre/arena/core/service/VedtakshistorikkServiceTest.java
@@ -13,7 +13,6 @@ import static no.nav.registre.arena.core.consumer.rs.AapSyntConsumer.ARENA_AAP_U
 
 import no.nav.registre.arena.core.service.util.IdenterUtils;
 import no.nav.registre.arena.core.service.util.ArbeidssoekerUtils;
-import no.nav.registre.arena.core.service.util.ServiceUtils;
 import no.nav.registre.arena.core.service.util.VedtakUtils;
 import no.nav.registre.testnorge.domain.dto.arena.testnorge.aap.gensaksopplysninger.Saksopplysning;
 import no.nav.registre.testnorge.domain.dto.arena.testnorge.historikk.Vedtakshistorikk;
@@ -42,9 +41,6 @@ public class VedtakshistorikkServiceTest {
 
     @Mock
     private AapSyntConsumer aapSyntConsumer;
-
-    @Mock
-    private ServiceUtils serviceUtils;
 
     @Mock
     private IdenterUtils identerUtils;

--- a/apps/testnorge-arena/arena-local/src/main/resources/application.properties
+++ b/apps/testnorge-arena/arena-local/src/main/resources/application.properties
@@ -1,14 +1,3 @@
 application.name=testnorge-arena
 application.version=application.version.todo //TODO Finn ut hvordan denne kan settes fra gradle
 spring.main.banner-mode=off
-
-testnorge-hodejegeren.rest-api.url=https://testnorge-hodejegeren.dev.adeo.no/api
-arena-forvalteren.rest-api.url=https://arena-forvalteren.dev.adeo.no/api
-pensjon-testdata-facade.rest-api.url=https://pensjon-testdata-facade.dev.adeo.no/api
-testnorge-token-provider.url=https://testnorge-token-provider.dev.adeo.no/token/user
-synt.rest-api.url=https://syntrest.dev.adeo.no/api
-synt-arena.rest-api.url=https://nais-synthdata-arena-aap.dev.adeo.no/api
-synt-arena-vedtakshistorikk.rest-api.url=https://nais-synthdata-arena-vedtakshistorikk.dev.adeo.no/api
-synt-arena-tiltak.rest-api.url=https://nais-synthdata-arena-tiltak.dev.adeo.no/api
-synt-arena-tillegg.rest-api.url=https://nais-synthdata-arena-tilleggsstonad.dev.adeo.no/api
-aktoerregister.api.url=https://app-%s.adeo.no/aktoerregister/api

--- a/libs/testnorge-domain/src/main/java/no/nav/registre/testnorge/domain/dto/arena/testnorge/brukere/Deltakerstatuser.java
+++ b/libs/testnorge-domain/src/main/java/no/nav/registre/testnorge/domain/dto/arena/testnorge/brukere/Deltakerstatuser.java
@@ -1,0 +1,12 @@
+package no.nav.registre.testnorge.domain.dto.arena.testnorge.brukere;
+
+public enum Deltakerstatuser {
+    FULLF,
+    DELAVB,
+    GJENN,
+    IKKEAKTUELL,
+    IKKEM,
+    JATAKK,
+    NEITAKK,
+    TILBUD
+}


### PR DESCRIPTION
Har oppdatert endring av tiltaksdeltakelse. Før ble alle tiltaksdeltakelser først satt til gjennomføres ("GJENN"), så ble relaterte BASI/BTIL vedtak sendt inn, og til slutt ble tiltaksdeltakelsen endret til enten fullført ("FULLF") eller del-avbrudd("DELAVB") basert på datoene i tiltaksdeltakelsen. 

Nå har jeg oppdatert sånn at det er mulig at tiltaksdeltakelsen blir satt til "TILBUD", "IKKEM", "IKKEAKTUELL", "VENTELISTE", eller "NEITAKK" i stedet for kun "GJENN". Hvis dette skjer så blir heller ikke BASI/BTIL vedtak sendt inn siden tiltaksdeltakelsen må være satt til gjennomføres for at vedtakene skal gå gjennom. Tiltaksdeltakelsen blir heller ikke endret til "FULLF" eller "DELAVB".