### PR TITLE
Oppdatert arena batch kjoring

### DIFF
--- a/apps/orkestratoren/src/main/java/no/nav/registre/orkestratoren/batch/v1/JobController.java
+++ b/apps/orkestratoren/src/main/java/no/nav/registre/orkestratoren/batch/v1/JobController.java
@@ -196,9 +196,9 @@ public class JobController {
 
     /**
     * Denne metoden oppretter vedtakshistorikk i Arena og registerer brukere med oppfølging (uten vedtak) i Arena.
-     * Metoden kjøres annen hver time.
+     * Metoden kjøres hver time fra 0-5 og fra 18-23.
     * */
-    @Scheduled(cron = "0 0 0-23/2 * * *")
+    @Scheduled(cron = "0 0 0-5,18-23 * * *")
     public void arenaSyntBatch() {
         for (var entry : avspillergruppeIdMedMiljoe.entrySet()) {
             for (int i = 0; i < arenaAntallNyeIdenter; i++) {
@@ -212,7 +212,7 @@ public class JobController {
             testnorgeArenaService.opprettArbeidssokereIArena(SyntetiserArenaRequest.builder()
                     .avspillergruppeId(entry.getKey())
                     .miljoe(entry.getValue())
-                    .antallNyeIdenter(2)
+                    .antallNyeIdenter(1)
                     .build(), true);
         }
     }


### PR DESCRIPTION
Har endret batch kjøringen til Arena i orkestratoren til å kjøre hver time mellom 18:00 - 05:00 i stedet for annen hver time gjennom hele dagen. Har endret sånn at det kun blir registrert en arbeidsøker i arena med oppfølging hver gang og skal også minke antall identer med vedtakshistorikk som blir generert hver gang (må endre det i vault) fra 50 til 15.

Minker antallet da for å se om det fikser litt performance issues testnorge-arena har hatt.