### PR TITLE
Fjernet misvisende logging

### DIFF
--- a/apps/testnorge-arena/src/main/java/no/nav/registre/testnorge/arena/service/util/IdenterUtils.java
+++ b/apps/testnorge-arena/src/main/java/no/nav/registre/testnorge/arena/service/util/IdenterUtils.java
@@ -236,7 +236,6 @@ public class IdenterUtils {
             List<Arbeidsoeker> arbeidsoekere
     ) {
         if (arbeidsoekere.isEmpty()) {
-            log.info("Fant ingen eksisterende identer.");
             return new ArrayList<>();
         }
 


### PR DESCRIPTION
Sjekker ofte om en ident eksisterer i arena sånn at de ikke blir prøvd registrert når de allerede er det. Når da loggene ofte sier "`Fant ingen eksisterende identer`" virker det som noe er feil, når det stemmer at idente(r) ikke eksisterer i arena enda. Fjernet dermed log.info-en. 