### PR TITLE
Endret avro plugin

### DIFF
--- a/libs/testnorge-avro-schema/build.gradle
+++ b/libs/testnorge-avro-schema/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'no.nav.registre.testnorge.java-conventions'
-    id 'com.commercehub.gradle.plugin.avro' version '0.21.0'
+    id 'com.github.davidmc24.gradle.plugin.avro' version '1.2.0'
 }
 
 dependencies {


### PR DESCRIPTION
Gammel versjon for avro plugin finnes ikke lenger. Byttet til ny versjon som jeg fikk bygget lokalt. Har ikke testet endringen mer enn det. 