### PR TITLE
Oppdatert initialvalues og validering aareg

### DIFF
--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/aareg/form/initialValues.js
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/aareg/form/initialValues.js
@@ -25,7 +25,7 @@ export const initialForenkletOppgjoersordningOrg = {
 		orgnummer: '',
 	},
 	ansettelsesPeriode: {
-		fom: subYears(new Date(), 20),
+		fom: subYears(new Date().setHours(0, 0, 0, 0), 20),
 		tom: null,
 		sluttaarsak: null,
 	},
@@ -40,7 +40,7 @@ export const initialForenkletOppgjoersordningPers = {
 		ident: '',
 	},
 	ansettelsesPeriode: {
-		fom: subYears(new Date(), 20),
+		fom: subYears(new Date().setHours(0, 0, 0, 0), 20),
 		tom: null,
 		sluttaarsak: null,
 	},
@@ -56,7 +56,7 @@ export const initialArbeidsforholdOrg = {
 	},
 	arbeidsforholdID: '',
 	ansettelsesPeriode: {
-		fom: subYears(new Date(), 20),
+		fom: subYears(new Date().setHours(0, 0, 0, 0), 20),
 		tom: null,
 		sluttaarsak: null,
 	},
@@ -78,7 +78,7 @@ export const initialArbeidsforholdPers = {
 	},
 	arbeidsforholdID: '',
 	ansettelsesPeriode: {
-		fom: subYears(new Date(), 20),
+		fom: subYears(new Date().setHours(0, 0, 0, 0), 20),
 		tom: null,
 		sluttaarsak: null,
 	},

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/aareg/form/validation.js
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/aareg/form/validation.js
@@ -113,15 +113,15 @@ const fartoy = Yup.array().of(
 const requiredPeriode = Yup.mixed()
 	.when('$aareg[0].arbeidsforholdstype', {
 		is: 'frilanserOppdragstakerHonorarPersonerMm',
-		then: requiredString,
+		then: requiredDate,
 	})
 	.when('$aareg[0].arbeidsforholdstype', {
 		is: 'maritimtArbeidsforhold',
-		then: requiredString,
+		then: requiredDate,
 	})
 	.when('$aareg[0].arbeidsforholdstype', {
 		is: 'ordinaertArbeidsforhold',
-		then: requiredString,
+		then: requiredDate,
 	})
 	.nullable()
 


### PR DESCRIPTION
Fikset sånn at initial date for ansettelsesstart alltid har 00:00:00 for time. Endret også fom og tom for genererperiode fra string til date. 