### PR TITLE
Begrenset boadresse valg for DNR og BOST

### DIFF
--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/form/partials/adresser/bostedsadresse/Bostedsadresse.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/form/partials/adresser/bostedsadresse/Bostedsadresse.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useContext } from 'react'
 import { Kategori } from '~/components/ui/form/kategori/Kategori'
 import { AvansertForm } from '~/components/fagsystem/pdlf/form/partials/avansert/AvansertForm'
 import { FormikSelect } from '~/components/ui/form/inputs/select/Select'
@@ -20,6 +20,7 @@ import { UkjentBosted } from '~/components/fagsystem/pdlf/form/partials/adresser
 import { VegadresseVelger } from '~/components/fagsystem/pdlf/form/partials/adresser/adressetyper/VegadresseVelger'
 import { MatrikkeladresseVelger } from '~/components/fagsystem/pdlf/form/partials/adresser/adressetyper/MatrikkeladresseVelger'
 import { FormikProps } from 'formik'
+import { BestillingsveilederContext } from '~/components/bestillingsveileder/Bestillingsveileder'
 
 interface BostedsadresseValues {
 	formikBag: FormikProps<{}>
@@ -30,6 +31,14 @@ type Target = {
 }
 
 export const Bostedsadresse = ({ formikBag }: BostedsadresseValues) => {
+	const opts = useContext(BestillingsveilederContext)
+	const getAdresseOptions = () => {
+		if (opts.identtype && opts.identtype !== 'FNR') {
+			return Options('adressetypeUtenlandskBostedsadresse')
+		}
+		return Options('adressetypeBostedsadresse')
+	}
+
 	const handleChangeAdressetype = (target: Target, path: string) => {
 		const adresse = _get(formikBag.values, path)
 		const adresseClone = _cloneDeep(adresse)
@@ -91,7 +100,7 @@ export const Bostedsadresse = ({ formikBag }: BostedsadresseValues) => {
 								<FormikSelect
 									name={`${path}.adressetype`}
 									label="Adressetype"
-									options={Options('adressetypeBostedsadresse')}
+									options={getAdresseOptions()}
 									onChange={(target: Target) => handleChangeAdressetype(target, path)}
 									size="large"
 								/>

--- a/apps/dolly-frontend/src/main/js/src/pages/gruppe/PersonVisning/PersonVisning.js
+++ b/apps/dolly-frontend/src/main/js/src/pages/gruppe/PersonVisning/PersonVisning.js
@@ -28,6 +28,16 @@ import './PersonVisning.less'
 import { PdlPersonMiljoeInfo } from '~/pages/gruppe/PersonVisning/PersonMiljoeinfo/PdlPersonMiljoeinfo'
 import { PdlVisning } from '~/components/fagsystem/pdl/visning/PdlVisning'
 
+const getIdenttype = (ident) => {
+	if (parseInt(ident.charAt(0)) > 3) {
+		return 'DNR'
+	} else if (parseInt(ident.charAt(2)) % 4 >= 2) {
+		return 'BOST'
+	} else {
+		return 'FNR'
+	}
+}
+
 export const PersonVisning = ({
 	fetchDataFraFagsystemer,
 	data,
@@ -55,7 +65,9 @@ export const PersonVisning = ({
 			<div className="person-visning_actions">
 				{!iLaastGruppe && ident.master !== 'PDLF' && (
 					<Button
-						onClick={() => leggTilPaaPerson(data, bestillingsListe, ident.master)}
+						onClick={() =>
+							leggTilPaaPerson(data, bestillingsListe, ident.master, getIdenttype(ident.ident))
+						}
 						kind="add-circle"
 					>
 						LEGG TIL/ENDRE

--- a/apps/dolly-frontend/src/main/js/src/pages/gruppe/PersonVisning/PersonVisningConnector.js
+++ b/apps/dolly-frontend/src/main/js/src/pages/gruppe/PersonVisning/PersonVisningConnector.js
@@ -52,12 +52,13 @@ const mapStateToProps = (state, ownProps) => ({
 const mapDispatchToProps = (dispatch, ownProps) => ({
 	fetchDataFraFagsystemer: () => dispatch(fetchDataFraFagsystemer(ownProps.personId)),
 	slettPerson: () => dispatch(actions.slettPerson(ownProps.personId)),
-	leggTilPaaPerson: (data, bestillinger, master) => {
+	leggTilPaaPerson: (data, bestillinger, master, type) => {
 		return dispatch(
 			push(`/gruppe/${ownProps.match.params.gruppeId}/bestilling/${ownProps.personId}`, {
 				personFoerLeggTil: data,
 				tidligereBestillinger: bestillinger,
 				identMaster: master,
+				identtype: type,
 			})
 		)
 	},

--- a/apps/dolly-frontend/src/main/js/src/service/SelectOptions.tsx
+++ b/apps/dolly-frontend/src/main/js/src/service/SelectOptions.tsx
@@ -121,6 +121,10 @@ const selectOptions: SelectOptions = {
 		{ value: 'UTENLANDSK_ADRESSE', label: 'Utenlandsk adresse' },
 		{ value: 'UKJENT_BOSTED', label: 'Ukjent bosted' },
 	],
+	//DNR og BOST kan kun ha utenlandsk adresse
+	adressetypeUtenlandskBostedsadresse: [
+		{ value: 'UTENLANDSK_ADRESSE', label: 'Utenlandsk adresse' },
+	],
 
 	adressetypeOppholdsadresse: [
 		{ value: 'VEGADRESSE', label: 'Vegadresse' },


### PR DESCRIPTION
Begrenset boadresse muligheter for DNR og BOST sånn at de kun kan ha utenlandsk adresse.

Fikset også at identtype er korrekt for legg til.