### PR TITLE
Byttet til synt-amelding

### DIFF
--- a/apps/generer-arbeidsforhold-populasjon-service/config.yml
+++ b/apps/generer-arbeidsforhold-populasjon-service/config.yml
@@ -28,8 +28,8 @@ spec:
         - application: oppsummeringsdokument-service
         - application: testnav-generer-organisasjon-populasjon-service
         - application: testnav-organisasjon-service
+        - application: synthdata-amelding
       external:
-        - host: testnav-syntrest-proxy.dev-fss-pub.nais.io
         - host: testnav-hodejegeren-proxy.dev-fss-pub.nais.io
   liveness:
     path: /internal/isAlive

--- a/apps/generer-arbeidsforhold-populasjon-service/src/main/java/no/nav/registre/testnav/genererarbeidsforholdpopulasjonservice/consumer/SyntArbeidsforholdConsumer.java
+++ b/apps/generer-arbeidsforhold-populasjon-service/src/main/java/no/nav/registre/testnav/genererarbeidsforholdpopulasjonservice/consumer/SyntArbeidsforholdConsumer.java
@@ -1,6 +1,7 @@
 package no.nav.registre.testnav.genererarbeidsforholdpopulasjonservice.consumer;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import no.nav.registre.testnav.genererarbeidsforholdpopulasjonservice.consumer.credentials.SyntAmeldingProperties;
 import org.springframework.http.MediaType;
 import org.springframework.http.codec.json.Jackson2JsonDecoder;
 import org.springframework.http.codec.json.Jackson2JsonEncoder;
@@ -13,7 +14,6 @@ import java.util.List;
 
 import no.nav.registre.testnav.genererarbeidsforholdpopulasjonservice.consumer.command.GenererArbeidsforholdHistorikkCommand;
 import no.nav.registre.testnav.genererarbeidsforholdpopulasjonservice.consumer.command.GenererStartArbeidsforholdCommand;
-import no.nav.registre.testnav.genererarbeidsforholdpopulasjonservice.consumer.credentials.SyntrestServiceProperties;
 import no.nav.testnav.libs.dto.syntrest.v1.ArbeidsforholdRequest;
 import no.nav.testnav.libs.dto.syntrest.v1.ArbeidsforholdResponse;
 import no.nav.testnav.libs.securitycore.domain.ServerProperties;
@@ -28,7 +28,7 @@ public class SyntArbeidsforholdConsumer {
 
     public SyntArbeidsforholdConsumer(
             TokenExchange tokenExchange,
-            SyntrestServiceProperties properties,
+            SyntAmeldingProperties properties,
             ObjectMapper objectMapper
     ) {
         this.tokenExchange = tokenExchange;

--- a/apps/generer-arbeidsforhold-populasjon-service/src/main/java/no/nav/registre/testnav/genererarbeidsforholdpopulasjonservice/consumer/command/GenererArbeidsforholdHistorikkCommand.java
+++ b/apps/generer-arbeidsforhold-populasjon-service/src/main/java/no/nav/registre/testnav/genererarbeidsforholdpopulasjonservice/consumer/command/GenererArbeidsforholdHistorikkCommand.java
@@ -35,7 +35,7 @@ public class GenererArbeidsforholdHistorikkCommand implements Callable<Mono<List
         var body = requests.toArray(new ArbeidsforholdRequest[requests.size()]);
         return webClient
                 .post()
-                .uri("/api/v1/generate/amelding/arbeidsforhold/historikk")
+                .uri("/api/v1/arbeidsforhold/historikk")
                 .body(BodyInserters.fromPublisher(Mono.just(body), ArbeidsforholdRequest[].class))
                 .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)

--- a/apps/generer-arbeidsforhold-populasjon-service/src/main/java/no/nav/registre/testnav/genererarbeidsforholdpopulasjonservice/consumer/command/GenererStartArbeidsforholdCommand.java
+++ b/apps/generer-arbeidsforhold-populasjon-service/src/main/java/no/nav/registre/testnav/genererarbeidsforholdpopulasjonservice/consumer/command/GenererStartArbeidsforholdCommand.java
@@ -30,7 +30,6 @@ public class GenererStartArbeidsforholdCommand implements Callable<Mono<List<Arb
     @Value
     private class Request {
         LocalDate startdato;
-        LocalDate sluttdata;
     }
 
     @Override
@@ -38,8 +37,8 @@ public class GenererStartArbeidsforholdCommand implements Callable<Mono<List<Arb
         log.info("Generer nytt arbeidsforhold den {}.", startdate);
         return webClient
                 .post()
-                .uri("/api/v1/generate/amelding/arbeidsforhold/initial")
-                .body(BodyInserters.fromPublisher(Mono.just(new Request(startdate, null)), Request.class))
+                .uri("/api/v1/arbeidsforhold/new")
+                .body(BodyInserters.fromPublisher(Mono.just(new Request(startdate)), Request.class))
                 .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                 .retrieve()

--- a/apps/generer-arbeidsforhold-populasjon-service/src/main/java/no/nav/registre/testnav/genererarbeidsforholdpopulasjonservice/consumer/credentials/SyntAmeldingProperties.java
+++ b/apps/generer-arbeidsforhold-populasjon-service/src/main/java/no/nav/registre/testnav/genererarbeidsforholdpopulasjonservice/consumer/credentials/SyntAmeldingProperties.java
@@ -6,6 +6,6 @@ import org.springframework.context.annotation.Configuration;
 import no.nav.testnav.libs.securitycore.domain.ServerProperties;
 
 @Configuration
-@ConfigurationProperties(prefix = "consumers.syntrest-proxy")
-public class SyntrestServiceProperties extends ServerProperties {
+@ConfigurationProperties(prefix = "consumers.synt-amelding")
+public class SyntAmeldingProperties extends ServerProperties {
 }

--- a/apps/generer-arbeidsforhold-populasjon-service/src/main/resources/application.yml
+++ b/apps/generer-arbeidsforhold-populasjon-service/src/main/resources/application.yml
@@ -17,11 +17,11 @@ spring:
           accepted-audience: dev-gcp:dolly:testnav-generer-arbeidsforhold-populasjon-service
 
 consumers:
-  syntrest-proxy:
-    cluster: dev-fss
+  synt-amelding:
+    url: https://synthdata-amelding.dev.intern.nav.no
+    cluster: dev-gcp
     namespace: dolly
-    name: testnav-syntrest-proxy
-    url: https://testnav-syntrest-proxy.dev-fss-pub.nais.io
+    name: synthdata-amelding
   testnav-hodejegeren-proxy:
     cluster: dev-fss
     namespace: dolly


### PR DESCRIPTION
Har oppdatert  generer-arbeidsforhold-populasjon-service til å bruke synt-amelding direkte i stedet for syntrest-proxy. Glemte å gjøre det før jeg fjernet støtten i syntrest tidligere. 