### PR TITLE
Byttet til bruk av char-rnn

### DIFF
--- a/apps/mn-synt-arbeidsforhold-service/src/main/java/no/nav/registre/testnorge/mn/syntarbeidsforholdservice/consumer/SyntrestConsumer.java
+++ b/apps/mn-synt-arbeidsforhold-service/src/main/java/no/nav/registre/testnorge/mn/syntarbeidsforholdservice/consumer/SyntrestConsumer.java
@@ -34,6 +34,8 @@ public class SyntrestConsumer {
     private final ArbeidsforholdHistorikkAdapter adapter;
     private final SyntetiseringProperties properties;
 
+    private static final String OPPRETTELSE_FEILMELDING = "Feil med opprettelse av arbeidsforhold: ";
+
     public SyntrestConsumer(
             @Value("${consumers.syntrest.url}") String url,
             ObjectMapper objectMapper,
@@ -58,27 +60,27 @@ public class SyntrestConsumer {
     }
 
     @SneakyThrows
-    public ArbeidsforholdResponse getNesteArbeidsforholdResponse(Arbeidsforhold arbeidsforhold, LocalDate kaldermaaned) {
+    private ArbeidsforholdResponse getNesteArbeidsforholdResponse(Arbeidsforhold arbeidsforhold, LocalDate kaldermaaned) {
         var dto = arbeidsforhold.toSyntrestDTO(kaldermaaned);
         try {
             return new GenerateNextArbeidsforholdCommand(webClient, dto).call();
         } catch (WebClientResponseException.InternalServerError e) {
-            throw new RuntimeException("Feil med opprettelse av arbeidsforhold: " + objectMapper.writeValueAsString(dto), e);
+            throw new RuntimeException(OPPRETTELSE_FEILMELDING + objectMapper.writeValueAsString(dto), e);
         }
     }
 
     @SneakyThrows
-    public List<ArbeidsforholdResponse> getArbeidsforholdHistorikkResponse(Arbeidsforhold arbeidsforhold, LocalDate kaldermaaned) {
+    private List<ArbeidsforholdResponse> getArbeidsforholdHistorikkResponse(Arbeidsforhold arbeidsforhold, LocalDate kaldermaaned) {
         var dto = arbeidsforhold.toSyntrestDTO(kaldermaaned);
         try {
             return new GenerateArbeidsforholdHistorikkCommand(webClient, dto).call();
         } catch (WebClientResponseException.InternalServerError e) {
-            throw new RuntimeException("Feil med opprettelse av arbeidsforhold: " + objectMapper.writeValueAsString(dto), e);
+            throw new RuntimeException(OPPRETTELSE_FEILMELDING + objectMapper.writeValueAsString(dto), e);
         }
     }
 
     @SneakyThrows
-    public ArbeidsforholdResponse getNesteArbeidsforholdWithHistorikkResponse(Arbeidsforhold arbeidsforhold, LocalDate kaldermaaned) {
+    private ArbeidsforholdResponse getNesteArbeidsforholdWithHistorikkResponse(Arbeidsforhold arbeidsforhold, LocalDate kaldermaaned) {
         String historikk = adapter.get(arbeidsforhold.getArbeidsforholdId()).getHistorikk();
         var dto = arbeidsforhold.toSyntrestDTO(kaldermaaned, historikk);
         try {
@@ -86,7 +88,7 @@ public class SyntrestConsumer {
             adapter.save(arbeidsforhold.getArbeidsforholdId(), response.getHistorikk());
             return response;
         } catch (WebClientResponseException.InternalServerError e) {
-            throw new RuntimeException("Feil med opprettelse av arbeidsforhold: " + objectMapper.writeValueAsString(dto), e);
+            throw new RuntimeException(OPPRETTELSE_FEILMELDING + objectMapper.writeValueAsString(dto), e);
         }
     }
 

--- a/apps/mn-synt-arbeidsforhold-service/src/main/java/no/nav/registre/testnorge/mn/syntarbeidsforholdservice/consumer/SyntrestConsumer.java
+++ b/apps/mn-synt-arbeidsforhold-service/src/main/java/no/nav/registre/testnorge/mn/syntarbeidsforholdservice/consumer/SyntrestConsumer.java
@@ -61,8 +61,8 @@ public class SyntrestConsumer {
     }
 
     @SneakyThrows
-    private ArbeidsforholdResponse getNesteArbeidsforholdResponse(Arbeidsforhold arbeidsforhold, LocalDate kaldermaaned) {
-        var dto = arbeidsforhold.toSyntrestDTO(kaldermaaned);
+    private ArbeidsforholdResponse getNesteArbeidsforholdResponse(Arbeidsforhold arbeidsforhold, LocalDate kalendermaaned) {
+        var dto = arbeidsforhold.toSyntrestDTO(kalendermaaned);
         try {
             return new GenerateNextArbeidsforholdCommand(webClient, dto).call();
         } catch (WebClientResponseException.InternalServerError e) {
@@ -71,8 +71,8 @@ public class SyntrestConsumer {
     }
 
     @SneakyThrows
-    private List<ArbeidsforholdResponse> getArbeidsforholdHistorikkResponse(Arbeidsforhold arbeidsforhold, LocalDate kaldermaaned) {
-        var dto = arbeidsforhold.toSyntrestDTO(kaldermaaned);
+    private List<ArbeidsforholdResponse> getArbeidsforholdHistorikkResponse(Arbeidsforhold arbeidsforhold, LocalDate kalendermaaned) {
+        var dto = arbeidsforhold.toSyntrestDTO(kalendermaaned);
         try {
             return new GenerateArbeidsforholdHistorikkCommand(webClient, dto).call();
         } catch (WebClientResponseException.InternalServerError e) {
@@ -81,9 +81,9 @@ public class SyntrestConsumer {
     }
 
     @SneakyThrows
-    private ArbeidsforholdResponse getNesteArbeidsforholdWithHistorikkResponse(Arbeidsforhold arbeidsforhold, LocalDate kaldermaaned) {
+    private ArbeidsforholdResponse getNesteArbeidsforholdWithHistorikkResponse(Arbeidsforhold arbeidsforhold, LocalDate kalendermaaned) {
         String historikk = adapter.get(arbeidsforhold.getArbeidsforholdId()).getHistorikk();
-        var dto = arbeidsforhold.toSyntrestDTO(kaldermaaned, historikk);
+        var dto = arbeidsforhold.toSyntrestDTO(kalendermaaned, historikk);
         try {
             ArbeidsforholdResponse response = new GenerateNextArbeidsforholdWithHistorikkCommand(webClient, dto).call();
             adapter.save(arbeidsforhold.getArbeidsforholdId(), response.getHistorikk());
@@ -94,11 +94,11 @@ public class SyntrestConsumer {
     }
 
     @SneakyThrows
-    public Arbeidsforhold getNesteArbeidsforhold(Arbeidsforhold arbeidsforhold, LocalDate kaldermaaned) {
-        log.info("Finner neste arbeidsforhold den {}.", kaldermaaned.plusMonths(1));
+    public Arbeidsforhold getNesteArbeidsforhold(Arbeidsforhold arbeidsforhold, LocalDate kalendermaaned) {
+        log.info("Finner neste arbeidsforhold den {}.", kalendermaaned.plusMonths(1));
         ArbeidsforholdResponse response = properties.isSaveHistory()
-                ? getNesteArbeidsforholdWithHistorikkResponse(arbeidsforhold, kaldermaaned)
-                : getNesteArbeidsforholdResponse(arbeidsforhold, kaldermaaned);
+                ? getNesteArbeidsforholdWithHistorikkResponse(arbeidsforhold, kalendermaaned)
+                : getNesteArbeidsforholdResponse(arbeidsforhold, kalendermaaned);
         return new Arbeidsforhold(
                 response,
                 arbeidsforhold.getIdent(),
@@ -108,9 +108,9 @@ public class SyntrestConsumer {
     }
 
     @SneakyThrows
-    public List<Arbeidsforhold> getArbeidsforholdHistorikk(Arbeidsforhold arbeidsforhold, LocalDate kaldermaaned) {
-        log.info("Finner arbeidsforhold historikk fra og med {}.", kaldermaaned.plusMonths(1));
-        List<ArbeidsforholdResponse> response = getArbeidsforholdHistorikkResponse(arbeidsforhold, kaldermaaned);
+    public List<Arbeidsforhold> getArbeidsforholdHistorikk(Arbeidsforhold arbeidsforhold, LocalDate kalendermaaned) {
+        log.info("Finner arbeidsforhold historikk fra og med {}.", kalendermaaned.plusMonths(1));
+        List<ArbeidsforholdResponse> response = getArbeidsforholdHistorikkResponse(arbeidsforhold, kalendermaaned);
         return response.stream().map(res -> new Arbeidsforhold(
                 res,
                 arbeidsforhold.getIdent(),

--- a/apps/mn-synt-arbeidsforhold-service/src/main/java/no/nav/registre/testnorge/mn/syntarbeidsforholdservice/consumer/SyntrestConsumer.java
+++ b/apps/mn-synt-arbeidsforhold-service/src/main/java/no/nav/registre/testnorge/mn/syntarbeidsforholdservice/consumer/SyntrestConsumer.java
@@ -25,6 +25,7 @@ import no.nav.registre.testnorge.mn.syntarbeidsforholdservice.consumer.command.G
 import no.nav.registre.testnorge.mn.syntarbeidsforholdservice.consumer.command.GenerateNextArbeidsforholdWithHistorikkCommand;
 import no.nav.registre.testnorge.mn.syntarbeidsforholdservice.consumer.command.GenerateStartArbeidsforholdCommand;
 import no.nav.registre.testnorge.mn.syntarbeidsforholdservice.domain.Arbeidsforhold;
+import no.nav.registre.testnorge.mn.syntarbeidsforholdservice.exception.SyntetiseringException;
 
 @Slf4j
 @Component
@@ -65,7 +66,7 @@ public class SyntrestConsumer {
         try {
             return new GenerateNextArbeidsforholdCommand(webClient, dto).call();
         } catch (WebClientResponseException.InternalServerError e) {
-            throw new RuntimeException(OPPRETTELSE_FEILMELDING + objectMapper.writeValueAsString(dto), e);
+            throw new SyntetiseringException(OPPRETTELSE_FEILMELDING + objectMapper.writeValueAsString(dto), e);
         }
     }
 
@@ -75,7 +76,7 @@ public class SyntrestConsumer {
         try {
             return new GenerateArbeidsforholdHistorikkCommand(webClient, dto).call();
         } catch (WebClientResponseException.InternalServerError e) {
-            throw new RuntimeException(OPPRETTELSE_FEILMELDING + objectMapper.writeValueAsString(dto), e);
+            throw new SyntetiseringException(OPPRETTELSE_FEILMELDING + objectMapper.writeValueAsString(dto), e);
         }
     }
 
@@ -88,7 +89,7 @@ public class SyntrestConsumer {
             adapter.save(arbeidsforhold.getArbeidsforholdId(), response.getHistorikk());
             return response;
         } catch (WebClientResponseException.InternalServerError e) {
-            throw new RuntimeException(OPPRETTELSE_FEILMELDING + objectMapper.writeValueAsString(dto), e);
+            throw new SyntetiseringException(OPPRETTELSE_FEILMELDING + objectMapper.writeValueAsString(dto), e);
         }
     }
 
@@ -124,7 +125,7 @@ public class SyntrestConsumer {
             ArbeidsforholdResponse response = new GenerateStartArbeidsforholdCommand(webClient, startdato).call();
             return new Arbeidsforhold(response, ident, virksomhetsnummer);
         } catch (WebClientResponseException.InternalServerError e) {
-            throw new RuntimeException("Feil med start av arbeidsforhold for dato: " + startdato, e);
+            throw new SyntetiseringException("Feil med start av arbeidsforhold for dato: " + startdato, e);
         }
     }
 }

--- a/apps/mn-synt-arbeidsforhold-service/src/main/java/no/nav/registre/testnorge/mn/syntarbeidsforholdservice/consumer/SyntrestConsumer.java
+++ b/apps/mn-synt-arbeidsforhold-service/src/main/java/no/nav/registre/testnorge/mn/syntarbeidsforholdservice/consumer/SyntrestConsumer.java
@@ -103,7 +103,7 @@ public class SyntrestConsumer {
                 response,
                 arbeidsforhold.getIdent(),
                 arbeidsforhold.getArbeidsforholdId(),
-                arbeidsforhold.getVirksomhentsnummer()
+                arbeidsforhold.getVirksomhetsnummer()
         );
     }
 
@@ -115,7 +115,7 @@ public class SyntrestConsumer {
                 res,
                 arbeidsforhold.getIdent(),
                 arbeidsforhold.getArbeidsforholdId(),
-                arbeidsforhold.getVirksomhentsnummer()))
+                arbeidsforhold.getVirksomhetsnummer()))
                 .collect(Collectors.toList());
     }
 

--- a/apps/mn-synt-arbeidsforhold-service/src/main/java/no/nav/registre/testnorge/mn/syntarbeidsforholdservice/consumer/command/GenerateArbeidsforholdHistorikkCommand.java
+++ b/apps/mn-synt-arbeidsforhold-service/src/main/java/no/nav/registre/testnorge/mn/syntarbeidsforholdservice/consumer/command/GenerateArbeidsforholdHistorikkCommand.java
@@ -27,7 +27,7 @@ public class GenerateArbeidsforholdHistorikkCommand implements Callable<List<Arb
         log.info("Generer arbeidsforhold historikk.");
         return webClient
                 .post()
-                .uri("/api/v1/generate/amelding/arbeidsforhold/crnn")
+                .uri("/api/v1/generate/amelding/arbeidsforhold")
                 .body(BodyInserters.fromPublisher(Mono.just(arbeidsforholdDTO), ArbeidsforholdRequest.class))
                 .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                 .retrieve()

--- a/apps/mn-synt-arbeidsforhold-service/src/main/java/no/nav/registre/testnorge/mn/syntarbeidsforholdservice/consumer/command/GenerateArbeidsforholdHistorikkCommand.java
+++ b/apps/mn-synt-arbeidsforhold-service/src/main/java/no/nav/registre/testnorge/mn/syntarbeidsforholdservice/consumer/command/GenerateArbeidsforholdHistorikkCommand.java
@@ -1,0 +1,37 @@
+package no.nav.registre.testnorge.mn.syntarbeidsforholdservice.consumer.command;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import no.nav.registre.testnorge.libs.dependencyanalysis.DependencyOn;
+import no.nav.registre.testnorge.libs.dto.syntrest.v1.ArbeidsforholdRequest;
+import no.nav.registre.testnorge.libs.dto.syntrest.v1.ArbeidsforholdResponse;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@DependencyOn("syntrest")
+@RequiredArgsConstructor
+public class GenerateArbeidsforholdHistorikkCommand implements Callable<List<ArbeidsforholdResponse>> {
+    private final WebClient webClient;
+    private final ArbeidsforholdRequest arbeidsforholdDTO;
+
+    @Override
+    public List<ArbeidsforholdResponse> call() {
+        log.info("Generer arbeidsforhold historikk.");
+        return webClient
+                .post()
+                .uri("/api/v1/generate/amelding/arbeidsforhold/charRnn")
+                .body(BodyInserters.fromPublisher(Mono.just(arbeidsforholdDTO), ArbeidsforholdRequest.class))
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .retrieve()
+                .bodyToMono(new ParameterizedTypeReference<List<ArbeidsforholdResponse>>(){})
+                .block();
+    }
+}

--- a/apps/mn-synt-arbeidsforhold-service/src/main/java/no/nav/registre/testnorge/mn/syntarbeidsforholdservice/consumer/command/GenerateArbeidsforholdHistorikkCommand.java
+++ b/apps/mn-synt-arbeidsforhold-service/src/main/java/no/nav/registre/testnorge/mn/syntarbeidsforholdservice/consumer/command/GenerateArbeidsforholdHistorikkCommand.java
@@ -27,7 +27,7 @@ public class GenerateArbeidsforholdHistorikkCommand implements Callable<List<Arb
         log.info("Generer arbeidsforhold historikk.");
         return webClient
                 .post()
-                .uri("/api/v1/generate/amelding/arbeidsforhold/charRnn")
+                .uri("/api/v1/generate/amelding/arbeidsforhold/crnn")
                 .body(BodyInserters.fromPublisher(Mono.just(arbeidsforholdDTO), ArbeidsforholdRequest.class))
                 .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                 .retrieve()

--- a/apps/mn-synt-arbeidsforhold-service/src/main/java/no/nav/registre/testnorge/mn/syntarbeidsforholdservice/consumer/command/GenerateArbeidsforholdHistorikkCommand.java
+++ b/apps/mn-synt-arbeidsforhold-service/src/main/java/no/nav/registre/testnorge/mn/syntarbeidsforholdservice/consumer/command/GenerateArbeidsforholdHistorikkCommand.java
@@ -24,7 +24,7 @@ public class GenerateArbeidsforholdHistorikkCommand implements Callable<List<Arb
 
     @Override
     public List<ArbeidsforholdResponse> call() {
-        log.info("Generer arbeidsforhold historikk.");
+        log.info("Genererer arbeidsforhold historikk.");
         return webClient
                 .post()
                 .uri("/api/v1/generate/amelding/arbeidsforhold")

--- a/apps/mn-synt-arbeidsforhold-service/src/main/java/no/nav/registre/testnorge/mn/syntarbeidsforholdservice/domain/Arbeidsforhold.java
+++ b/apps/mn-synt-arbeidsforhold-service/src/main/java/no/nav/registre/testnorge/mn/syntarbeidsforholdservice/domain/Arbeidsforhold.java
@@ -14,23 +14,23 @@ import no.nav.registre.testnorge.libs.dto.syntrest.v1.ArbeidsforholdWithHistorik
 @Slf4j
 public class Arbeidsforhold {
 
-    public Arbeidsforhold(ArbeidsforholdDTO dto, String ident, String virksomhentsnummer) {
+    public Arbeidsforhold(ArbeidsforholdDTO dto, String ident, String virksomhetsnummer) {
         this.dto = dto;
         this.ident = ident;
-        this.virksomhentsnummer = virksomhentsnummer;
+        this.virksomhetsnummer = virksomhetsnummer;
     }
 
     private final ArbeidsforholdDTO dto;
     private final String ident;
-    private String virksomhentsnummer;
+    private String virksomhetsnummer;
 
     public Arbeidsforhold(
             ArbeidsforholdResponse response,
             String ident,
             String arbeidsforholdId,
-            String virksomhentsnummer
+            String virksomhetsnummer
     ) {
-        this.virksomhentsnummer = virksomhentsnummer;
+        this.virksomhetsnummer = virksomhetsnummer;
         this.ident = ident;
         this.dto = ArbeidsforholdDTO
                 .builder()
@@ -49,17 +49,17 @@ public class Arbeidsforhold {
     public Arbeidsforhold(
             ArbeidsforholdResponse response,
             String ident,
-            String virksomhentsnummer
+            String virksomhetsnummer
     ) {
-        this(response, ident, UUID.randomUUID().toString(), virksomhentsnummer);
+        this(response, ident, UUID.randomUUID().toString(), virksomhetsnummer);
     }
 
-    public String getVirksomhentsnummer() {
-        return virksomhentsnummer;
+    public String getVirksomhetsnummer() {
+        return virksomhetsnummer;
     }
 
-    public void setVirksomhentsnummer(String virksomhentsnummer) {
-        this.virksomhentsnummer = virksomhentsnummer;
+    public void setVirksomhetsnummer(String virksomhetsnummer) {
+        this.virksomhetsnummer = virksomhetsnummer;
     }
 
     public String getIdent() {

--- a/apps/mn-synt-arbeidsforhold-service/src/main/java/no/nav/registre/testnorge/mn/syntarbeidsforholdservice/domain/Opplysningspliktig.java
+++ b/apps/mn-synt-arbeidsforhold-service/src/main/java/no/nav/registre/testnorge/mn/syntarbeidsforholdservice/domain/Opplysningspliktig.java
@@ -36,7 +36,7 @@ public class Opplysningspliktig {
     }
 
     public void addArbeidsforhold(Arbeidsforhold arbeidsforhold) {
-        String virksomhetsnummer = arbeidsforhold.getVirksomhentsnummer();
+        String virksomhetsnummer = arbeidsforhold.getVirksomhetsnummer();
         VirksomhetDTO virksomhet = dto.getVirksomheter()
                 .stream()
                 .filter(value -> value.getOrganisajonsnummer().equals(virksomhetsnummer))

--- a/apps/mn-synt-arbeidsforhold-service/src/main/java/no/nav/registre/testnorge/mn/syntarbeidsforholdservice/domain/Organisajon.java
+++ b/apps/mn-synt-arbeidsforhold-service/src/main/java/no/nav/registre/testnorge/mn/syntarbeidsforholdservice/domain/Organisajon.java
@@ -21,7 +21,7 @@ public class Organisajon {
         return !dto.getDriverVirksomheter().isEmpty();
     }
 
-    public String getRandomVirksomhentsnummer(){
+    public String getRandomVirksomhetsnummer(){
         return dto.getDriverVirksomheter().get(RANDOM.nextInt(dto.getDriverVirksomheter().size()));
     }
 

--- a/apps/mn-synt-arbeidsforhold-service/src/main/java/no/nav/registre/testnorge/mn/syntarbeidsforholdservice/exception/MNOrganisasjonException.java
+++ b/apps/mn-synt-arbeidsforhold-service/src/main/java/no/nav/registre/testnorge/mn/syntarbeidsforholdservice/exception/MNOrganisasjonException.java
@@ -1,0 +1,8 @@
+package no.nav.registre.testnorge.mn.syntarbeidsforholdservice.exception;
+
+public class MNOrganisasjonException extends RuntimeException {
+
+    public MNOrganisasjonException(String message) {
+        super(message);
+    }
+}

--- a/apps/mn-synt-arbeidsforhold-service/src/main/java/no/nav/registre/testnorge/mn/syntarbeidsforholdservice/exception/SyntetiseringException.java
+++ b/apps/mn-synt-arbeidsforhold-service/src/main/java/no/nav/registre/testnorge/mn/syntarbeidsforholdservice/exception/SyntetiseringException.java
@@ -1,0 +1,8 @@
+package no.nav.registre.testnorge.mn.syntarbeidsforholdservice.exception;
+
+public class SyntetiseringException extends RuntimeException {
+
+    public SyntetiseringException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/apps/mn-synt-arbeidsforhold-service/src/main/java/no/nav/registre/testnorge/mn/syntarbeidsforholdservice/provider/IdentController.java
+++ b/apps/mn-synt-arbeidsforhold-service/src/main/java/no/nav/registre/testnorge/mn/syntarbeidsforholdservice/provider/IdentController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.time.LocalDate;
 import java.util.Set;
 
-import no.nav.registre.testnorge.mn.syntarbeidsforholdservice.service.ArbeidsfoholdService;
+import no.nav.registre.testnorge.mn.syntarbeidsforholdservice.service.ArbeidsforholdService;
 import no.nav.registre.testnorge.mn.syntarbeidsforholdservice.service.IdentService;
 
 @RestController
@@ -22,7 +22,7 @@ import no.nav.registre.testnorge.mn.syntarbeidsforholdservice.service.IdentServi
 @RequestMapping("api/v1/identer")
 public class IdentController {
 
-    private final ArbeidsfoholdService arbeidsfoholdService;
+    private final ArbeidsforholdService arbeidsforholdService;
     private final IdentService identService;
 
     @PostMapping("/{ident}")
@@ -37,7 +37,7 @@ public class IdentController {
                     .badRequest()
                     .body("Kan ikke opprette for ident " + ident + "fordi personen allerede finnes AAREG (" + miljo + ").");
         }
-        arbeidsfoholdService.startArbeidsforhold(ident, fom, tom, miljo);
+        arbeidsforholdService.startArbeidsforhold(ident, fom, tom, miljo);
         return ResponseEntity.noContent().build();
     }
 

--- a/apps/mn-synt-arbeidsforhold-service/src/main/java/no/nav/registre/testnorge/mn/syntarbeidsforholdservice/provider/IdentController.java
+++ b/apps/mn-synt-arbeidsforhold-service/src/main/java/no/nav/registre/testnorge/mn/syntarbeidsforholdservice/provider/IdentController.java
@@ -1,6 +1,7 @@
 package no.nav.registre.testnorge.mn.syntarbeidsforholdservice.provider;
 
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/apps/mn-synt-arbeidsforhold-service/src/main/java/no/nav/registre/testnorge/mn/syntarbeidsforholdservice/provider/IdentController.java
+++ b/apps/mn-synt-arbeidsforhold-service/src/main/java/no/nav/registre/testnorge/mn/syntarbeidsforholdservice/provider/IdentController.java
@@ -36,7 +36,7 @@ public class IdentController {
         if (identService.getIdenterMedArbeidsforhold(miljo).contains(ident)) {
             return ResponseEntity
                     .badRequest()
-                    .body("Kan ikke opprette for ident " + ident + "fordi personen allerede finnes AAREG (" + miljo + ").");
+                    .body("Kan ikke opprette arbeidsforhold for ident " + ident + "fordi personen allerede finnes i AAREG (" + miljo + ").");
         }
         arbeidsforholdService.startArbeidsforhold(ident, fom, tom, miljo);
         return ResponseEntity.noContent().build();

--- a/apps/mn-synt-arbeidsforhold-service/src/main/java/no/nav/registre/testnorge/mn/syntarbeidsforholdservice/provider/OpplysningspliktigController.java
+++ b/apps/mn-synt-arbeidsforhold-service/src/main/java/no/nav/registre/testnorge/mn/syntarbeidsforholdservice/provider/OpplysningspliktigController.java
@@ -10,14 +10,14 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.time.LocalDate;
 
-import no.nav.registre.testnorge.mn.syntarbeidsforholdservice.service.ArbeidsfoholdService;
+import no.nav.registre.testnorge.mn.syntarbeidsforholdservice.service.ArbeidsforholdService;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("api/v1/opplysningspliktig")
 public class OpplysningspliktigController {
 
-    private final ArbeidsfoholdService syntentiseringService;
+    private final ArbeidsforholdService syntentiseringService;
 
     @PostMapping
     public ResponseEntity<?> generateForAll(

--- a/apps/mn-synt-arbeidsforhold-service/src/main/java/no/nav/registre/testnorge/mn/syntarbeidsforholdservice/provider/OpplysningspliktigController.java
+++ b/apps/mn-synt-arbeidsforhold-service/src/main/java/no/nav/registre/testnorge/mn/syntarbeidsforholdservice/provider/OpplysningspliktigController.java
@@ -1,6 +1,7 @@
 package no.nav.registre.testnorge.mn.syntarbeidsforholdservice.provider;
 
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;

--- a/apps/mn-synt-arbeidsforhold-service/src/main/java/no/nav/registre/testnorge/mn/syntarbeidsforholdservice/service/ArbeidsforholdService.java
+++ b/apps/mn-synt-arbeidsforhold-service/src/main/java/no/nav/registre/testnorge/mn/syntarbeidsforholdservice/service/ArbeidsforholdService.java
@@ -7,6 +7,8 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 import java.time.Period;
+import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -216,7 +218,7 @@ public class ArbeidsforholdService {
             log.info("Bytter jobb for person {} med tidligere arbeidsforhold {}.", previous.getIdent(), previous.getArbeidsforholdId());
             Arbeidsforhold next = syntrestConsumer.getFirstArbeidsforhold(kalendermaaned, previous.getIdent(), previous.getVirksomhentsnummer());
             log.info("Nytt arbeidsforhold id {} for person {}.", next.getArbeidsforholdId(), next.getIdent());
-            return Collections.singletonList(next);
+            return new ArrayList<>(Arrays.asList(next));
         } else if (historikk.isEmpty()) {
             return getArbeidsforholdHistorikk(previous, kalendermaaned.minusMonths(1));
         } else {

--- a/apps/mn-synt-arbeidsforhold-service/src/main/java/no/nav/registre/testnorge/mn/syntarbeidsforholdservice/service/ArbeidsforholdService.java
+++ b/apps/mn-synt-arbeidsforhold-service/src/main/java/no/nav/registre/testnorge/mn/syntarbeidsforholdservice/service/ArbeidsforholdService.java
@@ -215,10 +215,14 @@ public class ArbeidsforholdService {
             log.info("Nytt arbeidsforhold id {} for person {}.", next.getArbeidsforholdId(), next.getIdent());
             return Collections.singletonList(next);
         } else if (historikk.isEmpty()) {
-            return syntrestConsumer.getArbeidsforholdHistorikk(previous, kalendermaaned.minusMonths(1));
+            return getArbeidsforholdHistorikk(previous, kalendermaaned.minusMonths(1));
         } else {
             return historikk;
         }
+    }
+
+    private List<Arbeidsforhold> getArbeidsforholdHistorikk(Arbeidsforhold arbeidsforhold, LocalDate kalendermaaned) {
+        return syntrestConsumer.getArbeidsforholdHistorikk(arbeidsforhold, kalendermaaned);
     }
 
     private Arbeidsforhold createArbeidsforhold(boolean newArbeidsforhold, LocalDate kalendermaaned, Arbeidsforhold previous) {

--- a/apps/mn-synt-arbeidsforhold-service/src/main/java/no/nav/registre/testnorge/mn/syntarbeidsforholdservice/service/ArbeidsforholdService.java
+++ b/apps/mn-synt-arbeidsforhold-service/src/main/java/no/nav/registre/testnorge/mn/syntarbeidsforholdservice/service/ArbeidsforholdService.java
@@ -2,6 +2,7 @@ package no.nav.registre.testnorge.mn.syntarbeidsforholdservice.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
@@ -32,7 +33,6 @@ public class ArbeidsforholdService {
     private final SyntrestConsumer syntrestConsumer;
     private final SyntetiseringProperties syntetiseringProperties;
     private final Random random = new Random();
-
 
     private List<Organisajon> getOpplysningspliktigeorganisasjoner(String miljo) {
         List<Organisajon> organisajoner = mnorganisasjonConsumer
@@ -166,7 +166,6 @@ public class ArbeidsforholdService {
         }
     }
 
-
     private void syntHistory(
             Organisajon opplysningspliktigOrganisajon,
             Arbeidsforhold previous,
@@ -215,14 +214,12 @@ public class ArbeidsforholdService {
             Arbeidsforhold next = syntrestConsumer.getFirstArbeidsforhold(kalendermaaned, previous.getIdent(), previous.getVirksomhentsnummer());
             log.info("Nytt arbeidsforhold id {} for person {}.", next.getArbeidsforholdId(), next.getIdent());
             return Collections.singletonList(next);
-        }
-        else if (historikk.isEmpty()){
+        } else if (historikk.isEmpty()) {
             return syntrestConsumer.getArbeidsforholdHistorikk(previous, kalendermaaned.minusMonths(1));
         } else {
             return historikk;
         }
     }
-
 
     private Arbeidsforhold createArbeidsforhold(boolean newArbeidsforhold, LocalDate kalendermaaned, Arbeidsforhold previous) {
         if (newArbeidsforhold) {

--- a/apps/mn-synt-arbeidsforhold-service/src/main/java/no/nav/registre/testnorge/mn/syntarbeidsforholdservice/service/ArbeidsforholdService.java
+++ b/apps/mn-synt-arbeidsforhold-service/src/main/java/no/nav/registre/testnorge/mn/syntarbeidsforholdservice/service/ArbeidsforholdService.java
@@ -66,7 +66,7 @@ public class ArbeidsforholdService {
 
         List<Organisajon> organisajoner = getOpplysningspliktigeorganisasjoner(miljo);
         Organisajon organisajon = organisajoner.get(random.nextInt(organisajoner.size()));
-        String virksomhetsnummer = organisajon.getRandomVirksomhentsnummer();
+        String virksomhetsnummer = organisajon.getRandomVirksomhetsnummer();
         Opplysningspliktig opplysningspliktig = getOpplysningspliktig(organisajon, fom, miljo);
 
         Arbeidsforhold arbeidsforhold = createArbeidsforhold(fom, ident, virksomhetsnummer);
@@ -173,13 +173,13 @@ public class ArbeidsforholdService {
             Organisajon opplysningspliktigOrganisajon,
             Arbeidsforhold previous,
             String miljo,
-            Iterator<LocalDate> kalendermaander,
+            Iterator<LocalDate> kalendermaaneder,
             List<Arbeidsforhold> historikk
     ) {
-        if (!kalendermaander.hasNext()) {
+        if (!kalendermaaneder.hasNext()) {
             return;
         }
-        LocalDate kalendermaaned = kalendermaander.next();
+        LocalDate kalendermaaned = kalendermaaneder.next();
         boolean newArbeidsforhold = previous.getSluttdato() != null
                 && previous.getSluttdato().getMonth() == kalendermaaned.minusMonths(1).getMonth()
                 && previous.getSluttdato().getYear() == kalendermaaned.minusMonths(1).getYear();
@@ -198,17 +198,17 @@ public class ArbeidsforholdService {
             if (newArbeidsforhold) {
                 List<Organisajon> opplysningspliktigeorganisasjoner = getOpplysningspliktigeorganisasjoner(miljo);
                 Organisajon newOpplysningspliktigOrganisajon = opplysningspliktigeorganisasjoner.get(random.nextInt(opplysningspliktigeorganisasjoner.size()));
-                String virksomhentsnummer = newOpplysningspliktigOrganisajon.getRandomVirksomhentsnummer();
-                next.setVirksomhentsnummer(virksomhentsnummer);
+                String virksomhetsnummer = newOpplysningspliktigOrganisajon.getRandomVirksomhetsnummer();
+                next.setVirksomhetsnummer(virksomhetsnummer);
                 Opplysningspliktig opplysningspliktig = getOpplysningspliktig(newOpplysningspliktigOrganisajon, kalendermaaned, miljo);
                 opplysningspliktig.addArbeidsforhold(next);
                 arbeidsforholdConsumer.sendOpplysningspliktig(opplysningspliktig, miljo);
-                syntHistory(newOpplysningspliktigOrganisajon, next, miljo, kalendermaander, Collections.emptyList());
+                syntHistory(newOpplysningspliktigOrganisajon, next, miljo, kalendermaaneder, Collections.emptyList());
             } else {
                 Opplysningspliktig opplysningspliktig = getOpplysningspliktig(opplysningspliktigOrganisajon, kalendermaaned, miljo);
                 opplysningspliktig.addArbeidsforhold(next);
                 arbeidsforholdConsumer.sendOpplysningspliktig(opplysningspliktig, miljo);
-                syntHistory(opplysningspliktigOrganisajon, next, miljo, kalendermaander, newHistorikk);
+                syntHistory(opplysningspliktigOrganisajon, next, miljo, kalendermaaneder, newHistorikk);
             }
         }
     }
@@ -216,7 +216,7 @@ public class ArbeidsforholdService {
     private List<Arbeidsforhold> createArbeidsforholdHistorikk(boolean newArbeidsforhold, LocalDate kalendermaaned, Arbeidsforhold previous, List<Arbeidsforhold> historikk) {
         if (newArbeidsforhold) {
             log.info("Bytter jobb for person {} med tidligere arbeidsforhold {}.", previous.getIdent(), previous.getArbeidsforholdId());
-            Arbeidsforhold next = syntrestConsumer.getFirstArbeidsforhold(kalendermaaned, previous.getIdent(), previous.getVirksomhentsnummer());
+            Arbeidsforhold next = syntrestConsumer.getFirstArbeidsforhold(kalendermaaned, previous.getIdent(), previous.getVirksomhetsnummer());
             log.info("Nytt arbeidsforhold id {} for person {}.", next.getArbeidsforholdId(), next.getIdent());
             return new ArrayList<>(Arrays.asList(next));
         } else if (historikk.isEmpty()) {
@@ -233,7 +233,7 @@ public class ArbeidsforholdService {
     private Arbeidsforhold createArbeidsforhold(boolean newArbeidsforhold, LocalDate kalendermaaned, Arbeidsforhold previous) {
         if (newArbeidsforhold) {
             log.info("Bytter job for person {} med tidligere arbeidsforhold {}.", previous.getIdent(), previous.getArbeidsforholdId());
-            Arbeidsforhold next = syntrestConsumer.getFirstArbeidsforhold(kalendermaaned, previous.getIdent(), previous.getVirksomhentsnummer());
+            Arbeidsforhold next = syntrestConsumer.getFirstArbeidsforhold(kalendermaaned, previous.getIdent(), previous.getVirksomhetsnummer());
             log.info("Nytt arbeidsforhold id {} for person {}.", next.getArbeidsforholdId(), next.getIdent());
             return next;
         }

--- a/apps/mn-synt-arbeidsforhold-service/src/main/java/no/nav/registre/testnorge/mn/syntarbeidsforholdservice/service/ArbeidsforholdService.java
+++ b/apps/mn-synt-arbeidsforhold-service/src/main/java/no/nav/registre/testnorge/mn/syntarbeidsforholdservice/service/ArbeidsforholdService.java
@@ -23,6 +23,7 @@ import no.nav.registre.testnorge.mn.syntarbeidsforholdservice.consumer.SyntrestC
 import no.nav.registre.testnorge.mn.syntarbeidsforholdservice.domain.Arbeidsforhold;
 import no.nav.registre.testnorge.mn.syntarbeidsforholdservice.domain.Opplysningspliktig;
 import no.nav.registre.testnorge.mn.syntarbeidsforholdservice.domain.Organisajon;
+import no.nav.registre.testnorge.mn.syntarbeidsforholdservice.exception.MNOrganisasjonException;
 
 @Slf4j
 @Service
@@ -43,7 +44,7 @@ public class ArbeidsforholdService {
                 .collect(Collectors.toList());
 
         if (organisajoner.isEmpty()) {
-            throw new RuntimeException("Fant ingen opplysningspliktige i Mini-Norge som driver virksomheter");
+            throw new MNOrganisasjonException("Fant ingen opplysningspliktige i Mini-Norge som driver virksomheter");
         }
         return organisajoner;
     }

--- a/apps/mn-synt-arbeidsforhold-service/src/main/java/no/nav/registre/testnorge/mn/syntarbeidsforholdservice/service/ArbeidsforholdService.java
+++ b/apps/mn-synt-arbeidsforhold-service/src/main/java/no/nav/registre/testnorge/mn/syntarbeidsforholdservice/service/ArbeidsforholdService.java
@@ -190,22 +190,24 @@ public class ArbeidsforholdService {
             );
         }
         List<Arbeidsforhold> newHistorikk = createArbeidsforholdHistorikk(newArbeidsforhold, kalendermaaned, previous, historikk);
-        Arbeidsforhold next = newHistorikk.get(0);
-        newHistorikk.remove(0);
-        if (newArbeidsforhold) {
-            List<Organisajon> opplysningspliktigeorganisasjoner = getOpplysningspliktigeorganisasjoner(miljo);
-            Organisajon newOpplysningspliktigOrganisajon = opplysningspliktigeorganisasjoner.get(random.nextInt(opplysningspliktigeorganisasjoner.size()));
-            String virksomhentsnummer = newOpplysningspliktigOrganisajon.getRandomVirksomhentsnummer();
-            next.setVirksomhentsnummer(virksomhentsnummer);
-            Opplysningspliktig opplysningspliktig = getOpplysningspliktig(newOpplysningspliktigOrganisajon, kalendermaaned, miljo);
-            opplysningspliktig.addArbeidsforhold(next);
-            arbeidsforholdConsumer.sendOpplysningspliktig(opplysningspliktig, miljo);
-            syntHistory(newOpplysningspliktigOrganisajon, next, miljo, kalendermaander, Collections.emptyList());
-        } else {
-            Opplysningspliktig opplysningspliktig = getOpplysningspliktig(opplysningspliktigOrganisajon, kalendermaaned, miljo);
-            opplysningspliktig.addArbeidsforhold(next);
-            arbeidsforholdConsumer.sendOpplysningspliktig(opplysningspliktig, miljo);
-            syntHistory(opplysningspliktigOrganisajon, next, miljo, kalendermaander, newHistorikk);
+        if (!newHistorikk.isEmpty()){
+            Arbeidsforhold next = newHistorikk.get(0);
+            newHistorikk.remove(0);
+            if (newArbeidsforhold) {
+                List<Organisajon> opplysningspliktigeorganisasjoner = getOpplysningspliktigeorganisasjoner(miljo);
+                Organisajon newOpplysningspliktigOrganisajon = opplysningspliktigeorganisasjoner.get(random.nextInt(opplysningspliktigeorganisasjoner.size()));
+                String virksomhentsnummer = newOpplysningspliktigOrganisajon.getRandomVirksomhentsnummer();
+                next.setVirksomhentsnummer(virksomhentsnummer);
+                Opplysningspliktig opplysningspliktig = getOpplysningspliktig(newOpplysningspliktigOrganisajon, kalendermaaned, miljo);
+                opplysningspliktig.addArbeidsforhold(next);
+                arbeidsforholdConsumer.sendOpplysningspliktig(opplysningspliktig, miljo);
+                syntHistory(newOpplysningspliktigOrganisajon, next, miljo, kalendermaander, Collections.emptyList());
+            } else {
+                Opplysningspliktig opplysningspliktig = getOpplysningspliktig(opplysningspliktigOrganisajon, kalendermaaned, miljo);
+                opplysningspliktig.addArbeidsforhold(next);
+                arbeidsforholdConsumer.sendOpplysningspliktig(opplysningspliktig, miljo);
+                syntHistory(opplysningspliktigOrganisajon, next, miljo, kalendermaander, newHistorikk);
+            }
         }
     }
 

--- a/apps/mn-synt-arbeidsforhold-service/src/main/java/no/nav/registre/testnorge/mn/syntarbeidsforholdservice/service/ArbeidsforholdService.java
+++ b/apps/mn-synt-arbeidsforhold-service/src/main/java/no/nav/registre/testnorge/mn/syntarbeidsforholdservice/service/ArbeidsforholdService.java
@@ -26,7 +26,7 @@ import no.nav.registre.testnorge.mn.syntarbeidsforholdservice.domain.Organisajon
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class ArbeidsfoholdService {
+public class ArbeidsforholdService {
     private final MNOrganisasjonConsumer mnorganisasjonConsumer;
     private final ArbeidsforholdConsumer arbeidsforholdConsumer;
     private final SyntrestConsumer syntrestConsumer;
@@ -55,7 +55,7 @@ public class ArbeidsfoholdService {
         }
     }
 
-    public Arbeidsforhold createArbeidsforhold(LocalDate kalendermaaned, String ident, String virksomhetsnummer) {
+    private Arbeidsforhold createArbeidsforhold(LocalDate kalendermaaned, String ident, String virksomhetsnummer) {
         return syntrestConsumer.getFirstArbeidsforhold(kalendermaaned, ident, virksomhetsnummer);
     }
 
@@ -154,7 +154,7 @@ public class ArbeidsfoholdService {
         arbeidsforholdConsumer.sendOpplysningspliktig(opplysningspliktig, miljo);
     }
 
-    public void syntHistory(Organisajon organisajon, LocalDate kalendermaaned, String miljo) {
+    private void syntHistory(Organisajon organisajon, LocalDate kalendermaaned, String miljo) {
         Optional<Opplysningspliktig> thisMonth = getOpplysningspliktigForMonth(organisajon, kalendermaaned, miljo);
         Optional<Opplysningspliktig> lastMonth = getOpplysningspliktigForPreviousMonth(organisajon, kalendermaaned, miljo);
         if (thisMonth.isPresent()) {
@@ -167,7 +167,7 @@ public class ArbeidsfoholdService {
     }
 
 
-    public void syntHistory(
+    private void syntHistory(
             Organisajon opplysningspliktigOrganisajon,
             Arbeidsforhold previous,
             String miljo,
@@ -211,7 +211,7 @@ public class ArbeidsfoholdService {
 
     private List<Arbeidsforhold> createArbeidsforholdHistorikk(boolean newArbeidsforhold, LocalDate kalendermaaned, Arbeidsforhold previous, List<Arbeidsforhold> historikk) {
         if (newArbeidsforhold) {
-            log.info("Bytter job for person {} med tidligere arbeidsforhold {}.", previous.getIdent(), previous.getArbeidsforholdId());
+            log.info("Bytter jobb for person {} med tidligere arbeidsforhold {}.", previous.getIdent(), previous.getArbeidsforholdId());
             Arbeidsforhold next = syntrestConsumer.getFirstArbeidsforhold(kalendermaaned, previous.getIdent(), previous.getVirksomhentsnummer());
             log.info("Nytt arbeidsforhold id {} for person {}.", next.getArbeidsforholdId(), next.getIdent());
             return Collections.singletonList(next);

--- a/apps/mn-synt-arbeidsforhold-service/src/test/java/no/nav/registre/testnorge/mn/syntarbeidsforholdservice/provider/assertions/OpplysningspliktigDTOAssert.java
+++ b/apps/mn-synt-arbeidsforhold-service/src/test/java/no/nav/registre/testnorge/mn/syntarbeidsforholdservice/provider/assertions/OpplysningspliktigDTOAssert.java
@@ -67,24 +67,24 @@ public class OpplysningspliktigDTOAssert extends AbstractAssert<Opplysningsplikt
     }
 
 
-    public OpplysningspliktigDTOAssert hasOneOfVirksomhentsnummer(String... virksomhentsnummer) {
+    public OpplysningspliktigDTOAssert hasOneOfVirksomhetsnummer(String... virksomhetsnummer) {
         isNotNull();
 
         if (actual.getVirksomheter() == null || actual.getVirksomheter().isEmpty()) {
             failWithMessage("Finner ingen virksomhenter.");
         }
 
-        if (virksomhentsnummer == null) {
+        if (virksomhetsnummer == null) {
             return this;
         }
 
-        Set<String> vikrksomhentsnummerSet = Set.of(virksomhentsnummer);
+        Set<String> virksomhetsnummerSet = Set.of(virksomhetsnummer);
         Optional<VirksomhetDTO> optional = actual.getVirksomheter().stream().filter(virksomhet ->
-                vikrksomhentsnummerSet.contains(virksomhet.getOrganisajonsnummer())
+                virksomhetsnummerSet.contains(virksomhet.getOrganisajonsnummer())
         ).findAny();
 
         if (optional.isEmpty()) {
-            failWithMessage("Finner ingen virksomhetner med virksomhetsnummer [<%s>].", String.join(",", virksomhentsnummer));
+            failWithMessage("Finner ingen virksomhetner med virksomhetsnummer [<%s>].", String.join(",", virksomhetsnummer));
         }
         return this;
     }

--- a/apps/mn-synt-arbeidsforhold-service/src/test/java/no/nav/registre/testnorge/mn/syntarbeidsforholdservice/provider/assertions/OpplysningspliktigDTOAssert.java
+++ b/apps/mn-synt-arbeidsforhold-service/src/test/java/no/nav/registre/testnorge/mn/syntarbeidsforholdservice/provider/assertions/OpplysningspliktigDTOAssert.java
@@ -71,7 +71,7 @@ public class OpplysningspliktigDTOAssert extends AbstractAssert<Opplysningsplikt
         isNotNull();
 
         if (actual.getVirksomheter() == null || actual.getVirksomheter().isEmpty()) {
-            failWithMessage("Finner ingen virksomhenter.");
+            failWithMessage("Finner ingen virksomheter.");
         }
 
         if (virksomhetsnummer == null) {
@@ -84,7 +84,7 @@ public class OpplysningspliktigDTOAssert extends AbstractAssert<Opplysningsplikt
         ).findAny();
 
         if (optional.isEmpty()) {
-            failWithMessage("Finner ingen virksomhetner med virksomhetsnummer [<%s>].", String.join(",", virksomhetsnummer));
+            failWithMessage("Finner ingen virksomheter med virksomhetsnummer [<%s>].", String.join(",", virksomhetsnummer));
         }
         return this;
     }


### PR DESCRIPTION
Syntrest returnerer nå liste (med ukjent lengde) med fremtidig arbeidforhold i stedet for kun neste måneds arbeidsforhold. Har oppdatert koden sånn at det støtter dette og fikset litt code smells og skrivefeil. 

Har ikke klart å teste koden lokalt enda, da jeg ikke får AccessTokenService til å funke lokalt, men jeg tenkte det var greit å ha en PR på det jeg har endret mens jeg finner ut av det. 