### PR TITLE
Dolly frontend/oppdatering tps miljoe visning

### DIFF
--- a/apps/dolly-frontend/src/main/js/src/pages/gruppe/PersonListe/PersonListe.js
+++ b/apps/dolly-frontend/src/main/js/src/pages/gruppe/PersonListe/PersonListe.js
@@ -224,6 +224,7 @@ export default function PersonListe({
 						bestillingsIdListe={bruker.ident.bestillingId}
 						gruppeId={bruker.ident.gruppeId}
 						iLaastGruppe={iLaastGruppe}
+						brukertype={brukertype}
 					/>
 				)}
 			/>

--- a/apps/dolly-frontend/src/main/js/src/pages/gruppe/PersonVisning/PersonMiljoeinfo/PersonMiljoeinfo.tsx
+++ b/apps/dolly-frontend/src/main/js/src/pages/gruppe/PersonVisning/PersonMiljoeinfo/PersonMiljoeinfo.tsx
@@ -6,14 +6,17 @@ import SubOverskrift from '~/components/ui/subOverskrift/SubOverskrift'
 import { TpsMessagingApi } from '~/service/Api'
 
 type PersonMiljoeinfoProps = {
+	bankIdBruker: boolean
 	ident: string
 	miljoe: Array<string>
 }
 
-export const PersonMiljoeinfo = ({ ident, miljoe }: PersonMiljoeinfoProps) => {
+export const PersonMiljoeinfo = ({ bankIdBruker, ident }: PersonMiljoeinfoProps) => {
 	if (!ident) return null
 
-	const state = useAsync(async () => TpsMessagingApi.getTpsPersonInfo(ident, miljoe), [])
+	const state = bankIdBruker
+		? useAsync(async () => TpsMessagingApi.getTpsPersonInfo(ident, 'q1'), [])
+		: useAsync(async () => TpsMessagingApi.getTpsPersonInfoAllEnvs(ident), [])
 
 	return (
 		<div>

--- a/apps/dolly-frontend/src/main/js/src/pages/gruppe/PersonVisning/PersonMiljoeinfo/PersonMiljoeinfo.tsx
+++ b/apps/dolly-frontend/src/main/js/src/pages/gruppe/PersonVisning/PersonMiljoeinfo/PersonMiljoeinfo.tsx
@@ -8,7 +8,6 @@ import { TpsMessagingApi } from '~/service/Api'
 type PersonMiljoeinfoProps = {
 	bankIdBruker: boolean
 	ident: string
-	miljoe: Array<string>
 }
 
 export const PersonMiljoeinfo = ({ bankIdBruker, ident }: PersonMiljoeinfoProps) => {

--- a/apps/dolly-frontend/src/main/js/src/pages/gruppe/PersonVisning/PersonMiljoeinfo/PersonMiljoeinfo.tsx
+++ b/apps/dolly-frontend/src/main/js/src/pages/gruppe/PersonVisning/PersonMiljoeinfo/PersonMiljoeinfo.tsx
@@ -14,7 +14,7 @@ export const PersonMiljoeinfo = ({ bankIdBruker, ident }: PersonMiljoeinfoProps)
 	if (!ident) return null
 
 	const state = bankIdBruker
-		? useAsync(async () => TpsMessagingApi.getTpsPersonInfo(ident, 'q1'), [])
+		? useAsync(async () => TpsMessagingApi.getTpsPersonInfo(ident, ['q1']), [])
 		: useAsync(async () => TpsMessagingApi.getTpsPersonInfoAllEnvs(ident), [])
 
 	return (

--- a/apps/dolly-frontend/src/main/js/src/pages/gruppe/PersonVisning/PersonVisning.js
+++ b/apps/dolly-frontend/src/main/js/src/pages/gruppe/PersonVisning/PersonVisning.js
@@ -42,6 +42,7 @@ export const PersonVisning = ({
 	fetchDataFraFagsystemer,
 	data,
 	ident,
+	brukertype,
 	bestilling,
 	bestillingsListe,
 	loading,
@@ -116,7 +117,7 @@ export const PersonVisning = ({
 				loading={loading.udistub}
 			/>
 			<DokarkivVisning ident={ident.ident} />
-			{data.tpsf && <PersonMiljoeinfo ident={ident.ident} miljoe={bestilling?.environments} />}
+			<PersonMiljoeinfo bankIdBruker={brukertype === 'BANKID'} ident={ident.ident} />
 			<PdlPersonMiljoeInfo data={data.pdl} loading={loading.pdl} />
 			<TidligereBestillinger ids={ident.bestillingId} />
 			<BeskrivelseConnector ident={ident} />


### PR DESCRIPTION
Oppdatert tps miljoe visning sånn at info fra alle relevante miljoe blir vist og ikke bare de tilknyttet siste bestilling. Unntaket er hvis man er innlogget med bankid, da vises kun q1.