### PR TITLE
Lagt til støtte for aktiveringsdato i brukerregistrering

### DIFF
--- a/apps/testnorge-arena/src/main/java/no/nav/registre/testnorge/arena/service/BrukereService.java
+++ b/apps/testnorge-arena/src/main/java/no/nav/registre/testnorge/arena/service/BrukereService.java
@@ -12,6 +12,7 @@ import no.nav.registre.testnorge.domain.dto.arena.testnorge.vedtak.NyeBrukereRes
 
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -97,6 +98,27 @@ public class BrukereService {
                         .kvalifiseringsgruppe(kvalifiseringsgruppe)
                         .automatiskInnsendingAvMeldekort(true)
                         .oppfolging(oppfolging)
+                        .build())
+                .collect(Collectors.toList());
+
+        return brukereArenaForvalterConsumer.sendTilArenaForvalter(nyeBrukere);
+    }
+
+    public NyeBrukereResponse sendArbeidssoekereTilArenaForvalter(
+            List<String> identer,
+            String miljoe,
+            Kvalifiseringsgrupper kvalifiseringsgruppe,
+            String oppfolging,
+            LocalDate aktiveringsDato
+    ) {
+        var nyeBrukere = identer.stream().map(ident ->
+                NyBruker.builder()
+                        .personident(ident)
+                        .miljoe(miljoe)
+                        .kvalifiseringsgruppe(kvalifiseringsgruppe)
+                        .automatiskInnsendingAvMeldekort(true)
+                        .oppfolging(oppfolging)
+                        .aktiveringsDato(aktiveringsDato)
                         .build())
                 .collect(Collectors.toList());
 

--- a/apps/testnorge-arena/src/main/java/no/nav/registre/testnorge/arena/service/RettighetAapService.java
+++ b/apps/testnorge-arena/src/main/java/no/nav/registre/testnorge/arena/service/RettighetAapService.java
@@ -50,7 +50,7 @@ public class RettighetAapService {
     private final RettighetArenaForvalterConsumer rettighetArenaForvalterConsumer;
     private final ServiceUtils serviceUtils;
     private final IdentService identService;
-    private final ArbeidssoekerService arbeidsoekerUtils;
+    private final ArbeidssoekerService arbeidssoekerService;
     private final DatoUtils datoUtils;
     private final PensjonTestdataFacadeConsumer pensjonTestdataFacadeConsumer;
     private final Random rand;
@@ -78,7 +78,7 @@ public class RettighetAapService {
                 return Collections.emptyMap();
             }
 
-            arbeidsoekerUtils.opprettArbeidssoekerAap(ident, miljoe);
+            arbeidssoekerService.opprettArbeidssoekerAap(ident, miljoe, syntetisertRettighet.getFraDato());
 
             var aap115Rettighet = getAap115RettighetRequest(syntetisertRettighet.getFraDato().minusDays(1), syntetisertRettighet.getTilDato(), ident, miljoe);
             aap115Rettigheter.add(aap115Rettighet);
@@ -126,7 +126,7 @@ public class RettighetAapService {
             datoUtils.setDatoPeriodeVedtakInnenforMaxAntallMaaneder(rettighetRequest.getNyeAap().get(0), SYKEPENGEERSTATNING_MAKS_PERIODE);
         }
 
-        arbeidsoekerUtils.opprettArbeidssoekerAap(ident, miljoe);
+        arbeidssoekerService.opprettArbeidssoekerAap(ident, miljoe, syntetisertRettighet.getFraDato());
 
         return rettighetArenaForvalterConsumer.opprettRettighet(Collections.singletonList(rettighetRequest));
     }
@@ -164,7 +164,7 @@ public class RettighetAapService {
                 return Collections.emptyMap();
             }
 
-            arbeidsoekerUtils.opprettArbeidssoekerAap(utvalgtIdent, miljoe);
+            arbeidssoekerService.opprettArbeidssoekerAap(utvalgtIdent, miljoe, syntetisertRettighet.getFraDato());
 
             syntetisertRettighet.setBegrunnelse(BEGRUNNELSE);
             var rettighetRequest = new RettighetAap115Request(Collections.singletonList(syntetisertRettighet));
@@ -194,7 +194,7 @@ public class RettighetAapService {
         for (var syntetisertRettighet : syntetiserteRettigheter) {
             var utvalgtIdent = utvalgteIdenter.remove(utvalgteIdenter.size() - 1);
 
-            arbeidsoekerUtils.opprettArbeidssoekerAap(utvalgtIdent, miljoe);
+            arbeidssoekerService.opprettArbeidssoekerAap(utvalgtIdent, miljoe, syntetisertRettighet.getFraDato());
 
             syntetisertRettighet.setBegrunnelse(BEGRUNNELSE);
             var rettighetRequest = new RettighetUngUfoerRequest(Collections.singletonList(syntetisertRettighet));
@@ -225,7 +225,7 @@ public class RettighetAapService {
         for (var syntetisertRettighet : syntetiserteRettigheter) {
             var utvalgtIdent = utvalgteIdenter.remove(utvalgteIdenter.size() - 1);
 
-            arbeidsoekerUtils.opprettArbeidssoekerAap(utvalgtIdent, miljoe);
+            arbeidssoekerService.opprettArbeidssoekerAap(utvalgtIdent, miljoe, syntetisertRettighet.getFraDato());
 
             syntetisertRettighet.setBegrunnelse(BEGRUNNELSE);
             syntetisertRettighet.setForvalter(ServiceUtils.buildForvalter(identerMedKontonummer.remove(identerMedKontonummer.size() - 1)));
@@ -260,7 +260,7 @@ public class RettighetAapService {
         for (var syntetisertRettighet : syntetiserteRettigheter) {
             var utvalgtIdent = utvalgteIdenter.remove(utvalgteIdenter.size() - 1);
 
-            arbeidsoekerUtils.opprettArbeidssoekerAap(utvalgtIdent, miljoe);
+            arbeidssoekerService.opprettArbeidssoekerAap(utvalgtIdent, miljoe, syntetisertRettighet.getFraDato());
 
             syntetisertRettighet.setBegrunnelse(BEGRUNNELSE);
             var rettighetRequest = new RettighetFritakMeldekortRequest(Collections.singletonList(syntetisertRettighet));

--- a/apps/testnorge-arena/src/main/java/no/nav/registre/testnorge/arena/service/RettighetTiltakService.java
+++ b/apps/testnorge-arena/src/main/java/no/nav/registre/testnorge/arena/service/RettighetTiltakService.java
@@ -55,7 +55,7 @@ public class RettighetTiltakService {
     private final RettighetArenaForvalterConsumer rettighetArenaForvalterConsumer;
     private final ServiceUtils serviceUtils;
     private final IdentService identService;
-    private final ArbeidssoekerService arbeidsoekerUtils;
+    private final ArbeidssoekerService arbeidssoekerService;
     private final TiltakArenaForvalterConsumer tiltakArenaForvalterConsumer;
     private final Random rand;
 
@@ -460,7 +460,7 @@ public class RettighetTiltakService {
         for (var syntetisertRettighet : syntetiserteRettigheter) {
             var utvalgtIdent = utvalgteIdenter.remove(utvalgteIdenter.size() - 1);
 
-            arbeidsoekerUtils.opprettArbeidssoekerTiltak(utvalgtIdent, miljoe);
+            arbeidssoekerService.opprettArbeidssoekerTiltak(utvalgtIdent, miljoe, syntetisertRettighet.getFraDato());
 
             var rettighetRequest = new RettighetTiltaksaktivitetRequest(Collections.singletonList(syntetisertRettighet));
 

--- a/libs/testnorge-domain/src/main/java/no/nav/registre/testnorge/domain/dto/arena/testnorge/brukere/NyBruker.java
+++ b/libs/testnorge-domain/src/main/java/no/nav/registre/testnorge/domain/dto/arena/testnorge/brukere/NyBruker.java
@@ -6,6 +6,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.time.LocalDate;
+
 @Getter
 @Setter
 @Builder
@@ -19,4 +21,5 @@ public class NyBruker {
     private UtenServicebehov utenServicebehov;
     private Boolean automatiskInnsendingAvMeldekort;
     private String oppfolging;
+    private LocalDate aktiveringsDato;
 }


### PR DESCRIPTION
Registrering av brukere i Arena har fått et nytt felt som heter `aktiveringsDato`. Denne datoen bestemmer dato for 14a-vedtak  som automatisk genereres for ident. Hvis `aktiveringsDato` mangler blir denne satt til dagens dato, som ikke er logisk når første vedtak for ident er tilbake i tid. Har oppdatert koden sånn at `aktiveringsDato` blir nå satt lik fra-datoen til tidligste vedtak i historikken.