### PR TITLE
Ny mapping av bestillingsstatuser

### DIFF
--- a/apps/dolly-frontend/src/main/js/src/components/bestilling/sammendrag/miljoeStatus/MiljoeStatus.js
+++ b/apps/dolly-frontend/src/main/js/src/components/bestilling/sammendrag/miljoeStatus/MiljoeStatus.js
@@ -1,44 +1,67 @@
 import React from 'react'
 import SubOverskrift from '~/components/ui/subOverskrift/SubOverskrift'
-import Formatters from '~/utils/DataFormatter'
 import FagsystemStatus from './fagsystemStatus/FagsystemStatus'
 import ApiFeilmelding from '~/components/ui/apiFeilmelding/ApiFeilmelding'
 import antallIdenterOpprettet from '~/components/bestilling/utils/antallIdenterOpprettet'
 
 const mapStatusrapport = (bestillingstatus) => {
-	const successFirst = (a) => (a.melding ? 1 : -1)
-	return bestillingstatus
-		.reduce((acc, curr) => {
-			return acc.concat(
-				curr.statuser.map((status) => {
-					const feil = {
-						navn: curr.navn,
-						id: curr.id,
-						melding: status.melding !== 'OK' ? status.melding : null,
-					}
+	const sortBestilling = (a, b) => {
+		if (a.navn === b.navn) {
+			return a.miljo > b.miljo ? 1 : -1
+		}
+	}
 
-					if (status.identer) {
-						feil.miljo = null
-						feil.identer = status.identer
-					}
+	const statusListe = []
 
-					if (status.orgnummer) {
-						feil.miljo = null
-						feil.orgnummer = status.orgnummer
-					}
+	bestillingstatus.map((system) => {
+		system.statuser.map((status) => {
+			const systeminfo = {
+				navn: system.navn,
+				id: system.id,
+				melding: status.melding !== 'OK' ? status.melding : null,
+			}
 
-					if (status.detaljert) {
-						const miljoArray = status.detaljert.map((m) => m.miljo).sort()
-						const identArray = status.detaljert[0].identer
-						feil.miljo = miljoArray[0] ? Formatters.arrayToString(miljoArray) : ''
-						feil.identer = identArray
-					}
-
-					return feil
+			if (status.identer) {
+				statusListe.push({
+					...systeminfo,
+					miljo: null,
+					identer: status.identer,
 				})
-			)
-		}, [])
-		.sort(successFirst)
+			}
+
+			if (status.orgnummer) {
+				statusListe.push({
+					...systeminfo,
+					miljo: null,
+					orgnummer: status.orgnummer,
+				})
+			}
+
+			if (status.detaljert) {
+				status.detaljert.map((miljoInfo) => {
+					const statusIndex = statusListe.findIndex((x) => x.id === system.id)
+					if (
+						statusIndex >= 0 &&
+						(status.melding === statusListe[statusIndex].melding ||
+							(status.melding === 'OK' && statusListe[statusIndex].melding === null))
+					) {
+						statusListe[statusIndex].miljo = statusListe[statusIndex].miljo.concat(
+							', ',
+							miljoInfo.miljo.toUpperCase()
+						)
+					} else {
+						statusListe.push({
+							...systeminfo,
+							miljo: miljoInfo.miljo.toUpperCase(),
+							identer: miljoInfo.identer,
+						})
+					}
+				})
+			}
+		})
+	})
+
+	return statusListe.sort(sortBestilling)
 }
 
 export default function MiljoeStatus({ bestilling }) {
@@ -49,10 +72,12 @@ export default function MiljoeStatus({ bestilling }) {
 	return (
 		<div>
 			<SubOverskrift label="Bestillingsstatus" />
-			{bestilling.feil && (
+			{bestilling.systeminfo && (
 				<div className="feilmelding_generell">
 					{!erOrganisasjon && <p>{tekst}</p>}
-					{statusrapport.length < 1 && <ApiFeilmelding feilmelding={bestilling.feil} container />}
+					{statusrapport.length < 1 && (
+						<ApiFeilmelding feilmelding={bestilling.systeminfo} container />
+					)}
 				</div>
 			)}
 			<FagsystemStatus statusrapportListe={statusrapport} />

--- a/apps/dolly-frontend/src/main/js/src/utils/BestillingStatusFormattering.tsx
+++ b/apps/dolly-frontend/src/main/js/src/utils/BestillingStatusFormattering.tsx
@@ -9,6 +9,7 @@ export const fixNamesAndDuplicatesOfStatus = (statusListe: []) => {
 						miljo: string
 						melding: string
 						orgnummer: string
+						identer: Array<string>
 					}) => {
 						if (status.id?.includes('TPS_MESSAGING')) {
 							status.navn = 'Tjenestebasert personsystem (TPS)'
@@ -16,7 +17,9 @@ export const fixNamesAndDuplicatesOfStatus = (statusListe: []) => {
 						return status
 					}
 				)
-				.map((v) => [JSON.stringify([v.id, v.navn, v.miljo]), v])
+				.map((v) => {
+					return [JSON.stringify([v.navn, v.miljo, v.identer]), v]
+				})
 		).values(),
 	]
 }


### PR DESCRIPTION
Endret slik at vi viser alle statuser når f.eks. én ident har feilet i ett miljø.
Slår sammen visning i de tilfellene status fra tpsf og tpsmessaging er 100% lik.
(Pinlig liten PR, men jeg lovet at jeg har jobbet hardt 😅  )
