### PR TITLE
Fjernet gammel helsepersonell-api

### DIFF
--- a/apps/synt-sykemelding-api/src/main/resources/application.yml
+++ b/apps/synt-sykemelding-api/src/main/resources/application.yml
@@ -8,9 +8,6 @@ AAD_ISSUER_URI: https://login.microsoftonline.com/62366534-1ec3-4962-8869-9b5535
 consumers:
   hodejegeren:
     url: https://testnorge-hodejegeren.dev.adeo.no
-  helsepersonell:
-    client_id: af686685-d25a-462a-a0ea-e2a348c457d3
-    url: https://testnorge-helsepersonell-api.dev.adeo.no
   synt-sykemelding:
     url: https://synthdata-elsam-gcp.dev.intern.nav.no
     name: synthdata-elsam-gcp

--- a/apps/synt-sykemelding-api/src/test/resources/application-test.yml
+++ b/apps/synt-sykemelding-api/src/test/resources/application-test.yml
@@ -15,9 +15,6 @@ spring:
 consumers:
   hodejegeren:
     url: http://localhost:${wiremock.server.port}/hodejegeren
-  helsepersonell:
-    client_id: dummy
-    url: http://localhost:${wiremock.server.port}/helsepersonell
   synt-sykemelding:
     url: http://localhost:${wiremock.server.port}/synt
     name: synthdata-elsam-gcp


### PR DESCRIPTION
Synt sykemelding bruker allerede nye testnav-helsepersonell-service, men hadde fremdeles gamle helsepersonell-api i properties.