### PR TITLE
Dolly frontend/popp visning oppdatering

### DIFF
--- a/apps/dolly-frontend/src/main/js/src/components/bestilling/sammendrag/kriterier/BestillingKriterieMapper.js
+++ b/apps/dolly-frontend/src/main/js/src/components/bestilling/sammendrag/kriterier/BestillingKriterieMapper.js
@@ -1084,7 +1084,7 @@ export function mapBestillingData(bestillingData, bestillingsinformasjon) {
 
 	if (inntektStubKriterier) {
 		const inntektStub = {
-			header: 'A-ordningen (Inntektskomponenten)',
+			header: 'A-ordningen (Inntektstub)',
 			// items: [
 			// 	obj('Prosentøkning per år', inntektStubKriterier.prosentOekningPerAaar)
 			// ],

--- a/apps/dolly-frontend/src/main/js/src/components/bestillingsveileder/stegVelger/steg/steg1/paneler/ArbeidInntekt.js
+++ b/apps/dolly-frontend/src/main/js/src/components/bestillingsveileder/stegVelger/steg/steg1/paneler/ArbeidInntekt.js
@@ -8,7 +8,7 @@ export const ArbeidInntektPanel = ({ stateModifier, testnorgeIdent }) => {
 
 	const infoTekst =
 		'Arbeidsforhold: \nDataene her blir lagt til AAREG. \n\nInntekt: \nSkatte- og inntektsgrunnlag. Inntektene blir lagt i Sigrun-stub.' +
-		'\n\nPensjonsgivende inntekt: \nInntektene blir lagt til i POPP-register. \n\nInntektskomponenten: \nInformasjonen blir lagt i Inntekt-stub.'
+		'\n\nPensjonsgivende inntekt: \nInntektene blir lagt til i POPP-register. \n\nInntektstub: \nInformasjonen blir lagt i Inntekt-stub.'
 
 	return (
 		<Panel
@@ -28,7 +28,7 @@ export const ArbeidInntektPanel = ({ stateModifier, testnorgeIdent }) => {
 			<AttributtKategori title="Pensjonsgivende inntekt (POPP)">
 				<Attributt attr={sm.attrs.pensjonforvalter} />
 			</AttributtKategori>
-			<AttributtKategori title="A-ordningen (Inntektsstub)">
+			<AttributtKategori title="A-ordningen (Inntektstub)">
 				<Attributt attr={sm.attrs.inntektstub} />
 			</AttributtKategori>
 			<AttributtKategori title="Inntektsmelding (fra Altinn)">

--- a/apps/dolly-frontend/src/main/js/src/components/bestillingsveileder/stegVelger/steg/steg1/paneler/ArbeidInntekt.js
+++ b/apps/dolly-frontend/src/main/js/src/components/bestillingsveileder/stegVelger/steg/steg1/paneler/ArbeidInntekt.js
@@ -106,7 +106,7 @@ ArbeidInntektPanel.initialValues = ({ set, del, has }) => ({
 		checked: has('pensjonforvalter'),
 		add: () =>
 			set('pensjonforvalter.inntekt', {
-				fomAar: new Date().getFullYear() - 1,
+				fomAar: new Date().getFullYear() - 10,
 				tomAar: null,
 				belop: '',
 				redusertMedGrunnbelop: true,

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/inntektstub/form/Form.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/inntektstub/form/Form.tsx
@@ -42,7 +42,7 @@ export const InntektstubForm = ({ formikBag }: InntektstubFormProps) => (
 	//@ts-ignore
 	<Vis attributt={inntektstubAttributt}>
 		<Panel
-			heading="A-ordningen (Inntektskomponenten)"
+			heading="A-ordningen (Inntektstub)"
 			hasErrors={panelError(formikBag, inntektstubAttributt)}
 			iconType="inntektstub"
 			//@ts-ignore

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/inntektstub/visning/Visning.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/inntektstub/visning/Visning.tsx
@@ -41,7 +41,7 @@ export const InntektstubVisning = ({ liste, loading }: InntekstubVisning) => {
 
 	return (
 		<div>
-			<SubOverskrift label="A-ordningen (Inntektskomponenten)" iconKind="inntektstub" />
+			<SubOverskrift label="A-ordningen (Inntektsstub)" iconKind="inntektstub" />
 			<ErrorBoundary>
 				<DollyFieldArray
 					header="Inntektsinformasjon"

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/inntektstub/visning/Visning.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/inntektstub/visning/Visning.tsx
@@ -41,7 +41,7 @@ export const InntektstubVisning = ({ liste, loading }: InntekstubVisning) => {
 
 	return (
 		<div>
-			<SubOverskrift label="A-ordningen (Inntektsstub)" iconKind="inntektstub" />
+			<SubOverskrift label="A-ordningen (Inntektstub)" iconKind="inntektstub" />
 			<ErrorBoundary>
 				<DollyFieldArray
 					header="Inntektsinformasjon"

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/pensjon/visning/PensjonVisning.js
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/pensjon/visning/PensjonVisning.js
@@ -4,6 +4,7 @@ import { TitleValue } from '~/components/ui/titleValue/TitleValue'
 import Loading from '~/components/ui/loading/Loading'
 import { DollyFieldArray } from '~/components/ui/form/fieldArray/DollyFieldArray'
 import { ErrorBoundary } from '~/components/ui/appError/ErrorBoundary'
+import Panel from '~/components/ui/panel/Panel'
 
 export const PensjonVisning = ({ data, loading }) => {
 	if (loading) return <Loading label="Laster pensjonforvalter-data" />
@@ -12,14 +13,18 @@ export const PensjonVisning = ({ data, loading }) => {
 	return (
 		<ErrorBoundary>
 			<SubOverskrift label="Pensjonsgivende inntekt (POPP)" iconKind="pensjon" />
-			<DollyFieldArray data={data.inntekter} nested>
-				{(inntekt, idx) => (
-					<div className="person-visning_content" key={idx}>
-						<TitleValue title="Inntektsår" value={inntekt.inntektAar} />
-						<TitleValue title="Beløp" value={inntekt.belop} />
-					</div>
-				)}
-			</DollyFieldArray>
+
+			<Panel heading="Pensjonsgivende inntekter">
+				{' '}
+				<DollyFieldArray data={data.inntekter} nested>
+					{(inntekt, idx) => (
+						<div className="person-visning_content" key={idx}>
+							<TitleValue title="Inntektsår" value={inntekt.inntektAar} />
+							<TitleValue title="Beløp" value={inntekt.belop} />
+						</div>
+					)}
+				</DollyFieldArray>
+			</Panel>
 		</ErrorBoundary>
 	)
 }

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/pensjon/visning/PensjonVisning.js
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/pensjon/visning/PensjonVisning.js
@@ -8,13 +8,17 @@ import Panel from '~/components/ui/panel/Panel'
 
 export const PensjonVisning = ({ data, loading }) => {
 	if (loading) return <Loading label="Laster pensjonforvalter-data" />
-	if (!data || data.length === 0) return false
+	if (!data || !data.inntekter || data.inntekter.length === 0) return false
+
+	const inntektsaar = data.inntekter.map((inntekt) => inntekt.inntektAar)
+	const foerste = Math.min(...inntektsaar)
+	const siste = Math.max(...inntektsaar)
 
 	return (
 		<ErrorBoundary>
 			<SubOverskrift label="Pensjonsgivende inntekt (POPP)" iconKind="pensjon" />
 
-			<Panel heading="Pensjonsgivende inntekter">
+			<Panel heading={`Pensjonsgivende inntekter (${foerste} - ${siste})`}>
 				{' '}
 				<DollyFieldArray data={data.inntekter} nested>
 					{(inntekt, idx) => (

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/pensjon/visning/PensjonVisning.js
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/pensjon/visning/PensjonVisning.js
@@ -8,7 +8,7 @@ import Panel from '~/components/ui/panel/Panel'
 
 export const PensjonVisning = ({ data, loading }) => {
 	if (loading) return <Loading label="Laster pensjonforvalter-data" />
-	if (!data || !data.inntekter || data.inntekter.length === 0) return false
+	if (!data?.inntekter || data.inntekter.length === 0) return false
 
 	const inntektsaar = data.inntekter.map((inntekt) => inntekt.inntektAar)
 	const foerste = Math.min(...inntektsaar)

--- a/apps/dolly-frontend/src/main/js/src/components/ui/brukerAlert/AlertInntektskomponentenRequired.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/ui/brukerAlert/AlertInntektskomponentenRequired.tsx
@@ -5,8 +5,8 @@ export const AlertInntektskomponentenRequired = ({ vedtak }: { vedtak: string })
 	return (
 		<AlertStripeAdvarsel style={{ marginBottom: '20px' }}>
 			Personen må ha gyldig inntekt i A-ordningen for å kunne sette {vedtak}. Det kan du legge til
-			ved å gå tilbake til forrige side og huke av for A-ordningen (Inntektskomponenten) under
-			Arbeid og inntekt. For lettere utfylling anbefales bruk av forenklet versjon.
+			ved å gå tilbake til forrige side og huke av for A-ordningen (Inntektstub) under Arbeid og
+			inntekt. For lettere utfylling anbefales bruk av forenklet versjon.
 		</AlertStripeAdvarsel>
 	)
 }


### PR DESCRIPTION
Forslag til ny visning av Pensjonsinntekter:
<img width="909" alt="Skjermbilde 2022-04-11 kl  13 32 13" src="https://user-images.githubusercontent.com/58416744/162731019-11b3dea8-ecf7-440a-9028-e0e4781feb40.png">
<img width="909" alt="Skjermbilde 2022-04-11 kl  13 33 11" src="https://user-images.githubusercontent.com/58416744/162731130-d353ead3-63a4-44c5-90e0-328b52ee487c.png">


Har også endet "Inntektskomponenten" til "Inntekstub"
