### PR TITLE
Dolly-frontend : Frigjør/slett knapp for testnorge identer

### DIFF
--- a/apps/dolly-frontend/src/main/js/src/components/ui/button/FrigjoerButton/FrigjoerButton.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/ui/button/FrigjoerButton/FrigjoerButton.tsx
@@ -1,0 +1,49 @@
+import React, { ReactChildren } from 'react'
+import NavButton from '~/components/ui/button/NavButton/NavButton'
+import useBoolean from '~/utils/hooks/useBoolean'
+import DollyModal from '~/components/ui/modal/DollyModal'
+import Button from '~/components/ui/button/Button'
+import Icon from '~/components/ui/icon/Icon'
+import Loading from '~/components/ui/loading/Loading'
+
+import './FrigjoerModal.less'
+
+type Props = {
+	action: Function
+	loading: boolean
+	children: ReactChildren
+}
+
+export const FrigjoerButton = ({ action, loading, children }: Props) => {
+	if (loading) return <Loading label="frigjører..." />
+	const [modalIsOpen, openModal, closeModal] = useBoolean(false)
+
+	return (
+		<React.Fragment>
+			<Button onClick={openModal} kind="trashcan">
+				FRIGJØR/SLETT
+			</Button>
+			<DollyModal isOpen={modalIsOpen} closeModal={closeModal} width="40%" overflow="auto">
+				<div className="frigjoerModal">
+					<div className="frigjoerModal frigjoerModal-content">
+						<Icon size={50} kind="report-problem-circle" />
+						<h1>FRIGJØR/SLETT</h1>
+						<h4>{children}</h4>
+					</div>
+					<div className="frigjoerModal-actions">
+						<NavButton onClick={closeModal}>NEI</NavButton>
+						<NavButton
+							onClick={() => {
+								closeModal()
+								return action()
+							}}
+							type="hoved"
+						>
+							JA, JEG ER SIKKER
+						</NavButton>
+					</div>
+				</div>
+			</DollyModal>
+		</React.Fragment>
+	)
+}

--- a/apps/dolly-frontend/src/main/js/src/components/ui/button/FrigjoerButton/FrigjoerModal.less
+++ b/apps/dolly-frontend/src/main/js/src/components/ui/button/FrigjoerButton/FrigjoerModal.less
@@ -1,0 +1,23 @@
+@import (reference) '~lessVars';
+
+.frigjoerModal {
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  text-align: center;
+  &-content {
+    border-bottom: 1px solid @color-bg-divider;
+    margin-bottom: 20px;
+
+    h1 {
+      border: none;
+      margin: 10px 0 0;
+    }
+  }
+  &-actions {
+    padding: 20px 0 0;
+    button {
+      margin: 0 10px;
+    }
+  }
+}

--- a/apps/dolly-frontend/src/main/js/src/pages/gruppe/PersonVisning/PersonVisning.js
+++ b/apps/dolly-frontend/src/main/js/src/pages/gruppe/PersonVisning/PersonVisning.js
@@ -28,6 +28,7 @@ import { PdlPersonMiljoeInfo } from '~/pages/gruppe/PersonVisning/PersonMiljoein
 import { PdlVisning } from '~/components/fagsystem/pdl/visning/PdlVisning'
 import { ErrorBoundary } from '~/components/ui/appError/ErrorBoundary'
 import { DollyApi } from '~/service/Api'
+import { FrigjoerButton } from '~/components/ui/button/FrigjoerButton/FrigjoerButton'
 
 const getIdenttype = (ident) => {
 	if (parseInt(ident.charAt(0)) > 3) {
@@ -83,10 +84,16 @@ export const PersonVisning = ({
 						</Button>
 					)}
 					<BestillingSammendragModal bestilling={bestilling} />
-					{!iLaastGruppe && (
+					{!iLaastGruppe && ident.master !== 'PDL' && (
 						<SlettButton action={slettPerson} loading={loading.slettPerson}>
 							Er du sikker på at du vil slette denne personen?
 						</SlettButton>
+					)}
+					{!iLaastGruppe && ident.master === 'PDL' && (
+						<FrigjoerButton action={slettPerson} loading={loading.slettPerson}>
+							Er du sikker på at du vil frigjøre denne personen? All ekstra informasjon lagt til på
+							personen via Dolly vil bli slettet og personen vil bli frigjort fra gruppen.
+						</FrigjoerButton>
 					)}
 				</div>
 				{ident.master !== 'PDL' && (


### PR DESCRIPTION
Har endret "SLETT"-knappen for testnorge-identer til en "FRIGJØR/SLETT" knapp i stedet. Har også lagt til info om hva dette innebærer i modal-teksten.