### PR TITLE
Oppdatert batch kjoering for arena

### DIFF
--- a/apps/orkestratoren/src/main/java/no/nav/registre/orkestratoren/batch/v1/JobController.java
+++ b/apps/orkestratoren/src/main/java/no/nav/registre/orkestratoren/batch/v1/JobController.java
@@ -196,7 +196,7 @@ public class JobController {
     /**
     * Denne metoden oppretter vedtakshistorikk i Arena og kjøres annen hver time.
     * */
-    @Scheduled(cron = "0 0 0/2 * * *")
+    @Scheduled(cron = "0 0 0-23/2 * * *")
     public void arenaSyntBatch() {
         for (var entry : avspillergruppeIdMedMiljoe.entrySet()) {
             for (int i = 0; i < arenaAntallNyeIdenter; i++) {

--- a/apps/orkestratoren/src/main/java/no/nav/registre/orkestratoren/batch/v1/JobController.java
+++ b/apps/orkestratoren/src/main/java/no/nav/registre/orkestratoren/batch/v1/JobController.java
@@ -12,7 +12,6 @@ import org.springframework.web.client.HttpStatusCodeException;
 import java.util.Map;
 
 import no.nav.registre.orkestratoren.provider.rs.requests.SyntetiserAaregRequest;
-import no.nav.registre.orkestratoren.provider.rs.requests.SyntetiserArenaAapRequest;
 import no.nav.registre.orkestratoren.provider.rs.requests.SyntetiserArenaVedtakshistorikkRequest;
 import no.nav.registre.orkestratoren.provider.rs.requests.SyntetiserBisysRequest;
 import no.nav.registre.orkestratoren.provider.rs.requests.SyntetiserFrikortRequest;

--- a/apps/orkestratoren/src/main/java/no/nav/registre/orkestratoren/batch/v1/JobController.java
+++ b/apps/orkestratoren/src/main/java/no/nav/registre/orkestratoren/batch/v1/JobController.java
@@ -193,6 +193,9 @@ public class JobController {
         }
     }
 
+    /**
+    * Denne metoden oppretter vedtakshistorikk i Arena og kjøres annen hver time.
+    * */
     @Scheduled(cron = "0 0 0/2 * * *")
     public void arenaSyntBatch() {
         for (var entry : avspillergruppeIdMedMiljoe.entrySet()) {

--- a/apps/orkestratoren/src/main/java/no/nav/registre/orkestratoren/batch/v1/JobController.java
+++ b/apps/orkestratoren/src/main/java/no/nav/registre/orkestratoren/batch/v1/JobController.java
@@ -194,7 +194,7 @@ public class JobController {
         }
     }
 
-    @Scheduled(cron = "0 0 6 * * *")
+    @Scheduled(cron = "0 0 0/2 * * *")
     public void arenaSyntBatch() {
         for (var entry : avspillergruppeIdMedMiljoe.entrySet()) {
             for (int i = 0; i < arenaAntallNyeIdenter; i++) {
@@ -204,12 +204,6 @@ public class JobController {
                         .antallVedtakshistorikker(1)
                         .build());
             }
-
-            testnorgeArenaService.opprettArenaAap(SyntetiserArenaAapRequest.builder()
-                    .avspillergruppeId(entry.getKey())
-                    .miljoe(entry.getValue())
-                    .antallAap(arenaAntallNyeIdenter)
-                    .build());
         }
     }
 


### PR DESCRIPTION
Har oppdatert batch kjøring for arena i orkestratoren. Fjernet opprettelse av enkelt vedtak for aap sånn at kun vedtakshistorikk blir sendt inn. Har også oppdatert scheduling sånn at vedtakshistorikk blir sendt inn hver andre time i stedet for kun kl. 6. Har ikke brukt cron før så det hadde vært greit hvis noen kunne dobbelsjekke at det ble endret korrekt ;)