### PR TITLE
Fiks for org.apache.commons.lang3

### DIFF
--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/aareg/util/AaregMergeUtil.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/aareg/util/AaregMergeUtil.java
@@ -16,7 +16,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import static java.util.Objects.nonNull;
-import static net.logstash.logback.encoder.org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 @UtilityClass
 @Slf4j

--- a/apps/testnorge-inntekt/src/main/java/no/nav/registre/inntekt/config/JsonMapperConfig.java
+++ b/apps/testnorge-inntekt/src/main/java/no/nav/registre/inntekt/config/JsonMapperConfig.java
@@ -1,6 +1,6 @@
 package no.nav.registre.inntekt.config;
 
-import static net.logstash.logback.encoder.org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;

--- a/apps/testnorge-skd/build.gradle
+++ b/apps/testnorge-skd/build.gradle
@@ -57,6 +57,7 @@ dependencies {
     implementation 'com.google.guava:guava:31.0.1-jre'
     implementation 'com.jayway.jsonpath:json-path:2.6.0'
     implementation 'org.aspectj:aspectjweaver:1.9.7'
+    implementation 'org.apache.commons:commons-lang3:3.12.0'
     implementation 'io.micrometer:micrometer-registry-prometheus'
 
     implementation 'org.hibernate.validator:hibernate-validator'

--- a/apps/testnorge-skd/src/main/java/no/nav/registre/skd/service/FasteMeldingerService.java
+++ b/apps/testnorge-skd/src/main/java/no/nav/registre/skd/service/FasteMeldingerService.java
@@ -1,6 +1,6 @@
 package no.nav.registre.skd.service;
 
-import static net.logstash.logback.encoder.org.apache.commons.lang3.BooleanUtils.isTrue;
+import static org.apache.commons.lang3.BooleanUtils.isTrue;
 import static no.nav.registre.skd.service.utilities.RedigereSkdmeldingerUtility.opprettStatsborgerendringsmelding;
 import static no.nav.registre.skd.service.utilities.RedigereSkdmeldingerUtility.setObligatoriskeFelt;
 

--- a/apps/udi-stub/src/main/java/no/nav/udistub/provider/web/PersonStatusService.java
+++ b/apps/udi-stub/src/main/java/no/nav/udistub/provider/web/PersonStatusService.java
@@ -20,7 +20,7 @@ import v1.mt_1067_nav.no.udi.MT1067NAVV1Interface;
 import v1.mt_1067_nav.no.udi.PingFault;
 
 import static java.util.Objects.nonNull;
-import static net.logstash.logback.encoder.org.apache.commons.lang3.BooleanUtils.isNotTrue;
+import static org.apache.commons.lang3.BooleanUtils.isNotTrue;
 
 @Service
 @RequiredArgsConstructor


### PR DESCRIPTION
Logback encoder er blitt oppdatert og import av org.apache.commons.lang3 via den funker ikke. Endret til direkte import vis org.apache.commons.lang3 i stedet. 