### PR TITLE
Endret Localdate til string i permisjonsdatoer

### DIFF
--- a/apps/syntrest/src/main/java/no/nav/registre/syntrest/domain/amelding/Permisjon.java
+++ b/apps/syntrest/src/main/java/no/nav/registre/syntrest/domain/amelding/Permisjon.java
@@ -1,6 +1,5 @@
 package no.nav.registre.syntrest.domain.amelding;
 
-import java.time.LocalDate;
 import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/apps/syntrest/src/main/java/no/nav/registre/syntrest/domain/amelding/Permisjon.java
+++ b/apps/syntrest/src/main/java/no/nav/registre/syntrest/domain/amelding/Permisjon.java
@@ -21,10 +21,10 @@ import lombok.Setter;
 public class Permisjon {
 
     @JsonAlias({"STARTDATO", "startdato"})
-    private LocalDate startdato;
+    private String startdato;
 
     @JsonAlias({"SLUTTDATO", "sluttdato"})
-    private LocalDate sluttdato;
+    private String sluttdato;
 
     @JsonAlias({"PERMISJONSPROSENT", "permisjonsprosent"})
     private float permisjonsprosent;


### PR DESCRIPTION
Liten fiks for å kunne sende "permisjoner" med i input til synt_amelding.