### PR TITLE
Syntrest/bugfix swagger amelding

### DIFF
--- a/apps/syntrest/src/main/java/no/nav/registre/syntrest/consumer/SyntAmeldingConsumer.java
+++ b/apps/syntrest/src/main/java/no/nav/registre/syntrest/consumer/SyntAmeldingConsumer.java
@@ -22,7 +22,7 @@ public class SyntAmeldingConsumer extends SyntConsumer {
         this.webClient = WebClient.builder().baseUrl(synthAmeldingUrl).build();
     }
 
-    public ArbeidsforholdAmelding synthesizeArbeidsforhold(ArbeidsforholdAmelding tidligereArbeidsforholdAmelding, String syntAmeldingUrlPath) {
+    public ArbeidsforholdAmelding synthesizeArbeidsforhold(ArbeidsforholdAmelding tidligereArbeidsforhold, String syntAmeldingUrlPath) {
         try {
             applicationManager.startApplication(this);
         } catch (ApiException | InterruptedException e) {
@@ -31,7 +31,7 @@ public class SyntAmeldingConsumer extends SyntConsumer {
         }
 
         try {
-            return new PostArbeidsforholdCommand(tidligereArbeidsforholdAmelding, syntAmeldingUrlPath, webClient).call();
+            return new PostArbeidsforholdCommand(tidligereArbeidsforhold, syntAmeldingUrlPath, webClient).call();
         } catch (RestClientException e) {
             log.error("Unexpected Rest Client Exception: {}", Arrays.toString(e.getStackTrace()));
             throw e;

--- a/apps/syntrest/src/main/java/no/nav/registre/syntrest/consumer/SyntAmeldingConsumer.java
+++ b/apps/syntrest/src/main/java/no/nav/registre/syntrest/consumer/SyntAmeldingConsumer.java
@@ -4,7 +4,7 @@ import io.kubernetes.client.ApiException;
 import lombok.extern.slf4j.Slf4j;
 import no.nav.registre.syntrest.consumer.command.PostArbeidsforholdCommand;
 import no.nav.registre.syntrest.consumer.command.PostArbeidsforholdStartCommand;
-import no.nav.registre.syntrest.domain.amelding.Arbeidsforhold;
+import no.nav.registre.syntrest.domain.amelding.ArbeidsforholdAmelding;
 import no.nav.registre.syntrest.kubernetes.ApplicationManager;
 
 import org.springframework.web.client.RestClientException;
@@ -22,7 +22,7 @@ public class SyntAmeldingConsumer extends SyntConsumer {
         this.webClient = WebClient.builder().baseUrl(synthAmeldingUrl).build();
     }
 
-    public Arbeidsforhold synthesizeArbeidsforhold(Arbeidsforhold tidligereArbeidsforhold, String syntAmeldingUrlPath) {
+    public ArbeidsforholdAmelding synthesizeArbeidsforhold(ArbeidsforholdAmelding tidligereArbeidsforholdAmelding, String syntAmeldingUrlPath) {
         try {
             applicationManager.startApplication(this);
         } catch (ApiException | InterruptedException e) {
@@ -31,7 +31,7 @@ public class SyntAmeldingConsumer extends SyntConsumer {
         }
 
         try {
-            return new PostArbeidsforholdCommand(tidligereArbeidsforhold, syntAmeldingUrlPath, webClient).call();
+            return new PostArbeidsforholdCommand(tidligereArbeidsforholdAmelding, syntAmeldingUrlPath, webClient).call();
         } catch (RestClientException e) {
             log.error("Unexpected Rest Client Exception: {}", Arrays.toString(e.getStackTrace()));
             throw e;
@@ -40,7 +40,7 @@ public class SyntAmeldingConsumer extends SyntConsumer {
         }
     }
 
-    public List<Arbeidsforhold> synthesizeArbeidsforholdStart(List<String> datoer, String url) {
+    public List<ArbeidsforholdAmelding> synthesizeArbeidsforholdStart(List<String> datoer, String url) {
 
         try {
             applicationManager.startApplication(this);

--- a/apps/syntrest/src/main/java/no/nav/registre/syntrest/consumer/command/PostArbeidsforholdCommand.java
+++ b/apps/syntrest/src/main/java/no/nav/registre/syntrest/consumer/command/PostArbeidsforholdCommand.java
@@ -14,12 +14,12 @@ import reactor.core.publisher.Mono;
 public class PostArbeidsforholdCommand implements Callable<ArbeidsforholdAmelding> {
 
     private final WebClient webClient;
-    private final ArbeidsforholdAmelding arbeidsforholdAmelding;
+    private final ArbeidsforholdAmelding arbeidsforhold;
     private final String syntAmeldingUrlPath;
 
-    public PostArbeidsforholdCommand(ArbeidsforholdAmelding arbeidsforholdAmelding, String syntAmeldingUrlPath, WebClient webClient) {
+    public PostArbeidsforholdCommand(ArbeidsforholdAmelding arbeidsforhold, String syntAmeldingUrlPath, WebClient webClient) {
         this.webClient = webClient;
-        this.arbeidsforholdAmelding = arbeidsforholdAmelding;
+        this.arbeidsforhold = arbeidsforhold;
         this.syntAmeldingUrlPath = syntAmeldingUrlPath;
     }
 
@@ -27,7 +27,7 @@ public class PostArbeidsforholdCommand implements Callable<ArbeidsforholdAmeldin
     public ArbeidsforholdAmelding call() {
         ArbeidsforholdAmelding response;
         try {
-            var body = BodyInserters.fromPublisher(Mono.just(arbeidsforholdAmelding), ArbeidsforholdAmelding.class);
+            var body = BodyInserters.fromPublisher(Mono.just(arbeidsforhold), ArbeidsforholdAmelding.class);
 
             response = webClient.post()
                     .uri(builder -> builder.path(syntAmeldingUrlPath).build())

--- a/apps/syntrest/src/main/java/no/nav/registre/syntrest/consumer/command/PostArbeidsforholdCommand.java
+++ b/apps/syntrest/src/main/java/no/nav/registre/syntrest/consumer/command/PostArbeidsforholdCommand.java
@@ -7,34 +7,34 @@ import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import lombok.extern.slf4j.Slf4j;
-import no.nav.registre.syntrest.domain.amelding.Arbeidsforhold;
+import no.nav.registre.syntrest.domain.amelding.ArbeidsforholdAmelding;
 import reactor.core.publisher.Mono;
 
 @Slf4j
-public class PostArbeidsforholdCommand implements Callable<Arbeidsforhold> {
+public class PostArbeidsforholdCommand implements Callable<ArbeidsforholdAmelding> {
 
     private final WebClient webClient;
-    private final Arbeidsforhold arbeidsforhold;
+    private final ArbeidsforholdAmelding arbeidsforholdAmelding;
     private final String syntAmeldingUrlPath;
 
-    public PostArbeidsforholdCommand(Arbeidsforhold arbeidsforhold, String syntAmeldingUrlPath, WebClient webClient) {
+    public PostArbeidsforholdCommand(ArbeidsforholdAmelding arbeidsforholdAmelding, String syntAmeldingUrlPath, WebClient webClient) {
         this.webClient = webClient;
-        this.arbeidsforhold = arbeidsforhold;
+        this.arbeidsforholdAmelding = arbeidsforholdAmelding;
         this.syntAmeldingUrlPath = syntAmeldingUrlPath;
     }
 
     @Override
-    public Arbeidsforhold call() {
-        Arbeidsforhold response;
+    public ArbeidsforholdAmelding call() {
+        ArbeidsforholdAmelding response;
         try {
-            var body = BodyInserters.fromPublisher(Mono.just(arbeidsforhold), Arbeidsforhold.class);
+            var body = BodyInserters.fromPublisher(Mono.just(arbeidsforholdAmelding), ArbeidsforholdAmelding.class);
 
             response = webClient.post()
                     .uri(builder -> builder.path(syntAmeldingUrlPath).build())
                     .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                     .body(body)
                     .retrieve()
-                    .bodyToMono(Arbeidsforhold.class)
+                    .bodyToMono(ArbeidsforholdAmelding.class)
                     .block();
         } catch (Exception e) {
             log.error("Unexpected Rest Client Exception.", e);

--- a/apps/syntrest/src/main/java/no/nav/registre/syntrest/consumer/command/PostArbeidsforholdStartCommand.java
+++ b/apps/syntrest/src/main/java/no/nav/registre/syntrest/consumer/command/PostArbeidsforholdStartCommand.java
@@ -9,11 +9,11 @@ import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import lombok.extern.slf4j.Slf4j;
-import no.nav.registre.syntrest.domain.amelding.Arbeidsforhold;
+import no.nav.registre.syntrest.domain.amelding.ArbeidsforholdAmelding;
 import reactor.core.publisher.Mono;
 
 @Slf4j
-public class PostArbeidsforholdStartCommand implements Callable<List<Arbeidsforhold>> {
+public class PostArbeidsforholdStartCommand implements Callable<List<ArbeidsforholdAmelding>> {
 
     private final WebClient webClient;
     private final List<String> startdatoer;
@@ -21,7 +21,7 @@ public class PostArbeidsforholdStartCommand implements Callable<List<Arbeidsforh
 
     private static final ParameterizedTypeReference<List<String>> REQUEST_TYPE = new ParameterizedTypeReference<>() {
     };
-    private static final ParameterizedTypeReference<List<Arbeidsforhold>> RESPONSE_TYPE = new ParameterizedTypeReference<>() {
+    private static final ParameterizedTypeReference<List<ArbeidsforholdAmelding>> RESPONSE_TYPE = new ParameterizedTypeReference<>() {
     };
 
     public PostArbeidsforholdStartCommand(List<String> startdatoer, String syntAmeldingUrlPath, WebClient webClient) {
@@ -31,8 +31,8 @@ public class PostArbeidsforholdStartCommand implements Callable<List<Arbeidsforh
     }
 
     @Override
-    public List<Arbeidsforhold> call() {
-        List<Arbeidsforhold> response;
+    public List<ArbeidsforholdAmelding> call() {
+        List<ArbeidsforholdAmelding> response;
         try {
             var body = BodyInserters.fromPublisher(Mono.just(startdatoer), REQUEST_TYPE);
 

--- a/apps/syntrest/src/main/java/no/nav/registre/syntrest/controllers/SyntController.java
+++ b/apps/syntrest/src/main/java/no/nav/registre/syntrest/controllers/SyntController.java
@@ -27,7 +27,7 @@ import no.nav.registre.syntrest.consumer.SyntAmeldingConsumer;
 import no.nav.registre.syntrest.consumer.SyntConsumer;
 import no.nav.registre.syntrest.consumer.UriExpander;
 import no.nav.registre.syntrest.domain.aareg.Arbeidsforholdsmelding;
-import no.nav.registre.syntrest.domain.amelding.Arbeidsforhold;
+import no.nav.registre.syntrest.domain.amelding.ArbeidsforholdAmelding;
 import no.nav.registre.syntrest.domain.bisys.Barnebidragsmelding;
 import no.nav.registre.syntrest.domain.frikort.FrikortKvittering;
 import no.nav.registre.syntrest.domain.inst.Institusjonsmelding;
@@ -319,10 +319,10 @@ public class SyntController {
 
     @PostMapping("/amelding/arbeidsforhold")
     @Timed(value = "syntrest.resource.latency", extraTags = { "operation", "synthdata-amelding" })
-    public ResponseEntity<Arbeidsforhold> generateArbeidforhold(
-            @RequestBody Arbeidsforhold tidligereArbeidsforhold
+    public ResponseEntity<ArbeidsforholdAmelding> generateArbeidforhold(
+            @RequestBody ArbeidsforholdAmelding tidligereArbeidsforholdAmelding
     ) {
-        var response = ameldingConsumer.synthesizeArbeidsforhold(tidligereArbeidsforhold, "/arbeidsforhold");
+        var response = ameldingConsumer.synthesizeArbeidsforhold(tidligereArbeidsforholdAmelding, "/arbeidsforhold");
         doResponseValidation(response);
 
         return ResponseEntity.ok(response);
@@ -330,10 +330,10 @@ public class SyntController {
 
     @PostMapping("/amelding/arbeidsforhold/sklearn")
     @Timed(value = "syntrest.resource.latency", extraTags = { "operation", "synthdata-amelding" })
-    public ResponseEntity<Arbeidsforhold> generateArbeidforholdSklearn(
-            @RequestBody Arbeidsforhold tidligereArbeidsforhold
+    public ResponseEntity<ArbeidsforholdAmelding> generateArbeidforholdSklearn(
+            @RequestBody ArbeidsforholdAmelding tidligereArbeidsforholdAmelding
     ) {
-        var response = ameldingConsumer.synthesizeArbeidsforhold(tidligereArbeidsforhold, "/arbeidsforhold/sklearn");
+        var response = ameldingConsumer.synthesizeArbeidsforhold(tidligereArbeidsforholdAmelding, "/arbeidsforhold/sklearn");
         doResponseValidation(response);
 
         return ResponseEntity.ok(response);
@@ -341,7 +341,7 @@ public class SyntController {
 
     @PostMapping("/amelding/arbeidsforhold/start")
     @Timed(value = "syntrest.resource.latency", extraTags = { "operation", "synthdata-amelding" })
-    public ResponseEntity<List<Arbeidsforhold>> generateArbeidforholdStart(
+    public ResponseEntity<List<ArbeidsforholdAmelding>> generateArbeidforholdStart(
             @RequestBody List<String> startdatoer
     ) {
         var response = ameldingConsumer.synthesizeArbeidsforholdStart(startdatoer, "/arbeidsforhold/start");

--- a/apps/syntrest/src/main/java/no/nav/registre/syntrest/controllers/SyntController.java
+++ b/apps/syntrest/src/main/java/no/nav/registre/syntrest/controllers/SyntController.java
@@ -320,9 +320,9 @@ public class SyntController {
     @PostMapping("/amelding/arbeidsforhold")
     @Timed(value = "syntrest.resource.latency", extraTags = { "operation", "synthdata-amelding" })
     public ResponseEntity<ArbeidsforholdAmelding> generateArbeidforhold(
-            @RequestBody ArbeidsforholdAmelding tidligereArbeidsforholdAmelding
+            @RequestBody ArbeidsforholdAmelding tidligereArbeidsforhold
     ) {
-        var response = ameldingConsumer.synthesizeArbeidsforhold(tidligereArbeidsforholdAmelding, "/arbeidsforhold");
+        var response = ameldingConsumer.synthesizeArbeidsforhold(tidligereArbeidsforhold, "/arbeidsforhold");
         doResponseValidation(response);
 
         return ResponseEntity.ok(response);
@@ -331,9 +331,9 @@ public class SyntController {
     @PostMapping("/amelding/arbeidsforhold/sklearn")
     @Timed(value = "syntrest.resource.latency", extraTags = { "operation", "synthdata-amelding" })
     public ResponseEntity<ArbeidsforholdAmelding> generateArbeidforholdSklearn(
-            @RequestBody ArbeidsforholdAmelding tidligereArbeidsforholdAmelding
+            @RequestBody ArbeidsforholdAmelding tidligereArbeidsforhold
     ) {
-        var response = ameldingConsumer.synthesizeArbeidsforhold(tidligereArbeidsforholdAmelding, "/arbeidsforhold/sklearn");
+        var response = ameldingConsumer.synthesizeArbeidsforhold(tidligereArbeidsforhold, "/arbeidsforhold/sklearn");
         doResponseValidation(response);
 
         return ResponseEntity.ok(response);

--- a/apps/syntrest/src/main/java/no/nav/registre/syntrest/domain/amelding/ArbeidsforholdAmelding.java
+++ b/apps/syntrest/src/main/java/no/nav/registre/syntrest/domain/amelding/ArbeidsforholdAmelding.java
@@ -18,7 +18,7 @@ import lombok.Setter;
 @Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class Arbeidsforhold {
+public class ArbeidsforholdAmelding {
 
     @JsonAlias({"RAPPORTERINGSMAANED", "rapporteringsmaaned"})
     private String rapporteringsmaaned;


### PR DESCRIPTION
Swagger klarte ikke å skille mellom amelding sitt arbeidsforhold og en annen Arbeidsforhold klasse i testnorge. Endret dermed navn for amelding sitt `Arbeidsforhold` til` ArbeidsforholdAmelding`.