### PR TITLE
Testnorge arena/tilleggsstonad malgruppe sjekk

### DIFF
--- a/apps/testnorge-arena/arena-core/src/main/java/no/nav/registre/arena/core/service/VedtakshistorikkService.java
+++ b/apps/testnorge-arena/arena-core/src/main/java/no/nav/registre/arena/core/service/VedtakshistorikkService.java
@@ -82,6 +82,13 @@ public class VedtakshistorikkService {
             vedtakshistorikken.setUngUfoer(fjernAapUngUfoerMedUgyldigeDatoer(vedtakshistorikken.getUngUfoer()));
             oppdaterAapSykepengeerstatningDatoer(vedtakshistorikken.getAap());
 
+            if (vedtakshistorikken.getAlleTilleggVedtak() == null || vedtakshistorikken.getAlleTilleggVedtak().isEmpty()){
+                log.info("Mangler tillegg");
+                continue;
+            }else{
+                log.info("Har tillegg.");
+            }
+
             LocalDate tidligsteDato = datoUtils.finnTidligsteDato(vedtakshistorikken);
             LocalDate tidligsteDatoBarnetillegg = datoUtils.finnTidligeDatoBarnetillegg(vedtakshistorikken.getBarnetillegg());
 
@@ -587,7 +594,7 @@ public class VedtakshistorikkService {
         if (vedtaksliste == null || vedtaksliste.isEmpty()) {
             return false;
         }
-        var fraDato = vedtak.getFraDato();
+        var fraDato = vedtak.getVedtaksperiode().getFom();
 
         if (fraDato == null) {
             return false;

--- a/apps/testnorge-arena/arena-core/src/main/java/no/nav/registre/arena/core/service/VedtakshistorikkService.java
+++ b/apps/testnorge-arena/arena-core/src/main/java/no/nav/registre/arena/core/service/VedtakshistorikkService.java
@@ -10,22 +10,6 @@ import static no.nav.registre.arena.core.service.util.ServiceUtils.MAX_ALDER_UNG
 import static no.nav.registre.arena.core.service.util.ServiceUtils.MIN_ALDER_AAP;
 import static no.nav.registre.arena.core.service.util.ServiceUtils.MIN_ALDER_UNG_UFOER;
 
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
-import no.nav.registre.arena.core.consumer.rs.VedtakshistorikkSyntConsumer;
-import no.nav.registre.arena.core.service.util.ArbeidssoekerUtils;
-import no.nav.registre.arena.core.service.util.DatoUtils;
-import no.nav.registre.arena.core.service.util.IdenterUtils;
-import no.nav.registre.arena.core.service.util.ServiceUtils;
-import no.nav.registre.arena.core.service.util.VedtakUtils;
-import no.nav.registre.testnorge.domain.dto.arena.testnorge.vedtak.NyttVedtak;
-import no.nav.registre.testnorge.domain.dto.arena.testnorge.vedtak.NyttVedtakAap;
-import no.nav.registre.testnorge.domain.dto.arena.testnorge.vedtak.NyttVedtakResponse;
-import no.nav.registre.testnorge.domain.dto.arena.testnorge.vedtak.NyttVedtakTillegg;
-import no.nav.registre.testnorge.domain.dto.arena.testnorge.vedtak.NyttVedtakTiltak;
-import org.springframework.stereotype.Service;
-
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
@@ -34,6 +18,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 import no.nav.registre.arena.core.consumer.rs.RettighetArenaForvalterConsumer;
 import no.nav.registre.arena.core.consumer.rs.request.RettighetAap115Request;
@@ -46,11 +33,25 @@ import no.nav.registre.arena.core.consumer.rs.request.RettighetTiltaksdeltakelse
 import no.nav.registre.arena.core.consumer.rs.request.RettighetTiltakspengerRequest;
 import no.nav.registre.arena.core.consumer.rs.request.RettighetTvungenForvaltningRequest;
 import no.nav.registre.arena.core.consumer.rs.request.RettighetUngUfoerRequest;
+import no.nav.registre.arena.core.consumer.rs.VedtakshistorikkSyntConsumer;
 import no.nav.registre.arena.core.service.exception.VedtakshistorikkException;
+import no.nav.registre.arena.core.service.util.ArbeidssoekerUtils;
+import no.nav.registre.arena.core.service.util.DatoUtils;
+import no.nav.registre.arena.core.service.util.IdenterUtils;
+import no.nav.registre.arena.core.service.util.ServiceUtils;
+import no.nav.registre.arena.core.service.util.VedtakUtils;
+
 import no.nav.registre.testnorge.consumers.hodejegeren.response.KontoinfoResponse;
 import no.nav.registre.testnorge.domain.dto.arena.testnorge.brukere.Deltakerstatuser;
 import no.nav.registre.testnorge.domain.dto.arena.testnorge.historikk.Vedtakshistorikk;
+import no.nav.registre.testnorge.domain.dto.arena.testnorge.vedtak.NyttVedtak;
+import no.nav.registre.testnorge.domain.dto.arena.testnorge.vedtak.NyttVedtakAap;
+import no.nav.registre.testnorge.domain.dto.arena.testnorge.vedtak.NyttVedtakResponse;
+import no.nav.registre.testnorge.domain.dto.arena.testnorge.vedtak.NyttVedtakTillegg;
+import no.nav.registre.testnorge.domain.dto.arena.testnorge.vedtak.NyttVedtakTiltak;
 import no.nav.registre.testnorge.libs.core.util.IdentUtil;
+
+import org.springframework.stereotype.Service;
 
 @Slf4j
 @Service

--- a/apps/testnorge-arena/arena-core/src/main/java/no/nav/registre/arena/core/service/VedtakshistorikkService.java
+++ b/apps/testnorge-arena/arena-core/src/main/java/no/nav/registre/arena/core/service/VedtakshistorikkService.java
@@ -82,13 +82,6 @@ public class VedtakshistorikkService {
             vedtakshistorikken.setUngUfoer(fjernAapUngUfoerMedUgyldigeDatoer(vedtakshistorikken.getUngUfoer()));
             oppdaterAapSykepengeerstatningDatoer(vedtakshistorikken.getAap());
 
-            if (vedtakshistorikken.getAlleTilleggVedtak() == null || vedtakshistorikken.getAlleTilleggVedtak().isEmpty()){
-                log.info("Mangler tillegg");
-                continue;
-            }else{
-                log.info("Har tillegg.");
-            }
-
             LocalDate tidligsteDato = datoUtils.finnTidligsteDato(vedtakshistorikken);
             LocalDate tidligsteDatoBarnetillegg = datoUtils.finnTidligeDatoBarnetillegg(vedtakshistorikken.getBarnetillegg());
 

--- a/apps/testnorge-arena/arena-core/src/main/java/no/nav/registre/arena/core/service/util/DatoUtils.java
+++ b/apps/testnorge-arena/arena-core/src/main/java/no/nav/registre/arena/core/service/util/DatoUtils.java
@@ -1,11 +1,14 @@
 package no.nav.registre.arena.core.service.util;
 
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import no.nav.registre.testnorge.domain.dto.arena.testnorge.aap.gensaksopplysninger.GensakKoder;
 import no.nav.registre.testnorge.domain.dto.arena.testnorge.historikk.Vedtakshistorikk;
 import no.nav.registre.testnorge.domain.dto.arena.testnorge.vedtak.NyttVedtak;
 import no.nav.registre.testnorge.domain.dto.arena.testnorge.vedtak.NyttVedtakAap;
 import no.nav.registre.testnorge.domain.dto.arena.testnorge.vedtak.NyttVedtakTillegg;
 import no.nav.registre.testnorge.domain.dto.arena.testnorge.vedtak.NyttVedtakTiltak;
+import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
@@ -14,6 +17,9 @@ import java.util.List;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 
+@Slf4j
+@Service
+@RequiredArgsConstructor
 public class DatoUtils {
 
     public LocalDate finnTidligsteDato(Vedtakshistorikk vedtakshistorikken) {

--- a/apps/testnorge-arena/arena-core/src/main/java/no/nav/registre/arena/core/service/util/DatoUtils.java
+++ b/apps/testnorge-arena/arena-core/src/main/java/no/nav/registre/arena/core/service/util/DatoUtils.java
@@ -1,0 +1,150 @@
+package no.nav.registre.arena.core.service.util;
+
+import no.nav.registre.testnorge.domain.dto.arena.testnorge.aap.gensaksopplysninger.GensakKoder;
+import no.nav.registre.testnorge.domain.dto.arena.testnorge.historikk.Vedtakshistorikk;
+import no.nav.registre.testnorge.domain.dto.arena.testnorge.vedtak.NyttVedtak;
+import no.nav.registre.testnorge.domain.dto.arena.testnorge.vedtak.NyttVedtakAap;
+import no.nav.registre.testnorge.domain.dto.arena.testnorge.vedtak.NyttVedtakTillegg;
+import no.nav.registre.testnorge.domain.dto.arena.testnorge.vedtak.NyttVedtakTiltak;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Collections;
+import java.util.List;
+
+import static com.google.common.base.Strings.isNullOrEmpty;
+
+public class DatoUtils {
+
+    public LocalDate finnTidligsteDato(Vedtakshistorikk vedtakshistorikken) {
+
+        LocalDate tidligsteDato;
+        var aap = finnUtfyltAap(vedtakshistorikken);
+        var aapType = vedtakshistorikken.getAlleAapVedtak();
+        var tiltak = vedtakshistorikken.getAlleTiltakVedtak();
+        var tillegg = vedtakshistorikken.getAlleTilleggVedtak();
+
+        if (!aap.isEmpty()) {
+            tidligsteDato = finnTidligsteDatoAap(aap);
+        } else if (!aapType.isEmpty()) {
+            tidligsteDato = finnTidligsteDatoAapType(aapType);
+        } else if (!tiltak.isEmpty()) {
+            tidligsteDato = finnTidligsteDatoTiltak(tiltak);
+        } else if (!tillegg.isEmpty()) {
+            tidligsteDato = finnTidligsteDatoTillegg(tillegg);
+        } else {
+            return null;
+        }
+        return tidligsteDato;
+    }
+
+    public LocalDate finnTidligeDatoBarnetillegg(List<NyttVedtakTiltak> barnetillegg) {
+        if (barnetillegg != null && !barnetillegg.isEmpty()) {
+            return finnTidligsteDatoTiltak(barnetillegg);
+        }
+        return null;
+    }
+
+    private LocalDate finnTidligsteDatoAap(List<NyttVedtakAap> vedtak) {
+        var tidligsteDato = LocalDate.now();
+        for (var vedtaket : vedtak) {
+            tidligsteDato = finnTidligsteDatoAvTo(tidligsteDato, vedtaket.getFraDato());
+            var genSaksopplysninger = vedtaket.getGenSaksopplysninger();
+            for (var saksopplysning : genSaksopplysninger) {
+                if (isNullOrEmpty(saksopplysning.getVerdi())) {
+                    continue;
+                }
+                if (GensakKoder.KDATO.equals(saksopplysning.getKode())
+                        || GensakKoder.BTID.equals(saksopplysning.getKode())
+                        || GensakKoder.UFTID.equals(saksopplysning.getKode())
+                        || GensakKoder.YDATO.equals(saksopplysning.getKode())) {
+                    tidligsteDato = finnTidligsteDatoAvTo(tidligsteDato, LocalDate.parse(saksopplysning.getVerdi(), DateTimeFormatter.ofPattern("dd-MM-yyyy")));
+                }
+            }
+        }
+        return tidligsteDato;
+    }
+
+    private LocalDate finnTidligsteDatoAapType(List<NyttVedtakAap> vedtak) {
+        var tidligsteDato = LocalDate.now();
+        for (var vedtaket : vedtak) {
+            tidligsteDato = finnTidligsteDatoAvTo(tidligsteDato, vedtaket.getFraDato());
+        }
+        return tidligsteDato;
+    }
+
+    private LocalDate finnTidligsteDatoTiltak(List<NyttVedtakTiltak> vedtak) {
+        var tidligsteDato = LocalDate.now();
+        for (var vedtaket : vedtak) {
+            tidligsteDato = finnTidligsteDatoAvTo(tidligsteDato, vedtaket.getFraDato());
+        }
+        return tidligsteDato;
+    }
+
+    private LocalDate finnTidligsteDatoTillegg(List<NyttVedtakTillegg> vedtak) {
+        var tidligsteDato = LocalDate.now();
+        for (var vedtaket : vedtak) {
+            tidligsteDato = finnTidligsteDatoAvTo(tidligsteDato, vedtaket.getFraDato());
+            tidligsteDato = finnTidligsteDatoAvTo(tidligsteDato, vedtaket.getVedtaksperiode().getFom());
+        }
+        return tidligsteDato;
+    }
+
+    private LocalDate finnTidligsteDatoAvTo(
+            LocalDate date1,
+            LocalDate date2
+    ) {
+        if (date2 == null) {
+            return date1;
+        }
+        if (date2.isBefore(date1)) {
+            return date2;
+        } else {
+            return date1;
+        }
+    }
+
+    public NyttVedtak finnSenesteVedtak(List<? extends NyttVedtak> vedtak) {
+        var senesteDato = LocalDate.MIN;
+        NyttVedtak senesteVedtak = null;
+        for (var vedtaket : vedtak) {
+            LocalDate vedtakFraDato;
+            if (vedtaket instanceof NyttVedtakTillegg) {
+                vedtakFraDato = ((NyttVedtakTillegg) vedtaket).getVedtaksperiode().getFom();
+            } else {
+                vedtakFraDato = vedtaket.getFraDato();
+            }
+            if (vedtakFraDato != null && senesteDato.isBefore(vedtakFraDato)) {
+                senesteDato = vedtakFraDato;
+                senesteVedtak = vedtaket;
+            }
+        }
+        return senesteVedtak;
+    }
+
+    private List<NyttVedtakAap> finnUtfyltAap(Vedtakshistorikk vedtakshistorikk) {
+        var aap = vedtakshistorikk.getAap();
+
+        if (aap != null && !aap.isEmpty()) {
+            return aap;
+        }
+
+        return Collections.emptyList();
+    }
+
+    public boolean datoErInnenforPeriode(LocalDate vedtakDato, LocalDate periodeStart, LocalDate periodeSlutt) {
+        if (periodeStart == null || vedtakDato == null) {
+            return false;
+        }
+
+        if (periodeSlutt == null) {
+            return periodeStart.isEqual(vedtakDato);
+        } else {
+            if (periodeSlutt.isBefore(vedtakDato.plusDays(1))) {
+                return false;
+            } else {
+                return periodeStart.isBefore(vedtakDato.plusDays(1)) && periodeSlutt.isAfter(vedtakDato);
+            }
+        }
+    }
+}

--- a/apps/testnorge-arena/arena-core/src/main/java/no/nav/registre/arena/core/service/util/VedtakUtils.java
+++ b/apps/testnorge-arena/arena-core/src/main/java/no/nav/registre/arena/core/service/util/VedtakUtils.java
@@ -232,7 +232,7 @@ public class VedtakUtils {
     }
 
     private boolean harOverlappendeVedtak(NyttVedtakTiltak vedtak, List<? extends NyttVedtak> vedtaksliste) {
-        if (vedtaksliste == null || vedtaksliste.isEmpty()){
+        if (vedtaksliste == null || vedtaksliste.isEmpty()) {
             return false;
         }
         var fraDato = vedtak.getFraDato();
@@ -297,7 +297,6 @@ public class VedtakUtils {
 
         }
     }
-
 
     private List<List<NyttVedtakTiltak>> getVedtakSequences(List<NyttVedtakTiltak> vedtak) {
         List<List<NyttVedtakTiltak>> vedtakSequences = new ArrayList<>();

--- a/apps/testnorge-arena/arena-core/src/test/java/no/nav/registre/arena/core/service/VedtakshistorikkServiceTest.java
+++ b/apps/testnorge-arena/arena-core/src/test/java/no/nav/registre/arena/core/service/VedtakshistorikkServiceTest.java
@@ -14,6 +14,7 @@ import static no.nav.registre.arena.core.service.RettighetAapService.ARENA_AAP_U
 import no.nav.registre.arena.core.consumer.rs.VedtakshistorikkSyntConsumer;
 import no.nav.registre.arena.core.service.util.IdenterUtils;
 import no.nav.registre.arena.core.service.util.ArbeidssoekerUtils;
+import no.nav.registre.arena.core.service.util.DatoUtils;
 import no.nav.registre.arena.core.service.util.VedtakUtils;
 import no.nav.registre.testnorge.domain.dto.arena.testnorge.aap.gensaksopplysninger.Saksopplysning;
 import no.nav.registre.testnorge.domain.dto.arena.testnorge.historikk.Vedtakshistorikk;
@@ -33,7 +34,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import no.nav.registre.arena.core.consumer.rs.AapSyntConsumer;
 import no.nav.registre.arena.core.consumer.rs.RettighetArenaForvalterConsumer;
 import no.nav.registre.testnorge.consumers.hodejegeren.response.KontoinfoResponse;
 
@@ -51,6 +51,9 @@ public class VedtakshistorikkServiceTest {
 
     @Mock
     private VedtakUtils vedtakUtils;
+
+    @Mock
+    private DatoUtils datoUtils;
 
     @Mock
     private RettighetArenaForvalterConsumer rettighetArenaForvalterConsumer;
@@ -105,6 +108,7 @@ public class VedtakshistorikkServiceTest {
                 .fritakMeldekort(fritakMeldekortRettigheter)
                 .build();
 
+
         vedtakshistorikkListe = new ArrayList<>((Collections.singletonList(vedtakshistorikk)));
 
         when(identerUtils.getUtvalgteIdenterIAldersgruppe(eq(avspillergruppeId), eq(antallIdenter), anyInt(), anyInt(), eq(miljoe))).thenReturn(identer);
@@ -120,6 +124,7 @@ public class VedtakshistorikkServiceTest {
                         .kontonummer(kontonummer)
                         .build())));
         when(vedtakshistorikkSyntConsumer.syntetiserVedtakshistorikk(antallIdenter)).thenReturn(vedtakshistorikkListe);
+        when(datoUtils.finnTidligsteDato(vedtakshistorikkListe.get(0))).thenReturn(ARENA_AAP_UNG_UFOER_DATE_LIMIT.minusDays(7));
 
         var nyRettighetAapResponse = NyttVedtakResponse.builder()
                 .nyeRettigheterAap(aapRettigheter)
@@ -150,7 +155,7 @@ public class VedtakshistorikkServiceTest {
 
         var response = vedtakshistorikkService.genererVedtakshistorikk(avspillergruppeId, miljoe, antallIdenter);
 
-        verify(identerUtils).getUtvalgteIdenterIAldersgruppe(eq(avspillergruppeId), eq(1), anyInt(), anyInt(), eq(miljoe));
+        verify(identerUtils).getUtvalgteIdenterIAldersgruppe(eq(avspillergruppeId), eq(antallIdenter), anyInt(), anyInt(), eq(miljoe));
         verify(vedtakshistorikkSyntConsumer).syntetiserVedtakshistorikk(antallIdenter);
         verify(rettighetAapService).opprettPersonOgInntektIPopp(anyString(), anyString(), any(NyttVedtakAap.class));
         verify(rettighetArenaForvalterConsumer).opprettRettighet(anyList());

--- a/apps/testnorge-arena/arena-core/src/test/java/no/nav/registre/arena/core/service/util/DatoUtilsTest.java
+++ b/apps/testnorge-arena/arena-core/src/test/java/no/nav/registre/arena/core/service/util/DatoUtilsTest.java
@@ -1,0 +1,34 @@
+package no.nav.registre.arena.core.service.util;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.MockitoJUnitRunner;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DatoUtilsTest {
+
+    @InjectMocks
+    private DatoUtils datoUtils;
+
+    @Test
+    public void shouldCheckIfDatoErInnenforPeriode(){
+        var dagensDato = LocalDate.now();
+        var periodeASlutt = LocalDate.now().plusDays(7);
+        var periodeBSlutt = LocalDate.now().minusDays(7);
+
+        var periodeStartFoer = LocalDate.now().minusDays(7);
+
+        assertThat(datoUtils.datoErInnenforPeriode(dagensDato, dagensDato, periodeASlutt)).isTrue();
+        assertThat(datoUtils.datoErInnenforPeriode(dagensDato, dagensDato, null)).isTrue();
+        assertThat(datoUtils.datoErInnenforPeriode(dagensDato, dagensDato, dagensDato)).isFalse();
+        assertThat(datoUtils.datoErInnenforPeriode(dagensDato, dagensDato, periodeBSlutt)).isFalse();
+        assertThat(datoUtils.datoErInnenforPeriode(dagensDato, periodeStartFoer, dagensDato)).isFalse();
+        assertThat(datoUtils.datoErInnenforPeriode(dagensDato, periodeStartFoer, dagensDato)).isFalse();
+        assertThat(datoUtils.datoErInnenforPeriode(dagensDato, periodeStartFoer, periodeASlutt)).isTrue();
+
+    }
+}

--- a/apps/testnorge-arena/arena-core/src/test/java/no/nav/registre/arena/core/service/util/DatoUtilsTest.java
+++ b/apps/testnorge-arena/arena-core/src/test/java/no/nav/registre/arena/core/service/util/DatoUtilsTest.java
@@ -24,7 +24,6 @@ public class DatoUtilsTest {
 
         assertThat(datoUtils.datoErInnenforPeriode(dagensDato, dagensDato, periodeASlutt)).isTrue();
         assertThat(datoUtils.datoErInnenforPeriode(dagensDato, dagensDato, null)).isTrue();
-        assertThat(datoUtils.datoErInnenforPeriode(dagensDato, dagensDato, dagensDato)).isFalse();
         assertThat(datoUtils.datoErInnenforPeriode(dagensDato, dagensDato, periodeBSlutt)).isFalse();
         assertThat(datoUtils.datoErInnenforPeriode(dagensDato, periodeStartFoer, dagensDato)).isFalse();
         assertThat(datoUtils.datoErInnenforPeriode(dagensDato, periodeStartFoer, dagensDato)).isFalse();

--- a/libs/testnorge-domain/src/main/java/no/nav/registre/testnorge/domain/dto/arena/testnorge/vedtak/NyttVedtakTillegg.java
+++ b/libs/testnorge-domain/src/main/java/no/nav/registre/testnorge/domain/dto/arena/testnorge/vedtak/NyttVedtakTillegg.java
@@ -8,7 +8,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-
+import lombok.Builder;
 import java.util.List;
 
 import no.nav.registre.testnorge.domain.dto.arena.testnorge.tilleggsstoenad.Vedtaksperiode;
@@ -26,6 +26,7 @@ import no.nav.registre.testnorge.domain.dto.arena.testnorge.tilleggsstoenad.tils
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class NyttVedtakTillegg extends NyttVedtak {


### PR DESCRIPTION
Tilleggsstønad-vedtak i historikken med et par spesifikke målgruppekoder må ha et nødvendig gyldig tilknyttet vedtak (perioden for Tilleggsstønad-vedtak er innenfor perioden til tilknyttet vedtak) (for eks tilleggstønad vedtak med målgruppekode MOTILPEN må ha tiltakspenger vedtak). Hvis et gyldig tilknyttet vedtak mangler blir nå tilleggsstønad-vedtakene med den spesifikke målgruppekoden fjernet fra historikken. 

Har også (som vanlig 🤣) ryddet litt i koden sånn at dato relaterte metoder i vedtakshistorikkservice er flyttet til en egen `DatoUtils`-fil og  `genererVedtakshisorikk`-metoden er blitt litt midre kompleks med at den nå bruker en `getMaksimumAlder`-metode.