### PR TITLE
Fjerne namespace fra xsd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@
 .gradle
 *build/
 **/out/*
+
+##brreg-stub
+apps/brreg-stub/src/generated

--- a/apps/brreg-stub/build.gradle
+++ b/apps/brreg-stub/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'no.nav.registre.testnorge.java-conventions'
     id "uk.co.boothen.gradle.wsimport" version "0.16"
-    id 'org.unbroken-dome.xjc' version '2.0.0'
+    id 'com.ewerk.gradle.plugins.jaxb2' version '1.0.10'
     id 'org.springframework.boot' version '2.3.4.RELEASE'
     id 'io.spring.dependency-management' version '1.0.8.RELEASE'
 }
@@ -16,11 +16,37 @@ wsimport {
     }
 }
 
+jaxb2 {
+    xjc {
+        'hentroller' {
+            basePackage = 'no.nav.brregstub.tjenestekontrakter.hentroller'
+            schema = 'src/main/xsd/HentRoller.xsd'
+        }
+    }
+    xjc {
+        'rolleutskrift' {
+            basePackage = 'no.nav.brregstub.tjenestekontrakter.rolleutskrift'
+            schema = 'src/main/xsd/Rolleutskrift.xsd'
+        }
+    }
+}
+
 dependencies {
     implementation 'org.projectlombok:lombok:1.18.12'
     implementation 'org.springframework.boot:spring-boot-starter-web:2.3.4.RELEASE'
     implementation 'org.springframework.boot:spring-boot-starter-web-services:2.3.4.RELEASE'
     implementation 'org.springframework.vault:spring-vault-core:2.2.0.RELEASE'
+
+    jaxb2 'org.jvnet.jaxb2_commons:jaxb2-basics-runtime:0.9.5'
+    jaxb2 'org.jvnet.jaxb2_commons:jaxb2-basics-ant:0.9.5'
+    jaxb2 'org.jvnet.jaxb2_commons:jaxb2-basics:0.9.5'
+
+    // default JAXB libs added by the plugin
+    jaxb2 'com.sun.xml.bind:jaxb-core:2.2.11'
+    jaxb2 'com.sun.xml.bind:jaxb-xjc:2.2.11'
+    jaxb2 'com.sun.xml.bind:jaxb-impl:2.2.11'
+
+    jaxb2 'javax.xml.bind:jaxb-api:2.3.1'
 
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa:2.3.4.RELEASE'
     implementation 'org.postgresql:postgresql:42.2.16'

--- a/apps/brreg-stub/src/main/xsd/HentRoller.xsd
+++ b/apps/brreg-stub/src/main/xsd/HentRoller.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- edited with XMLSpy v2006 sp2 U (http://www.altova.com) by Bronnoysundregistrene (Bronnoysundregistrene) -->
 <!-- edited with XMLSPY v5 rel. 3 U (http://www.xmlspy.com) by Stein Ivar Olsen (Bronnoysundregistrene) -->
-<xs:schema xmlns="no:nav:brregstub:tjenestekontrakter:hentroller" xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="no:nav:brregstub:tjenestekontrakter:hentroller">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
     <xs:element name="grunndata">
         <xs:annotation>
             <xs:documentation>Bekskriver tjenesten hentRoller</xs:documentation>

--- a/apps/brreg-stub/src/main/xsd/Rolleutskrift.xsd
+++ b/apps/brreg-stub/src/main/xsd/Rolleutskrift.xsd
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- edited with XMLSPY v5 rel. 3 U (http://www.xmlspy.com) by Stein Ivar Olsen (Bronnoysundregistrene) -->
-<xs:schema xmlns="no:nav:brregstub:tjenestekontrakter:rolleutskrift" xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           elementFormDefault="qualified" targetNamespace="no:nav:brregstub:tjenestekontrakter:rolleutskrift">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
     <xs:element name="grunndata">
         <xs:annotation>
             <xs:documentation>Bekskriver tjenesten hentRolleutskrift</xs:documentation>


### PR DESCRIPTION
Team Arbeidsforhold er foreløpig fornøyd med denne løsningen, men den trenger nok litt mer kjærlighet før IntelliJ godtar den. HentRolleMapper og Rolleoversikt finner ikke `tjenestekontrakter` selv om den er en del av build.