### PR TITLE
Skjermingsregister innsending av tomt objekt fiks

### DIFF
--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/skjermingsregister/SkjermingsRegisterClient.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/skjermingsregister/SkjermingsRegisterClient.java
@@ -41,7 +41,7 @@ public class SkjermingsRegisterClient implements ClientRegister {
         dollyPersonCache.fetchIfEmpty(dollyPerson);
 
         if ((nonNull(bestilling.getTpsf()) && nonNull(bestilling.getTpsf().getEgenAnsattDatoFom())) ||
-                (nonNull(bestilling.getSkjerming()))) {
+                ((nonNull(bestilling.getSkjerming())) && nonNull(bestilling.getSkjerming().getEgenAnsattDatoFom()))) {
 
             var skjermetFra = nonNull(bestilling.getSkjerming())
                     ? bestilling.getSkjerming().getEgenAnsattDatoFom()

--- a/apps/dolly-frontend/src/main/js/src/components/bestillingsveileder/stegVelger/steg/steg1/paneler/Personinformasjon.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/bestillingsveileder/stegVelger/steg/steg1/paneler/Personinformasjon.tsx
@@ -226,8 +226,7 @@ PersoninformasjonPanel.initialValues = ({ set, setMulti, del, has, opts }) => {
 					'tpsMessaging.egenAnsattDatoTom',
 					'tpsf.egenAnsattDatoFom',
 					'tpsf.egenAnsattDatoTom',
-					'skjerming.egenAnsattDatoFom',
-					'skjerming.egenAnsattDatoTom',
+					'skjerming',
 				])
 			},
 		},


### PR DESCRIPTION
- Fjerner hele skjermingsobjektet dersom skjerming avhukes i Dolly frontend
- Lagt på ekstra sjekk i backend for å filtrere ut tomme skjermingsobjekter