### PR TITLE
Endret tilbake til helsepersonell url uten tmp

### DIFF
--- a/apps/helsepersonell-api/config.yml
+++ b/apps/helsepersonell-api/config.yml
@@ -43,5 +43,5 @@ spec:
       cpu: 500m
       memory: 5000Mi
   ingresses:
-    - "https://testnorge-helsepersonell-api-tmp.dev.adeo.no"
-    - "https://testnorge-helsepersonell-api-tmp.dev.intern.nav.no"
+    - "https://testnorge-helsepersonell-api.dev.adeo.no"
+    - "https://testnorge-helsepersonell-api.dev.intern.nav.no"


### PR DESCRIPTION
Er vel greit å endre denne tilbake nå, og fikse opp i vault URLene ved merge? 