### PR TITLE
Dolly frontend/oppdater redirect basert på location

### DIFF
--- a/apps/dolly-frontend/src/main/js/src/components/layout/header/Header.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/layout/header/Header.tsx
@@ -60,7 +60,11 @@ export default ({ brukerProfil, brukerBilde }: Props) => {
 					Dokumentasjon
 				</a>
 				<a
-					href="https://dolly-backend.dev.adeo.no/swagger-ui/index.html?configUrl=/v3/api-docs/swagger-config"
+					href={
+						window.location.hostname.includes('frontend')
+							? 'https://dolly-backend-dev.dev.adeo.no/swagger-ui/index.html?configUrl=/v3/api-docs/swagger-config'
+							: 'https://dolly-backend.dev.adeo.no/swagger-ui/index.html?configUrl=/v3/api-docs/swagger-config'
+					}
 					target="_blank"
 				>
 					API-dok

--- a/apps/dolly-frontend/src/main/js/src/components/ui/appError/AppError.js
+++ b/apps/dolly-frontend/src/main/js/src/components/ui/appError/AppError.js
@@ -48,15 +48,13 @@ export const AppError = ({ error, stackTrace, style }) => (
 			Noe gikk galt under visning av elementet. <br />
 			Dersom refresh av siden ikke fungerer, forsøk å trykke{' '}
 			<b>
-				<a
+				<aß
 					href={
-						window.location.hostname.includes('localhost')
-							? 'http://localhost:3000/oauth2/authorization/aad'
-							: 'https://dolly.ekstern.dev.nav.no/oauth2/authorization/aad'
+						window.location.protocol + '//' + window.location.host + '/oauth2/authorization/aad'
 					}
 				>
 					her
-				</a>
+				</aß>
 			</b>
 			, eller kontakt Team Dolly på slack{' '}
 			<b>

--- a/apps/dolly-frontend/src/main/js/src/components/ui/appError/AppError.js
+++ b/apps/dolly-frontend/src/main/js/src/components/ui/appError/AppError.js
@@ -48,13 +48,13 @@ export const AppError = ({ error, stackTrace, style }) => (
 			Noe gikk galt under visning av elementet. <br />
 			Dersom refresh av siden ikke fungerer, forsøk å trykke{' '}
 			<b>
-				<aß
+				<a
 					href={
 						window.location.protocol + '//' + window.location.host + '/oauth2/authorization/aad'
 					}
 				>
 					her
-				</aß>
+				</a>
 			</b>
 			, eller kontakt Team Dolly på slack{' '}
 			<b>


### PR DESCRIPTION
Har endret "her" knapp til å redirecte til oauth basert på location.
Har endret "API-dok" til å redirecte til dolly-backend-dev for dolly-frontend-dev.