### PR TITLE
Ident registert i popp for 11.5 vedtak

### DIFF
--- a/apps/testnorge-arena/src/main/java/no/nav/registre/testnorge/arena/service/VedtakshistorikkService.java
+++ b/apps/testnorge-arena/src/main/java/no/nav/registre/testnorge/arena/service/VedtakshistorikkService.java
@@ -314,8 +314,11 @@ public class VedtakshistorikkService {
             String miljoe
     ) {
         var aap = historikk.getAap();
+        var aap115 = historikk.getAap115();
         if (aap != null && !aap.isEmpty()) {
             return rettighetAapService.opprettetPersonOgInntektIPopp(personident, miljoe, aap.get(0));
+        } else if (aap115 != null && !aap115.isEmpty()){
+            return rettighetAapService.opprettetPersonOgInntektIPopp(personident, miljoe, aap115.get(0));
         }
         return true;
     }


### PR DESCRIPTION
Har oppdatert sånn at ident som får vedtakshistorikk også blir registert med ident i POPP hvis det er finnes 11.5 vedtak i historikken og ikke bare AAP.