### PR TITLE
testnorge-arena til dolly namespace

### DIFF
--- a/apps/testnorge-arena/nais.yaml
+++ b/apps/testnorge-arena/nais.yaml
@@ -2,7 +2,7 @@ apiVersion: nais.io/v1alpha1
 kind: Application
 metadata:
   name: testnorge-arena
-  namespace: default
+  namespace: dolly
   labels:
     team: dolly
 spec:


### PR DESCRIPTION
Siden du har så mange aktive brancher på arena ser jeg for meg at det fort kan bli tull hvis jeg begynner å bytte namespace samtidig. Du kan bare merge inn denne når du er klar for det, og så eventuelt merge inn master i de aktive branchene 😄 Jeg har kopiert alle credentials i vault fra default til dolly, så jeg tror det skal fungere så snart denne er deploya.