### PR TITLE
Dolly frontend/utvide org valg

### DIFF
--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/brregstub/form/partials/orgnrToggle.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/brregstub/form/partials/orgnrToggle.tsx
@@ -1,20 +1,21 @@
 import React, { useEffect, useState } from 'react'
 import _get from 'lodash/get'
 import { FormikProps } from 'formik'
-import { ToggleGruppe, ToggleKnapp } from '~/components/ui/toggle/Toggle'
 import { OrganisasjonLoader } from '~/components/organisasjonSelect'
 import { DollySelect } from '~/components/ui/form/inputs/select/Select'
 import { EgneOrganisasjoner } from '~/components/fagsystem/brregstub/form/partials/egneOrganisasjoner'
 import { OrganisasjonTextSelect } from '~/components/fagsystem/brregstub/form/partials/organisasjonTextSelect'
 import { MiljoeApi } from '~/service/Api'
+import {
+	OrganisasjonToogleGruppe,
+	inputValg,
+} from '~/components/organisasjonSelect/OrganisasjonToogleGruppe'
 
 interface OrgnrToggleProps {
 	path: string
 	formikBag: FormikProps<{}>
 	setEnhetsinfo: (org: any, path: string) => {}
 }
-
-const inputValg = { fraEgenListe: 'egen', fraFellesListe: 'felles', skrivSelv: 'skriv' }
 
 export const OrgnrToggle = ({ path, formikBag, setEnhetsinfo }: OrgnrToggleProps) => {
 	const [inputType, setInputType] = useState(inputValg.fraFellesListe)
@@ -47,29 +48,11 @@ export const OrgnrToggle = ({ path, formikBag, setEnhetsinfo }: OrgnrToggleProps
 
 	return (
 		<div className="toggle--wrapper">
-			<ToggleGruppe onChange={handleToggleChange} name={path}>
-				<ToggleKnapp
-					key={inputValg.fraFellesListe}
-					value={inputValg.fraFellesListe}
-					checked={inputType === inputValg.fraFellesListe}
-				>
-					Felles organisasjoner
-				</ToggleKnapp>
-				<ToggleKnapp
-					key={inputValg.fraEgenListe}
-					value={inputValg.fraEgenListe}
-					checked={inputType === inputValg.fraEgenListe}
-				>
-					Egen organisasjon
-				</ToggleKnapp>
-				<ToggleKnapp
-					key={inputValg.skrivSelv}
-					value={inputValg.skrivSelv}
-					checked={inputType === inputValg.skrivSelv}
-				>
-					Skriv inn org.nr.
-				</ToggleKnapp>
-			</ToggleGruppe>
+			<OrganisasjonToogleGruppe
+				path={path}
+				inputType={inputType}
+				handleToggleChange={handleToggleChange}
+			/>
 			{inputType === inputValg.fraFellesListe && (
 				<OrganisasjonLoader
 					render={(data) => (

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/inntektsmelding/form/partials/orgnrToogle.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/inntektsmelding/form/partials/orgnrToogle.tsx
@@ -1,10 +1,13 @@
 import React, { useEffect, useState } from 'react'
 import { FormikProps } from 'formik'
-import { ToggleGruppe, ToggleKnapp } from '~/components/ui/toggle/Toggle'
 import { OrganisasjonMedArbeidsforholdSelect } from '~/components/organisasjonSelect'
 import { FormikSelect } from '~/components/ui/form/inputs/select/Select'
 import { FormikTextInput } from '~/components/ui/form/inputs/textInput/TextInput'
 import { SelectOptionsOppslag } from '~/service/SelectOptionsOppslag'
+import {
+	OrganisasjonToogleGruppe,
+	inputValg,
+} from '~/components/organisasjonSelect/OrganisasjonToogleGruppe'
 
 interface OrgnrToggleProps {
 	path: string
@@ -16,8 +19,6 @@ type Virksomhet = {
 	orgnavn: string
 	orgnummer: string
 }
-
-const inputValg = { fraEgenListe: 'egen', fraFellesListe: 'felles', skrivSelv: 'skriv' }
 
 export const OrgnrToggle = ({ path, formikBag }: OrgnrToggleProps) => {
 	const [inputType, setInputType] = useState(inputValg.fraFellesListe)
@@ -48,29 +49,11 @@ export const OrgnrToggle = ({ path, formikBag }: OrgnrToggleProps) => {
 
 	return (
 		<div className="toggle--wrapper">
-			<ToggleGruppe onChange={handleToggleChange} name={path}>
-				<ToggleKnapp
-					key={inputValg.fraFellesListe}
-					value={inputValg.fraFellesListe}
-					checked={inputType === inputValg.fraFellesListe}
-				>
-					Felles organisasjoner
-				</ToggleKnapp>
-				<ToggleKnapp
-					key={inputValg.fraEgenListe}
-					value={inputValg.fraEgenListe}
-					checked={inputType === inputValg.fraEgenListe}
-				>
-					Egen organisasjon
-				</ToggleKnapp>
-				<ToggleKnapp
-					key={inputValg.skrivSelv}
-					value={inputValg.skrivSelv}
-					checked={inputType === inputValg.skrivSelv}
-				>
-					Skriv inn org.nr.
-				</ToggleKnapp>
-			</ToggleGruppe>
+			<OrganisasjonToogleGruppe
+				path={path}
+				inputType={inputType}
+				handleToggleChange={handleToggleChange}
+			/>
 			{inputType === inputValg.fraFellesListe && (
 				<OrganisasjonMedArbeidsforholdSelect
 					path={path}

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/inntektsmelding/form/partials/orgnrToogle.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/inntektsmelding/form/partials/orgnrToogle.tsx
@@ -88,7 +88,7 @@ export const OrgnrToggle = ({ path, formikBag }: OrgnrToggleProps) => {
 				/>
 			)}
 			{inputType === inputValg.skrivSelv && (
-				<FormikTextInput name={path} label="Arbeidsgiver (orgnr)" size="xlarge" />
+				<FormikTextInput type="number" name={path} label="Arbeidsgiver (orgnr)" size="xlarge" />
 			)}
 		</div>
 	)

--- a/apps/dolly-frontend/src/main/js/src/components/organisasjonSelect/OrganisasjonToogleGruppe.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/organisasjonSelect/OrganisasjonToogleGruppe.tsx
@@ -1,0 +1,42 @@
+import React from 'react'
+import { ToggleGruppe, ToggleKnapp } from '~/components/ui/toggle/Toggle'
+
+interface OrganisasjonToogleGruppeProps {
+	path: string
+	inputType: string
+	handleToggleChange: (event: React.ChangeEvent<any>) => void
+}
+
+export const inputValg = { fraEgenListe: 'egen', fraFellesListe: 'felles', skrivSelv: 'skriv' }
+
+export const OrganisasjonToogleGruppe = ({
+	path,
+	inputType,
+	handleToggleChange,
+}: OrganisasjonToogleGruppeProps) => {
+	return (
+		<ToggleGruppe onChange={handleToggleChange} name={path}>
+			<ToggleKnapp
+				key={inputValg.fraFellesListe}
+				value={inputValg.fraFellesListe}
+				checked={inputType === inputValg.fraFellesListe}
+			>
+				Felles organisasjoner
+			</ToggleKnapp>
+			<ToggleKnapp
+				key={inputValg.fraEgenListe}
+				value={inputValg.fraEgenListe}
+				checked={inputType === inputValg.fraEgenListe}
+			>
+				Egen organisasjon
+			</ToggleKnapp>
+			<ToggleKnapp
+				key={inputValg.skrivSelv}
+				value={inputValg.skrivSelv}
+				checked={inputType === inputValg.skrivSelv}
+			>
+				Skriv inn org.nr.
+			</ToggleKnapp>
+		</ToggleGruppe>
+	)
+}


### PR DESCRIPTION
Oppdatert org valg i A-ordningen sånn at den inkluderer egne organisasjoner.

Lagde også en egen OrganisasjonToogleGruppe komponent for å fjerne duplikat kode.