### PR TITLE
Testnorge arena/parallell kjoring

### DIFF
--- a/apps/orkestratoren/src/main/java/no/nav/registre/orkestratoren/batch/v1/JobController.java
+++ b/apps/orkestratoren/src/main/java/no/nav/registre/orkestratoren/batch/v1/JobController.java
@@ -195,25 +195,25 @@ public class JobController {
     }
 
     /**
-    * Denne metoden oppretter vedtakshistorikk i Arena og registerer brukere med oppfølging (uten vedtak) i Arena.
-     * Metoden kjøres hver time fra 0-5 og fra 18-23.
-    * */
-    @Scheduled(cron = "0 0 0-5,18-23 * * *")
+     * Denne metoden oppretter vedtakshistorikk i Arena og registerer brukere med oppfølging (uten vedtak) i Arena.
+     * Metoden kjøres hver time.
+     */
+    @Scheduled(cron = "0 0 0-23 * * *")
     public void arenaSyntBatch() {
         for (var entry : avspillergruppeIdMedMiljoe.entrySet()) {
-            for (int i = 0; i < arenaAntallNyeIdenter; i++) {
+            for (int i = 0; i < 4; i++) {
                 testnorgeArenaService.opprettArenaVedtakshistorikk(SyntetiserArenaVedtakshistorikkRequest.builder()
                         .avspillergruppeId(entry.getKey())
                         .miljoe(entry.getValue())
-                        .antallVedtakshistorikker(1)
+                        .antallVedtakshistorikker(arenaAntallNyeIdenter)
                         .build());
-            }
 
-            testnorgeArenaService.opprettArbeidssokereIArena(SyntetiserArenaRequest.builder()
-                    .avspillergruppeId(entry.getKey())
-                    .miljoe(entry.getValue())
-                    .antallNyeIdenter(1)
-                    .build(), true);
+                testnorgeArenaService.opprettArbeidssokereIArena(SyntetiserArenaRequest.builder()
+                        .avspillergruppeId(entry.getKey())
+                        .miljoe(entry.getValue())
+                        .antallNyeIdenter(1)
+                        .build(), true);
+            }
         }
     }
 

--- a/apps/testnorge-arena/src/main/java/no/nav/registre/testnorge/arena/consumer/rs/InnsatsArenaForvalterConsumer.java
+++ b/apps/testnorge-arena/src/main/java/no/nav/registre/testnorge/arena/consumer/rs/InnsatsArenaForvalterConsumer.java
@@ -24,8 +24,8 @@ public class InnsatsArenaForvalterConsumer {
     public void endreInnsatsbehov(EndreInnsatsbehovRequest endreRequest) {
         var response = new PostEndreInnsatsbehovCommand(endreRequest, webClient).call();
 
-        if (response.getNyeEndreInnsatsbehovFeilList() != null &&
-                !response.getNyeEndreInnsatsbehovFeilList().isEmpty()) {
+        if (response == null || (response.getNyeEndreInnsatsbehovFeilList() != null &&
+                !response.getNyeEndreInnsatsbehovFeilList().isEmpty())) {
             log.info(String.format("Endring av innsatsbehov for ident %s feilet", endreRequest.getPersonident()));
         }
     }

--- a/apps/testnorge-arena/src/main/java/no/nav/registre/testnorge/arena/consumer/rs/command/HentVedtakshistorikkCommand.java
+++ b/apps/testnorge-arena/src/main/java/no/nav/registre/testnorge/arena/consumer/rs/command/HentVedtakshistorikkCommand.java
@@ -39,10 +39,9 @@ public class HentVedtakshistorikkCommand implements Callable<List<Vedtakshistori
 
     @Override
     public List<Vedtakshistorikk> call() {
-        List<Vedtakshistorikk> response = Collections.emptyList();
         try {
             log.info("Henter vedtakshistorikk.");
-            response = webClient.post()
+            return webClient.post()
                     .uri(builder ->
                             builder.path("/v1/arena/vedtakshistorikk")
                                     .build()
@@ -56,8 +55,8 @@ public class HentVedtakshistorikkCommand implements Callable<List<Vedtakshistori
                     .block();
         } catch (Exception | Error e) {
             log.error("Klarte ikke hente vedtakshistorikk.", e);
+            return Collections.emptyList();
         }
-        return response;
     }
 
 }

--- a/apps/testnorge-arena/src/main/java/no/nav/registre/testnorge/arena/consumer/rs/command/HentVedtakshistorikkCommand.java
+++ b/apps/testnorge-arena/src/main/java/no/nav/registre/testnorge/arena/consumer/rs/command/HentVedtakshistorikkCommand.java
@@ -53,7 +53,7 @@ public class HentVedtakshistorikkCommand implements Callable<List<Vedtakshistori
                     .retrieve()
                     .bodyToMono(RESPONSE_TYPE)
                     .block();
-        } catch (Exception | Error e) {
+        } catch (Exception e) {
             log.error("Klarte ikke hente vedtakshistorikk.", e);
             return Collections.emptyList();
         }

--- a/apps/testnorge-arena/src/main/java/no/nav/registre/testnorge/arena/consumer/rs/command/HentVedtakshistorikkCommand.java
+++ b/apps/testnorge-arena/src/main/java/no/nav/registre/testnorge/arena/consumer/rs/command/HentVedtakshistorikkCommand.java
@@ -54,7 +54,7 @@ public class HentVedtakshistorikkCommand implements Callable<List<Vedtakshistori
                     .retrieve()
                     .bodyToMono(RESPONSE_TYPE)
                     .block();
-        } catch (Exception e) {
+        } catch (Exception | Error e) {
             log.error("Klarte ikke hente vedtakshistorikk.", e);
         }
         return response;

--- a/apps/testnorge-arena/src/main/java/no/nav/registre/testnorge/arena/consumer/rs/command/PostEndreInnsatsbehovCommand.java
+++ b/apps/testnorge-arena/src/main/java/no/nav/registre/testnorge/arena/consumer/rs/command/PostEndreInnsatsbehovCommand.java
@@ -30,9 +30,8 @@ public class PostEndreInnsatsbehovCommand implements Callable<EndreInnsatsbehovR
 
     @Override
     public EndreInnsatsbehovResponse call() {
-        EndreInnsatsbehovResponse response = null;
         try {
-            response = webClient.post()
+            return webClient.post()
                     .uri(builder ->
                             builder.path("/v1/endreInnsatsbehov")
                                     .build()
@@ -46,7 +45,7 @@ public class PostEndreInnsatsbehovCommand implements Callable<EndreInnsatsbehovR
                     .block();
         } catch (Exception e) {
             log.error("Kunne ikke endre innsatsbehov i arena forvalteren.", e);
+            return null;
         }
-        return response;
     }
 }

--- a/apps/testnorge-arena/src/main/java/no/nav/registre/testnorge/arena/consumer/rs/command/PostFinnTiltakCommand.java
+++ b/apps/testnorge-arena/src/main/java/no/nav/registre/testnorge/arena/consumer/rs/command/PostFinnTiltakCommand.java
@@ -35,10 +35,9 @@ public class PostFinnTiltakCommand implements Callable<NyttVedtakResponse> {
 
     @Override
     public NyttVedtakResponse call() {
-        NyttVedtakResponse response = null;
         try {
             log.info("Henter tiltak for ident {} i miljø {}", ident, miljoe);
-            response = webClient.post()
+            return webClient.post()
                     .uri(builder ->
                             builder.path("/v1/finntiltak")
                                     .build()
@@ -52,8 +51,8 @@ public class PostFinnTiltakCommand implements Callable<NyttVedtakResponse> {
                     .block();
         } catch (Exception e) {
             log.error("Klarte ikke hente tiltak for ident {} i miljø {}", ident, miljoe, e);
+            return null;
         }
-        return response;
     }
 }
 

--- a/apps/testnorge-arena/src/main/java/no/nav/registre/testnorge/arena/consumer/rs/command/PostRettighetCommand.java
+++ b/apps/testnorge-arena/src/main/java/no/nav/registre/testnorge/arena/consumer/rs/command/PostRettighetCommand.java
@@ -29,9 +29,8 @@ public class PostRettighetCommand implements Callable<NyttVedtakResponse> {
 
     @Override
     public NyttVedtakResponse call() {
-        NyttVedtakResponse response = null;
         try {
-            response = webClient.post()
+            return webClient.post()
                     .uri(builder ->
                             builder.path(rettighet.getArenaForvalterUrlPath())
                                     .build()
@@ -45,7 +44,7 @@ public class PostRettighetCommand implements Callable<NyttVedtakResponse> {
                     .block();
         } catch (Exception e) {
             log.error("Kunne ikke opprette rettighet i arena-forvalteren.", e);
+            return null;
         }
-        return response;
     }
 }

--- a/apps/testnorge-arena/src/main/java/no/nav/registre/testnorge/arena/consumer/rs/command/PostSyntAapRequestCommand.java
+++ b/apps/testnorge-arena/src/main/java/no/nav/registre/testnorge/arena/consumer/rs/command/PostSyntAapRequestCommand.java
@@ -32,18 +32,17 @@ public class PostSyntAapRequestCommand implements Callable<List<NyttVedtakAap>> 
     private static final ParameterizedTypeReference<List<NyttVedtakAap>> RESPONSE_TYPE = new ParameterizedTypeReference<>() {
     };
 
-    public PostSyntAapRequestCommand(WebClient webClient, List<RettighetSyntRequest> requests, String urlPath ){
+    public PostSyntAapRequestCommand(WebClient webClient, List<RettighetSyntRequest> requests, String urlPath) {
         this.webClient = webClient;
         this.requests = requests;
         this.urlPath = urlPath;
     }
 
     @Override
-    public List<NyttVedtakAap> call(){
-        List<NyttVedtakAap> response = Collections.emptyList();
+    public List<NyttVedtakAap> call() {
         try {
             log.info("Henter syntetiske AAP vedtak.");
-            response = webClient.post()
+            return webClient.post()
                     .uri(builder ->
                             builder.path(urlPath)
                                     .build()
@@ -57,7 +56,7 @@ public class PostSyntAapRequestCommand implements Callable<List<NyttVedtakAap>> 
                     .block();
         } catch (Exception e) {
             log.error("Klarte ikke hente syntetiske AAP vedtak.", e);
+            return Collections.emptyList();
         }
-        return response;
     }
 }

--- a/apps/testnorge-arena/src/main/java/no/nav/registre/testnorge/arena/consumer/rs/command/PostSyntTilleggRequestCommand.java
+++ b/apps/testnorge-arena/src/main/java/no/nav/registre/testnorge/arena/consumer/rs/command/PostSyntTilleggRequestCommand.java
@@ -40,10 +40,9 @@ public class PostSyntTilleggRequestCommand implements Callable<List<NyttVedtakTi
 
     @Override
     public List<NyttVedtakTillegg> call() {
-        List<NyttVedtakTillegg> response = Collections.emptyList();
         try {
             log.info("Henter syntetiske tilleggsstonad vedtak.");
-            response = webClient.post()
+            return webClient.post()
                     .uri(builder ->
                             builder.path(urlPath)
                                     .build()
@@ -57,7 +56,7 @@ public class PostSyntTilleggRequestCommand implements Callable<List<NyttVedtakTi
                     .block();
         } catch (Exception e) {
             log.error("Klarte ikke hente syntetiske tilleggsstonad vedtak.", e);
+            return Collections.emptyList();
         }
-        return response;
     }
 }

--- a/apps/testnorge-arena/src/main/java/no/nav/registre/testnorge/arena/consumer/rs/command/PostSyntTiltakRequestCommand.java
+++ b/apps/testnorge-arena/src/main/java/no/nav/registre/testnorge/arena/consumer/rs/command/PostSyntTiltakRequestCommand.java
@@ -40,10 +40,9 @@ public class PostSyntTiltakRequestCommand implements Callable<List<NyttVedtakTil
 
     @Override
     public List<NyttVedtakTiltak> call() {
-        List<NyttVedtakTiltak> response = Collections.emptyList();
         try {
             log.info("Henter syntetiske tiltak vedtak.");
-            response = webClient.post()
+            return webClient.post()
                     .uri(builder ->
                             builder.path(urlPath)
                                     .build()
@@ -57,7 +56,7 @@ public class PostSyntTiltakRequestCommand implements Callable<List<NyttVedtakTil
                     .block();
         } catch (Exception e) {
             log.error("Klarte ikke hente syntetiske tiltak vedtak.", e);
+            return Collections.emptyList();
         }
-        return response;
     }
 }

--- a/apps/testnorge-arena/src/main/java/no/nav/registre/testnorge/arena/service/VedtakshistorikkService.java
+++ b/apps/testnorge-arena/src/main/java/no/nav/registre/testnorge/arena/service/VedtakshistorikkService.java
@@ -17,7 +17,10 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ForkJoinPool;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -75,8 +78,35 @@ public class VedtakshistorikkService {
             String miljoe,
             int antallNyeIdenter
     ) {
-        var vedtakshistorikk = vedtakshistorikkSyntConsumer.syntetiserVedtakshistorikk(antallNyeIdenter);
         Map<String, List<NyttVedtakResponse>> responses = new HashMap<>();
+        var intStream = IntStream.range(0, antallNyeIdenter).boxed().collect(Collectors.toList());
+        ForkJoinPool forkJoinPool = null;
+        try {
+            forkJoinPool = new ForkJoinPool(10);
+            forkJoinPool.submit(() ->
+                    intStream.parallelStream().forEach(i ->
+                            opprettHistorikkForIdent(avspillergruppeId, miljoe, responses)
+                    )
+            ).get();
+        } catch (InterruptedException e) {
+            log.error("Kunne ikke opprette vedtakshistorikk.", e);
+            Thread.currentThread().interrupt();
+        } catch (ExecutionException e) {
+            log.error("Kunne ikke opprette vedtakshistorikk.", e);
+        } finally {
+            if (forkJoinPool != null) {
+                forkJoinPool.shutdown();
+            }
+        }
+        return responses;
+    }
+
+    private void opprettHistorikkForIdent(
+            Long avspillergruppeId,
+            String miljoe,
+            Map<String, List<NyttVedtakResponse>> responses
+    ) {
+        var vedtakshistorikk = vedtakshistorikkSyntConsumer.syntetiserVedtakshistorikk(1);
         for (var vedtakshistorikken : vedtakshistorikk) {
             vedtakshistorikken.setTilsynFamiliemedlemmer(fjernTilsynFamiliemedlemmerVedtakMedUgyldigeDatoer(vedtakshistorikken.getTilsynFamiliemedlemmer()));
             vedtakshistorikken.setUngUfoer(fjernAapUngUfoerMedUgyldigeDatoer(vedtakshistorikken.getUngUfoer()));
@@ -86,7 +116,7 @@ public class VedtakshistorikkService {
             LocalDate tidligsteDatoBarnetillegg = datoUtils.finnTidligeDatoBarnetillegg(vedtakshistorikken.getBarnetillegg());
 
             if (tidligsteDato == null) {
-                continue;
+                return;
             }
 
             var minimumAlder = Math.toIntExact(ChronoUnit.YEARS.between(tidligsteDato.minusYears(MIN_ALDER_AAP), LocalDate.now()));
@@ -98,7 +128,6 @@ public class VedtakshistorikkService {
                 opprettVedtaksHistorikkResponse(avspillergruppeId, miljoe, responses, vedtakshistorikken, tidligsteDatoBarnetillegg, minimumAlder, maksimumAlder);
             }
         }
-        return responses;
     }
 
     private int getMaksimumAlder(

--- a/apps/testnorge-arena/src/main/java/no/nav/registre/testnorge/arena/service/VedtakshistorikkService.java
+++ b/apps/testnorge-arena/src/main/java/no/nav/registre/testnorge/arena/service/VedtakshistorikkService.java
@@ -80,9 +80,8 @@ public class VedtakshistorikkService {
     ) {
         Map<String, List<NyttVedtakResponse>> responses = new HashMap<>();
         var intStream = IntStream.range(0, antallNyeIdenter).boxed().collect(Collectors.toList());
-        ForkJoinPool forkJoinPool = null;
+        ForkJoinPool forkJoinPool = new ForkJoinPool(10);
         try {
-            forkJoinPool = new ForkJoinPool(10);
             forkJoinPool.submit(() ->
                     intStream.parallelStream().forEach(i ->
                             opprettHistorikkForIdent(avspillergruppeId, miljoe, responses)
@@ -94,9 +93,7 @@ public class VedtakshistorikkService {
         } catch (ExecutionException e) {
             log.error("Kunne ikke opprette vedtakshistorikk.", e);
         } finally {
-            if (forkJoinPool != null) {
-                forkJoinPool.shutdown();
-            }
+            forkJoinPool.shutdown();
         }
         return responses;
     }

--- a/apps/testnorge-arena/src/main/java/no/nav/registre/testnorge/arena/service/VedtakshistorikkService.java
+++ b/apps/testnorge-arena/src/main/java/no/nav/registre/testnorge/arena/service/VedtakshistorikkService.java
@@ -113,7 +113,7 @@ public class VedtakshistorikkService {
             LocalDate tidligsteDatoBarnetillegg = datoUtils.finnTidligeDatoBarnetillegg(vedtakshistorikken.getBarnetillegg());
 
             if (tidligsteDato == null) {
-                return;
+                continue;
             }
 
             var minimumAlder = Math.toIntExact(ChronoUnit.YEARS.between(tidligsteDato.minusYears(MIN_ALDER_AAP), LocalDate.now()));

--- a/apps/testnorge-arena/src/main/java/no/nav/registre/testnorge/arena/service/util/IdenterUtils.java
+++ b/apps/testnorge-arena/src/main/java/no/nav/registre/testnorge/arena/service/util/IdenterUtils.java
@@ -132,7 +132,7 @@ public class IdenterUtils {
 
             for (var ident : identerMedAktoerId.keySet()) {
                 var relasjonsResponse = getRelasjonerTilIdent(ident, miljoe);
-                if (relasjonsResponse != null && inneholderBarnUnder18VedTidspunkt(relasjonsResponse, tidligsteDato)) {
+                if (inneholderBarnUnder18VedTidspunkt(relasjonsResponse, tidligsteDato)) {
                     utvalgteIdenter.add(ident);
                     if (utvalgteIdenter.size() >= antallNyeIdenter) {
                         return utvalgteIdenter;
@@ -144,9 +144,11 @@ public class IdenterUtils {
     }
 
     private boolean inneholderBarnUnder18VedTidspunkt(RelasjonsResponse relasjonsResponse, LocalDate tidligsteDato) {
-        for (var relasjon : relasjonsResponse.getRelasjoner()) {
-            if (erRelasjonEtBarnUnder18VedTidspunkt(relasjon, tidligsteDato)) {
-                return true;
+        if (relasjonsResponse != null && relasjonsResponse.getRelasjoner() != null) {
+            for (var relasjon : relasjonsResponse.getRelasjoner()) {
+                if (erRelasjonEtBarnUnder18VedTidspunkt(relasjon, tidligsteDato)) {
+                    return true;
+                }
             }
         }
         return false;


### PR DESCRIPTION
Har oppdatert generering av vedtakshistorikk i testnorge-arena til å kjøre i parallell for å korte ned tiden det tar å sende inn historikken. Mens jeg testet endringen oppdaget jeg et par småfeil andre steder i koden som jeg også har fisket.

Sist oppdaterte jeg batch-kjøringen for arena i orkestratoren. 