### PR TITLE
Testnorge-sok/forenkle sok

### DIFF
--- a/.github/workflows/app.person-search-service.yml
+++ b/.github/workflows/app.person-search-service.yml
@@ -27,7 +27,7 @@ jobs:
     name: Deploy
     uses: navikt/testnorge/.github/workflows/common.deploy.yml@master
     needs: build
-    if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/person-search-service/begrense-soekeresultat' }}
+    if: ${{ github.ref == 'refs/heads/master' }}
     with:
       resource: 'apps/person-search-service/config.yml'
       app-name: 'person-search-service'

--- a/.github/workflows/app.person-search-service.yml
+++ b/.github/workflows/app.person-search-service.yml
@@ -27,7 +27,7 @@ jobs:
     name: Deploy
     uses: navikt/testnorge/.github/workflows/common.deploy.yml@master
     needs: build
-    if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/person-search-service/forkorte-soeketid' }}
+    if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/person-search-service/begrense-soekeresultat' }}
     with:
       resource: 'apps/person-search-service/config.yml'
       app-name: 'person-search-service'

--- a/apps/dolly-frontend/src/main/js/src/pages/testnorgePage/TestnorgePage.tsx
+++ b/apps/dolly-frontend/src/main/js/src/pages/testnorgePage/TestnorgePage.tsx
@@ -12,24 +12,18 @@ import { Exception } from 'sass'
 
 export default () => {
 	const [items, setItems] = useState<Person[]>([])
-	const [page, setPage] = useState(1)
-	const [pageSize] = useState(10)
-	const [numberOfItems, setNumberOfItems] = useState<number | null>(null)
 	const [loading, setLoading] = useState(false)
 	const [valgtePersoner, setValgtePersoner] = useState([])
 	const [startedSearch, setStartedSearch] = useState(false)
-	const [randomSeed, setRandomSeed] = useState(Math.random() + '')
 	const [error, setError] = useState(null)
 
-	const search = (searchPage: number, seed: string, values: any) => {
+	const search = (seed: string, values: any) => {
 		setError(null)
 		setStartedSearch(true)
 		setLoading(true)
-		PersonSearch.search(getSearchValues(searchPage, pageSize, seed, values))
+		PersonSearch.search(getSearchValues(seed, values))
 			.then((response) => {
-				setPage(searchPage)
 				setItems(response.items)
-				setNumberOfItems(response.numerOfItems)
 				setLoading(false)
 			})
 			.catch((e: Exception) => {
@@ -40,9 +34,8 @@ export default () => {
 
 	const onSubmit = (values: any) => {
 		const seed = Math.random() + ''
-		search(1, seed, values)
+		search(seed, values)
 		setValgtePersoner([])
-		setRandomSeed(seed)
 	}
 
 	return (
@@ -58,7 +51,8 @@ export default () => {
 				Testnorge er tilgjengelig i PDL.
 				<br />
 				<br />
-				Søket viser kun Testnorge-identer som ikke allerede er importert til en gruppe i Dolly.
+				Søket returnerer maks 100 tilfeldige Testnorge-identer som passer søkekriteriene og som ikke
+				allerede er importert til en gruppe i Dolly.
 			</p>
 
 			<Formik initialValues={initialValues} onSubmit={onSubmit}>
@@ -75,12 +69,6 @@ export default () => {
 										loading={loading}
 										valgtePersoner={valgtePersoner}
 										setValgtePersoner={setValgtePersoner}
-										pageSize={pageSize}
-										page={page}
-										numberOfItems={numberOfItems}
-										onChange={(pageNumber: number) =>
-											search(pageNumber, randomSeed, formikBag.values)
-										}
 									/>
 								)}
 							</>

--- a/apps/dolly-frontend/src/main/js/src/pages/testnorgePage/search/SearchView.tsx
+++ b/apps/dolly-frontend/src/main/js/src/pages/testnorgePage/search/SearchView.tsx
@@ -17,9 +17,6 @@ type Props = {
 	loading: boolean
 	valgtePersoner: string[]
 	setValgtePersoner: (personer: string[]) => void
-	pageing: Pageing
-	numberOfItems?: number
-	onChange?: (page: number) => void
 	importerPersoner: (valgtePersoner: string[]) => void
 }
 
@@ -28,21 +25,7 @@ const SearchView = styled.div`
 	flex-direction: column;
 `
 
-const SearchPagination = styled(Pagination)`
-	display: flex;
-	align-self: center;
-`
-
-export default ({
-	items,
-	loading,
-	valgtePersoner,
-	setValgtePersoner,
-	pageing,
-	numberOfItems,
-	onChange,
-	importerPersoner,
-}: Props) => {
+export default ({ items, loading, valgtePersoner, setValgtePersoner, importerPersoner }: Props) => {
 	if (loading) return <Loading label="Søker..." />
 	if (!items || items.length === 0) {
 		return (
@@ -122,12 +105,7 @@ export default ({
 					person?.kjoenn === 'MANN' ? <ManIconItem /> : <WomanIconItem />
 				}
 				onExpand={(person: Person) => <PersonView person={person} />}
-			/>
-			<SearchPagination
-				currentPage={pageing.page}
-				numberOfItems={numberOfItems || pageing.page * pageing.pageSize}
-				itemsPerPage={pageing.pageSize}
-				onChange={onChange}
+				pagination
 			/>
 			<div className="flexbox--align-center--justify-end">
 				<NavButton

--- a/apps/dolly-frontend/src/main/js/src/pages/testnorgePage/search/SearchViewConnector.tsx
+++ b/apps/dolly-frontend/src/main/js/src/pages/testnorgePage/search/SearchViewConnector.tsx
@@ -3,21 +3,11 @@ import { withRouter } from 'react-router-dom'
 import { push } from 'connected-react-router'
 import SearchView from '~/pages/testnorgePage/search/SearchView'
 
-const getPageing = (pageSize: number, page: number) => {
-	return {
-		pageSize: pageSize,
-		page: page,
-	}
-}
-
 const mapStateToProps = (state: any, ownProps: any) => ({
 	items: ownProps.items,
 	valgtePersoner: ownProps.valgtePersoner,
 	setValgtePersoner: ownProps.setValgtePersoner,
 	loading: ownProps.loading,
-	pageing: getPageing(ownProps.pageSize, ownProps.page),
-	numberOfItems: ownProps.numberOfItems,
-	onChange: ownProps.onChange,
 })
 
 const mapDispatchToProps = (dispatch: any) => ({

--- a/apps/dolly-frontend/src/main/js/src/pages/testnorgePage/utils.ts
+++ b/apps/dolly-frontend/src/main/js/src/pages/testnorgePage/utils.ts
@@ -34,12 +34,7 @@ export const initialValues = {
 	},
 }
 
-export const getSearchValues = (
-	page: number,
-	pageSize: number,
-	randomSeed: string,
-	values: any
-) => {
+export const getSearchValues = (randomSeed: string, values: any) => {
 	let identer = values?.personinformasjon?.identer ? [...values.personinformasjon.identer] : []
 	if (values?.personinformasjon?.ident?.ident) {
 		identer.push(values?.personinformasjon?.ident?.ident)
@@ -47,9 +42,10 @@ export const getSearchValues = (
 	}
 
 	return {
-		page: page,
-		pageSize: pageSize,
+		page: 1,
+		pageSize: 100,
 		randomSeed: randomSeed,
+		terminateAfter: 100,
 		kjoenn: values?.personinformasjon?.diverse?.kjoenn,
 		foedsel: {
 			fom: values?.personinformasjon?.alder?.foedselsdato?.fom,

--- a/apps/person-search-service/src/main/java/no/nav/registre/testnorge/personsearchservice/adapter/PersonSearchAdapter.java
+++ b/apps/person-search-service/src/main/java/no/nav/registre/testnorge/personsearchservice/adapter/PersonSearchAdapter.java
@@ -76,7 +76,7 @@ public class PersonSearchAdapter {
         int page = search.getPage();
         int pageSize = search.getPageSize();
         searchSourceBuilder.from((page - 1) * pageSize);
-        searchSourceBuilder.timeout(new TimeValue(60, TimeUnit.SECONDS));
+        searchSourceBuilder.timeout(new TimeValue(3, TimeUnit.SECONDS));
         searchSourceBuilder.size(pageSize);
         searchSourceBuilder.query(queryBuilder);
         Optional.ofNullable(search.getTerminateAfter())

--- a/apps/person-search-service/src/main/java/no/nav/registre/testnorge/personsearchservice/adapter/PersonSearchAdapter.java
+++ b/apps/person-search-service/src/main/java/no/nav/registre/testnorge/personsearchservice/adapter/PersonSearchAdapter.java
@@ -18,8 +18,6 @@ import org.elasticsearch.index.query.RangeQueryBuilder;
 import org.elasticsearch.index.query.functionscore.RandomScoreFunctionBuilder;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
-import org.elasticsearch.search.sort.ScoreSortBuilder;
-import org.elasticsearch.search.sort.SortOrder;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
@@ -81,7 +79,6 @@ public class PersonSearchAdapter {
         searchSourceBuilder.timeout(new TimeValue(60, TimeUnit.SECONDS));
         searchSourceBuilder.size(pageSize);
         searchSourceBuilder.query(queryBuilder);
-        searchSourceBuilder.sort(new ScoreSortBuilder().order(SortOrder.DESC));
         Optional.ofNullable(search.getTerminateAfter())
                 .ifPresent(searchSourceBuilder::terminateAfter);
 

--- a/apps/person-search-service/src/main/java/no/nav/registre/testnorge/personsearchservice/adapter/PersonSearchAdapter.java
+++ b/apps/person-search-service/src/main/java/no/nav/registre/testnorge/personsearchservice/adapter/PersonSearchAdapter.java
@@ -18,6 +18,8 @@ import org.elasticsearch.index.query.RangeQueryBuilder;
 import org.elasticsearch.index.query.functionscore.RandomScoreFunctionBuilder;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.search.sort.ScoreSortBuilder;
+import org.elasticsearch.search.sort.SortOrder;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
@@ -79,6 +81,7 @@ public class PersonSearchAdapter {
         searchSourceBuilder.timeout(new TimeValue(60, TimeUnit.SECONDS));
         searchSourceBuilder.size(pageSize);
         searchSourceBuilder.query(queryBuilder);
+        searchSourceBuilder.sort(new ScoreSortBuilder().order(SortOrder.DESC));
         Optional.ofNullable(search.getTerminateAfter())
                 .ifPresent(searchSourceBuilder::terminateAfter);
 

--- a/apps/person-search-service/src/main/java/no/nav/registre/testnorge/personsearchservice/adapter/PersonSearchAdapter.java
+++ b/apps/person-search-service/src/main/java/no/nav/registre/testnorge/personsearchservice/adapter/PersonSearchAdapter.java
@@ -110,8 +110,8 @@ public class PersonSearchAdapter {
     private void queryAlder(Short fra, Short til, BoolQueryBuilder queryBuilder) {
         LocalDate now = LocalDate.now();
 
-        LocalDate tom = now.minusYears(fra == null ? 0 : fra).plusMonths(12).minusDays(1);
-        LocalDate fom = til != null ? now.minusYears(til).minusMonths(12) : null;
+        LocalDate tom = fra != null ? now.minusYears(fra).minusMonths(3) : now.minusMonths(3);
+        LocalDate fom = til != null ? now.minusYears(til).minusYears(1) : null;
 
         queryFoedselsdato(fom, tom, queryBuilder);
     }


### PR DESCRIPTION
Har ryddet i Dolly-frontend sånn at søk returnerer maks 100 identer om gangen og man ikke trenger å gjøre et nytt søk for hver paginering da vi henter alle 100 ved søk og DollyTable har en egen paginering som er lettere å bruke.

Har også justert litt i person-search-service. Har satt timeout til 3 sekunder og har justert alder query (etter tips fra Kristen) :) 