### PR TITLE
Oppdatert maxinMemorysize for webclient

### DIFF
--- a/apps/syntrest/src/main/java/no/nav/registre/syntrest/consumer/SyntConsumer.java
+++ b/apps/syntrest/src/main/java/no/nav/registre/syntrest/consumer/SyntConsumer.java
@@ -4,6 +4,7 @@ import io.kubernetes.client.ApiException;
 import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.reactive.function.client.ExchangeStrategies;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import java.net.MalformedURLException;
@@ -42,7 +43,12 @@ public abstract class SyntConsumer {
         this.url = new URL(uri);
 
         var baseUrl = this.url.getProtocol() + "://" + this.url.getAuthority();
-        this.webClient = webClientBuilder.baseUrl(baseUrl).build();
+        this.webClient = webClientBuilder.exchangeStrategies(ExchangeStrategies.builder()
+                .codecs(configurer -> configurer
+                        .defaultCodecs()
+                        .maxInMemorySize(16 * 1024 * 1024))
+                .build())
+                .baseUrl(baseUrl).build();
     }
 
     protected void scheduleIfShutdown() {


### PR DESCRIPTION
Endepunkt for meldekort får 
```
There was an unexpected error (type=Internal Server Error, status=500).
Exceeded limit on max bytes to buffer : 262144
```
når numToGenerate er 45 eller større. 

Som løsning har jeg oppdatert webClient i SyntConsumer. Fant ikke en måte å gjøre det kun for webClient til meldekort siden alle bruker felles webclientBuilder (se SyntConsymerConfig), så hvis noen har en god ide er det bare å si ifra ;)