### PR TITLE
Orkestratoren/pause batch kjoringer

### DIFF
--- a/apps/orkestratoren/build.gradle
+++ b/apps/orkestratoren/build.gradle
@@ -11,7 +11,7 @@ sonarqube {
         property "sonar.sourceEncoding", "UTF-8"
         property "sonar.projectKey", "orkestratoren"
         property "sonar.projectName", "orkestratoren"
-        property "sonar.organization", "navit"
+        property "sonar.organization", "navikt"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.project.monorepo.enabled", true
         property "sonar.login", System.getenv("SONAR_TOKEN")

--- a/apps/orkestratoren/src/main/java/no/nav/registre/orkestratoren/batch/v1/JobController.java
+++ b/apps/orkestratoren/src/main/java/no/nav/registre/orkestratoren/batch/v1/JobController.java
@@ -112,18 +112,20 @@ public class JobController {
 
     @Scheduled(cron = "0 0 0 * * *")
     public void tpsSyntBatch() {
-        for (var entry : avspillergruppeIdMedMiljoe.entrySet()) {
-            try {
-                testnorgeSkdService.genererSkdmeldinger(entry.getKey(), entry.getValue(), antallSkdmeldingerPerEndringskode);
-            } catch (HttpStatusCodeException e) {
-                log.warn(e.getResponseBodyAsString(), e);
-            }
-        }
+        log.info("Innsending midlertidig stanset.");
+//        for (var entry : avspillergruppeIdMedMiljoe.entrySet()) {
+//            try {
+//                testnorgeSkdService.genererSkdmeldinger(entry.getKey(), entry.getValue(), antallSkdmeldingerPerEndringskode);
+//            } catch (HttpStatusCodeException e) {
+//                log.warn(e.getResponseBodyAsString(), e);
+//            }
+//        }
     }
 
     @Scheduled(cron = "0 0 0 * * *")
     public void navSyntBatch() {
         log.info("Nav-endringsmeldinger batch midlertidig stanset.");
+        //Feil i innsending av nav-endringsmeldinger må fikses før denne eventuelt kan startes igjen.
 //        for (var entry : avspillergruppeIdMedMiljoe.entrySet()) {
 //            var syntetiserNavmeldingerRequest = SyntetiserNavmeldingerRequest.builder()
 //                    .avspillergruppeId(entry.getKey())
@@ -136,63 +138,70 @@ public class JobController {
 
     @Scheduled(cron = "0 0 1 1 * *")
     public void inntektSyntBatch() {
-        for (var entry : avspillergruppeIdMedMiljoe.entrySet()) {
-            var request = new SyntetiserInntektsmeldingRequest(entry.getKey(), entry.getValue());
-            var feiledeInntektsmeldinger = testnorgeInntektService.genererInntektsmeldinger(request);
-            log.info("Inntekt-synt.-batch har matet Inntektstub med meldinger. Meldinger som feilet: {}.", feiledeInntektsmeldinger.keySet().toString());
-        }
+        log.info("Innsending midlertidig stanset.");
+//        for (var entry : avspillergruppeIdMedMiljoe.entrySet()) {
+//            var request = new SyntetiserInntektsmeldingRequest(entry.getKey(), entry.getValue());
+//            var feiledeInntektsmeldinger = testnorgeInntektService.genererInntektsmeldinger(request);
+//            log.info("Inntekt-synt.-batch har matet Inntektstub med meldinger. Meldinger som feilet: {}.", feiledeInntektsmeldinger.keySet().toString());
+//        }
     }
 
     @Scheduled(cron = "0 0 1 1 5 *")
     public void poppSyntBatch() {
-        for (var entry : avspillergruppeIdMedMiljoe.entrySet()) {
-            var syntetiserPoppRequest = new SyntetiserPoppRequest(entry.getKey(), entry.getValue(), poppbatchAntallNyeIdenter);
-            var testdataEier = "synt_test";
-            testnorgeSigrunService.genererSkattegrunnlag(syntetiserPoppRequest, testdataEier);
-        }
+        log.info("Innsending midlertidig stanset.");
+//        for (var entry : avspillergruppeIdMedMiljoe.entrySet()) {
+//            var syntetiserPoppRequest = new SyntetiserPoppRequest(entry.getKey(), entry.getValue(), poppbatchAntallNyeIdenter);
+//            var testdataEier = "synt_test";
+//            testnorgeSigrunService.genererSkattegrunnlag(syntetiserPoppRequest, testdataEier);
+//        }
     }
 
     @Scheduled(cron = "0 0 1 1 * *")
     public void aaregSyntBatch() {
-        for (var entry : avspillergruppeIdMedMiljoe.entrySet()) {
-            var syntetiserAaregRequest = new SyntetiserAaregRequest(entry.getKey(), entry.getValue(), aaregbatchAntallNyeIdenter);
-            testnorgeAaregService.genererArbeidsforholdsmeldinger(syntetiserAaregRequest, true);
-        }
+        log.info("Innsending midlertidig stanset.");
+//        for (var entry : avspillergruppeIdMedMiljoe.entrySet()) {
+//            var syntetiserAaregRequest = new SyntetiserAaregRequest(entry.getKey(), entry.getValue(), aaregbatchAntallNyeIdenter);
+//            testnorgeAaregService.genererArbeidsforholdsmeldinger(syntetiserAaregRequest, true);
+//        }
     }
 
     @Scheduled(cron = "0 0 0 * * *")
     public void instSyntBatch() {
-        for (var entry : avspillergruppeIdMedMiljoe.entrySet()) {
-            var syntetiserInstRequest = new SyntetiserInstRequest(entry.getKey(), entry.getValue(), instbatchAntallNyeIdenter);
-            testnorgeInstService.genererInstitusjonsforhold(syntetiserInstRequest);
-        }
+        log.info("Innsending midlertidig stanset.");
+//        for (var entry : avspillergruppeIdMedMiljoe.entrySet()) {
+//            var syntetiserInstRequest = new SyntetiserInstRequest(entry.getKey(), entry.getValue(), instbatchAntallNyeIdenter);
+//            testnorgeInstService.genererInstitusjonsforhold(syntetiserInstRequest);
+//        }
     }
 
     @Scheduled(cron = "0 0 0 * * *")
     public void bisysSyntBatch() {
-        for (var entry : avspillergruppeIdMedMiljoe.entrySet()) {
-            var syntetiserBisysRequest = new SyntetiserBisysRequest(entry.getKey(), entry.getValue(), bisysbatchAntallNyeIdenter);
-            testnorgeBisysService.genererBistandsmeldinger(syntetiserBisysRequest);
-        }
+        log.info("Innsending midlertidig stanset.");
+//        for (var entry : avspillergruppeIdMedMiljoe.entrySet()) {
+//            var syntetiserBisysRequest = new SyntetiserBisysRequest(entry.getKey(), entry.getValue(), bisysbatchAntallNyeIdenter);
+//            testnorgeBisysService.genererBistandsmeldinger(syntetiserBisysRequest);
+//        }
     }
 
     @Scheduled(cron = "0 0 0 1 5 *")
     public void tpSyntBatch() {
-        for (var entry : avspillergruppeIdMedMiljoe.entrySet()) {
-            var request = new SyntetiserTpRequest(entry.getKey(), entry.getValue(), tpAntallPersoner);
-            var entity = testnorgeTpService.genererTp(request);
-            if (!entity.getStatusCode().is2xxSuccessful()) {
-                log.error("Klarte ikke å fullføre syntetisering i TP batch kjøring");
-            }
-        }
+        log.info("Innsending midlertidig stanset.");
+//        for (var entry : avspillergruppeIdMedMiljoe.entrySet()) {
+//            var request = new SyntetiserTpRequest(entry.getKey(), entry.getValue(), tpAntallPersoner);
+//            var entity = testnorgeTpService.genererTp(request);
+//            if (!entity.getStatusCode().is2xxSuccessful()) {
+//                log.error("Klarte ikke å fullføre syntetisering i TP batch kjøring");
+//            }
+//        }
     }
 
     @Scheduled(cron = "0 0 1 1 * *")
     public void samSyntBatch() {
-        for (var entry : avspillergruppeIdMedMiljoe.entrySet()) {
-            var syntetiserSamRequest = new SyntetiserSamRequest(entry.getKey(), entry.getValue(), samAntallMeldinger);
-            testnorgeSamService.genererSamordningsmeldinger(syntetiserSamRequest);
-        }
+        log.info("Innsending midlertidig stanset.");
+//        for (var entry : avspillergruppeIdMedMiljoe.entrySet()) {
+//            var syntetiserSamRequest = new SyntetiserSamRequest(entry.getKey(), entry.getValue(), samAntallMeldinger);
+//            testnorgeSamService.genererSamordningsmeldinger(syntetiserSamRequest);
+//        }
     }
 
     /**
@@ -201,8 +210,8 @@ public class JobController {
      */
     @Scheduled(cron = "0 0 0-23 * * *")
     public void arenaSyntBatch() {
-        for (var entry : avspillergruppeIdMedMiljoe.entrySet()) {
-            log.info("Innsending til Arena er midlertidig stanset");
+        log.info("Innsending til Arena er midlertidig stanset pga prod-setting i Arena");
+//        for (var entry : avspillergruppeIdMedMiljoe.entrySet()) {
 //            testnorgeArenaService.opprettArenaVedtakshistorikk(SyntetiserArenaVedtakshistorikkRequest.builder()
 //                    .avspillergruppeId(entry.getKey())
 //                    .miljoe(entry.getValue())
@@ -214,22 +223,24 @@ public class JobController {
 //                    .miljoe(entry.getValue())
 //                    .antallNyeIdenter(1)
 //                    .build(), true);
-        }
+//        }
     }
 
     @Scheduled(cron = "0 0 0 * * *")
     public void medlSyntBatch() {
-        for (var entry : avspillergruppeIdMedMiljoe.entrySet()) {
-            var syntetiserMedlRequest = new SyntetiserMedlRequest(entry.getKey(), entry.getValue(), medlProsentfaktor);
-            testnorgeMedlService.genererMedlemskap(syntetiserMedlRequest);
-        }
+        log.info("Innsending midlertidig stanset.");
+//        for (var entry : avspillergruppeIdMedMiljoe.entrySet()) {
+//            var syntetiserMedlRequest = new SyntetiserMedlRequest(entry.getKey(), entry.getValue(), medlProsentfaktor);
+//            testnorgeMedlService.genererMedlemskap(syntetiserMedlRequest);
+//        }
     }
 
     @Scheduled(cron = "0 0 0 * * *")
     public void frikortSyntBatch() {
-        for (var entry : avspillergruppeIdMedMiljoe.entrySet()) {
-            var syntetiserFrikortRequest = new SyntetiserFrikortRequest(entry.getKey(), entry.getValue(), frikortAntallNyeIdenter);
-            testnorgeFrikortService.genererFrikortEgenmeldinger(syntetiserFrikortRequest);
-        }
+        log.info("Innsending midlertidig stanset.");
+//        for (var entry : avspillergruppeIdMedMiljoe.entrySet()) {
+//            var syntetiserFrikortRequest = new SyntetiserFrikortRequest(entry.getKey(), entry.getValue(), frikortAntallNyeIdenter);
+//            testnorgeFrikortService.genererFrikortEgenmeldinger(syntetiserFrikortRequest);
+//        }
     }
 }

--- a/apps/orkestratoren/src/main/java/no/nav/registre/orkestratoren/batch/v1/JobController.java
+++ b/apps/orkestratoren/src/main/java/no/nav/registre/orkestratoren/batch/v1/JobController.java
@@ -36,7 +36,7 @@ import no.nav.registre.orkestratoren.service.TestnorgeSkdService;
 import no.nav.registre.orkestratoren.service.TestnorgeTpService;
 
 @Component
-@EnableScheduling
+//@EnableScheduling
 @Getter
 @Slf4j
 public class JobController {
@@ -112,14 +112,13 @@ public class JobController {
 
     @Scheduled(cron = "0 0 0 * * *")
     public void tpsSyntBatch() {
-        log.info("Innsending midlertidig stanset.");
-//        for (var entry : avspillergruppeIdMedMiljoe.entrySet()) {
-//            try {
-//                testnorgeSkdService.genererSkdmeldinger(entry.getKey(), entry.getValue(), antallSkdmeldingerPerEndringskode);
-//            } catch (HttpStatusCodeException e) {
-//                log.warn(e.getResponseBodyAsString(), e);
-//            }
-//        }
+        for (var entry : avspillergruppeIdMedMiljoe.entrySet()) {
+            try {
+                testnorgeSkdService.genererSkdmeldinger(entry.getKey(), entry.getValue(), antallSkdmeldingerPerEndringskode);
+            } catch (HttpStatusCodeException e) {
+                log.warn(e.getResponseBodyAsString(), e);
+            }
+        }
     }
 
     @Scheduled(cron = "0 0 0 * * *")
@@ -138,70 +137,63 @@ public class JobController {
 
     @Scheduled(cron = "0 0 1 1 * *")
     public void inntektSyntBatch() {
-        log.info("Innsending midlertidig stanset.");
-//        for (var entry : avspillergruppeIdMedMiljoe.entrySet()) {
-//            var request = new SyntetiserInntektsmeldingRequest(entry.getKey(), entry.getValue());
-//            var feiledeInntektsmeldinger = testnorgeInntektService.genererInntektsmeldinger(request);
-//            log.info("Inntekt-synt.-batch har matet Inntektstub med meldinger. Meldinger som feilet: {}.", feiledeInntektsmeldinger.keySet().toString());
-//        }
+        for (var entry : avspillergruppeIdMedMiljoe.entrySet()) {
+            var request = new SyntetiserInntektsmeldingRequest(entry.getKey(), entry.getValue());
+            var feiledeInntektsmeldinger = testnorgeInntektService.genererInntektsmeldinger(request);
+            log.info("Inntekt-synt.-batch har matet Inntektstub med meldinger. Meldinger som feilet: {}.", feiledeInntektsmeldinger.keySet().toString());
+        }
     }
 
     @Scheduled(cron = "0 0 1 1 5 *")
     public void poppSyntBatch() {
-        log.info("Innsending midlertidig stanset.");
-//        for (var entry : avspillergruppeIdMedMiljoe.entrySet()) {
-//            var syntetiserPoppRequest = new SyntetiserPoppRequest(entry.getKey(), entry.getValue(), poppbatchAntallNyeIdenter);
-//            var testdataEier = "synt_test";
-//            testnorgeSigrunService.genererSkattegrunnlag(syntetiserPoppRequest, testdataEier);
-//        }
+        for (var entry : avspillergruppeIdMedMiljoe.entrySet()) {
+            var syntetiserPoppRequest = new SyntetiserPoppRequest(entry.getKey(), entry.getValue(), poppbatchAntallNyeIdenter);
+            var testdataEier = "synt_test";
+            testnorgeSigrunService.genererSkattegrunnlag(syntetiserPoppRequest, testdataEier);
+        }
     }
 
     @Scheduled(cron = "0 0 1 1 * *")
     public void aaregSyntBatch() {
-        log.info("Innsending midlertidig stanset.");
-//        for (var entry : avspillergruppeIdMedMiljoe.entrySet()) {
-//            var syntetiserAaregRequest = new SyntetiserAaregRequest(entry.getKey(), entry.getValue(), aaregbatchAntallNyeIdenter);
-//            testnorgeAaregService.genererArbeidsforholdsmeldinger(syntetiserAaregRequest, true);
-//        }
+        for (var entry : avspillergruppeIdMedMiljoe.entrySet()) {
+            var syntetiserAaregRequest = new SyntetiserAaregRequest(entry.getKey(), entry.getValue(), aaregbatchAntallNyeIdenter);
+            testnorgeAaregService.genererArbeidsforholdsmeldinger(syntetiserAaregRequest, true);
+        }
     }
 
     @Scheduled(cron = "0 0 0 * * *")
     public void instSyntBatch() {
-        log.info("Innsending midlertidig stanset.");
-//        for (var entry : avspillergruppeIdMedMiljoe.entrySet()) {
-//            var syntetiserInstRequest = new SyntetiserInstRequest(entry.getKey(), entry.getValue(), instbatchAntallNyeIdenter);
-//            testnorgeInstService.genererInstitusjonsforhold(syntetiserInstRequest);
-//        }
+        for (var entry : avspillergruppeIdMedMiljoe.entrySet()) {
+            var syntetiserInstRequest = new SyntetiserInstRequest(entry.getKey(), entry.getValue(), instbatchAntallNyeIdenter);
+            testnorgeInstService.genererInstitusjonsforhold(syntetiserInstRequest);
+        }
     }
 
     @Scheduled(cron = "0 0 0 * * *")
     public void bisysSyntBatch() {
-        log.info("Innsending midlertidig stanset.");
-//        for (var entry : avspillergruppeIdMedMiljoe.entrySet()) {
-//            var syntetiserBisysRequest = new SyntetiserBisysRequest(entry.getKey(), entry.getValue(), bisysbatchAntallNyeIdenter);
-//            testnorgeBisysService.genererBistandsmeldinger(syntetiserBisysRequest);
-//        }
+        for (var entry : avspillergruppeIdMedMiljoe.entrySet()) {
+            var syntetiserBisysRequest = new SyntetiserBisysRequest(entry.getKey(), entry.getValue(), bisysbatchAntallNyeIdenter);
+            testnorgeBisysService.genererBistandsmeldinger(syntetiserBisysRequest);
+        }
     }
 
     @Scheduled(cron = "0 0 0 1 5 *")
     public void tpSyntBatch() {
-        log.info("Innsending midlertidig stanset.");
-//        for (var entry : avspillergruppeIdMedMiljoe.entrySet()) {
-//            var request = new SyntetiserTpRequest(entry.getKey(), entry.getValue(), tpAntallPersoner);
-//            var entity = testnorgeTpService.genererTp(request);
-//            if (!entity.getStatusCode().is2xxSuccessful()) {
-//                log.error("Klarte ikke å fullføre syntetisering i TP batch kjøring");
-//            }
-//        }
+        for (var entry : avspillergruppeIdMedMiljoe.entrySet()) {
+            var request = new SyntetiserTpRequest(entry.getKey(), entry.getValue(), tpAntallPersoner);
+            var entity = testnorgeTpService.genererTp(request);
+            if (!entity.getStatusCode().is2xxSuccessful()) {
+                log.error("Klarte ikke å fullføre syntetisering i TP batch kjøring");
+            }
+        }
     }
 
     @Scheduled(cron = "0 0 1 1 * *")
     public void samSyntBatch() {
-        log.info("Innsending midlertidig stanset.");
-//        for (var entry : avspillergruppeIdMedMiljoe.entrySet()) {
-//            var syntetiserSamRequest = new SyntetiserSamRequest(entry.getKey(), entry.getValue(), samAntallMeldinger);
-//            testnorgeSamService.genererSamordningsmeldinger(syntetiserSamRequest);
-//        }
+        for (var entry : avspillergruppeIdMedMiljoe.entrySet()) {
+            var syntetiserSamRequest = new SyntetiserSamRequest(entry.getKey(), entry.getValue(), samAntallMeldinger);
+            testnorgeSamService.genererSamordningsmeldinger(syntetiserSamRequest);
+        }
     }
 
     /**
@@ -228,19 +220,17 @@ public class JobController {
 
     @Scheduled(cron = "0 0 0 * * *")
     public void medlSyntBatch() {
-        log.info("Innsending midlertidig stanset.");
-//        for (var entry : avspillergruppeIdMedMiljoe.entrySet()) {
-//            var syntetiserMedlRequest = new SyntetiserMedlRequest(entry.getKey(), entry.getValue(), medlProsentfaktor);
-//            testnorgeMedlService.genererMedlemskap(syntetiserMedlRequest);
-//        }
+        for (var entry : avspillergruppeIdMedMiljoe.entrySet()) {
+            var syntetiserMedlRequest = new SyntetiserMedlRequest(entry.getKey(), entry.getValue(), medlProsentfaktor);
+            testnorgeMedlService.genererMedlemskap(syntetiserMedlRequest);
+        }
     }
 
     @Scheduled(cron = "0 0 0 * * *")
     public void frikortSyntBatch() {
-        log.info("Innsending midlertidig stanset.");
-//        for (var entry : avspillergruppeIdMedMiljoe.entrySet()) {
-//            var syntetiserFrikortRequest = new SyntetiserFrikortRequest(entry.getKey(), entry.getValue(), frikortAntallNyeIdenter);
-//            testnorgeFrikortService.genererFrikortEgenmeldinger(syntetiserFrikortRequest);
-//        }
+        for (var entry : avspillergruppeIdMedMiljoe.entrySet()) {
+            var syntetiserFrikortRequest = new SyntetiserFrikortRequest(entry.getKey(), entry.getValue(), frikortAntallNyeIdenter);
+            testnorgeFrikortService.genererFrikortEgenmeldinger(syntetiserFrikortRequest);
+        }
     }
 }

--- a/apps/orkestratoren/src/test/java/no/nav/registre/orkestratoren/batch/JobControllerTest.java
+++ b/apps/orkestratoren/src/test/java/no/nav/registre/orkestratoren/batch/JobControllerTest.java
@@ -1,161 +1,161 @@
-//package no.nav.registre.orkestratoren.batch;
-//
-//import static org.mockito.ArgumentMatchers.any;
-//import static org.mockito.ArgumentMatchers.anyString;
-//import static org.mockito.ArgumentMatchers.eq;
-//import static org.mockito.Mockito.verify;
-//import static org.mockito.Mockito.when;
-//
-//import org.junit.jupiter.api.BeforeEach;
-//import org.junit.jupiter.api.Disabled;
-//import org.junit.jupiter.api.Test;
-//import org.junit.jupiter.api.extension.ExtendWith;
-//import org.mockito.InjectMocks;
-//import org.mockito.Mock;
-//import org.mockito.junit.jupiter.MockitoExtension;
-//import org.springframework.http.HttpStatus;
-//import org.springframework.http.ResponseEntity;
-//import org.springframework.test.util.ReflectionTestUtils;
-//
-//import java.util.ArrayList;
-//import java.util.Collections;
-//import java.util.HashMap;
-//import java.util.List;
-//import java.util.Map;
-//
-//import no.nav.registre.orkestratoren.batch.v1.JobController;
-//import no.nav.registre.orkestratoren.service.TestnorgeAaregService;
-//import no.nav.registre.orkestratoren.service.TestnorgeArenaService;
-//import no.nav.registre.orkestratoren.service.TestnorgeBisysService;
-//import no.nav.registre.orkestratoren.service.TestnorgeFrikortService;
-//import no.nav.registre.orkestratoren.service.TestnorgeInntektService;
-//import no.nav.registre.orkestratoren.service.TestnorgeInstService;
-//import no.nav.registre.orkestratoren.service.TestnorgeMedlService;
-//import no.nav.registre.orkestratoren.service.TestnorgeSamService;
-//import no.nav.registre.orkestratoren.service.TestnorgeSigrunService;
-//import no.nav.registre.orkestratoren.service.TestnorgeSkdService;
-//import no.nav.registre.orkestratoren.service.TestnorgeTpService;
-//
-//@ExtendWith(MockitoExtension.class)
-//public class JobControllerTest {
-//
-//    @Mock
-//    private TestnorgeSkdService testnorgeSkdService;
-//
-//    @Mock
-//    private TestnorgeInntektService testnorgeInntektService;
-//
-//    @Mock
-//    private TestnorgeSigrunService testnorgeSigrunService;
-//
-//    @Mock
-//    private TestnorgeAaregService testnorgeAaregService;
-//
-//    @Mock
-//    private TestnorgeInstService testnorgeInstService;
-//
-//    @Mock
-//    private TestnorgeBisysService testnorgeBisysService;
-//
-//    @Mock
-//    private TestnorgeTpService testnorgeTpService;
-//
-//    @Mock
-//    private TestnorgeSamService testnorgeSamService;
-//
-//    @Mock
-//    private TestnorgeArenaService testnorgeArenaService;
-//
-//    @Mock
-//    private TestnorgeMedlService testnorgeMedlService;
-//
-//    @Mock
-//    private TestnorgeFrikortService testnorgeFrikortService;
-//
-//    @InjectMocks
-//    private JobController jobController;
-//
-//    private final Long avspillergruppeId = 123L;
-//    private List<String> miljoer;
-//    private Map<String, Integer> antallMeldingerPerEndringskode;
-//
-//    @BeforeEach
-//    void setUp() {
-//        String miljoe = "t1";
-//        miljoer = new ArrayList<>(Collections.singletonList(miljoe));
-//        Map<Long, String> avspillergruppeIdMedMiljoe = new HashMap<>();
-//        avspillergruppeIdMedMiljoe.put(avspillergruppeId, miljoe);
-//        ReflectionTestUtils.setField(jobController, "avspillergruppeIdMedMiljoe", avspillergruppeIdMedMiljoe);
-//        antallMeldingerPerEndringskode = new HashMap<>();
-//        antallMeldingerPerEndringskode.put("0110", 2);
-//        ReflectionTestUtils.setField(jobController, "antallSkdmeldingerPerEndringskode", antallMeldingerPerEndringskode);
-//    }
-//
-//    @Test
-//    void shouldStartTpsBatch() {
-//        jobController.tpsSyntBatch();
-//        verify(testnorgeSkdService).genererSkdmeldinger(avspillergruppeId, miljoer.get(0), antallMeldingerPerEndringskode);
-//    }
-//
-//    @Test
-//    @Disabled("Koden er kommentert ut")
-//    void shouldStartNavBatch() {
-//        jobController.navSyntBatch();
-//        verify(testnorgeSkdService).genererNavmeldinger(any());
-//    }
-//
-//    @Test
-//    void shouldStartInntektBatch() {
-//        jobController.inntektSyntBatch();
-//        verify(testnorgeInntektService).genererInntektsmeldinger(any());
-//    }
-//
-//    @Test
-//    void shouldStartPoppBatch() {
-//        jobController.poppSyntBatch();
-//        verify(testnorgeSigrunService).genererSkattegrunnlag(any(), anyString());
-//    }
-//
-//    @Test
-//    void shouldStartAaregBatch() {
-//        jobController.aaregSyntBatch();
-//        verify(testnorgeAaregService).genererArbeidsforholdsmeldinger(any(), eq(true));
-//    }
-//
-//    @Test
-//    void shouldStartInstBatch() {
-//        jobController.instSyntBatch();
-//        verify(testnorgeInstService).genererInstitusjonsforhold(any());
-//    }
-//
-//    @Test
-//    void shouldStartBisysBatch() {
-//        jobController.bisysSyntBatch();
-//        verify(testnorgeBisysService).genererBistandsmeldinger(any());
-//    }
-//
-//    @Test
-//    void shouldStartTpBatch() {
-//        when(testnorgeTpService.genererTp(any())).thenReturn(new ResponseEntity(HttpStatus.OK));
-//        jobController.tpSyntBatch();
-//        verify(testnorgeTpService).genererTp(any());
-//    }
-//
-//    @Test
-//    void shouldStartSamBatch() {
-//        jobController.samSyntBatch();
-//        verify(testnorgeSamService).genererSamordningsmeldinger(any());
-//    }
-//
-//    @Test
-//    void shouldStartMedlBatch() {
-//        jobController.medlSyntBatch();
-//        verify(testnorgeMedlService).genererMedlemskap(any());
-//    }
-//
-//    @Test
-//    void shouldStartFrikortBatch() {
-//        jobController.frikortSyntBatch();
-//        verify(testnorgeFrikortService).genererFrikortEgenmeldinger(any());
-//    }
-//}
+package no.nav.registre.orkestratoren.batch;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import no.nav.registre.orkestratoren.batch.v1.JobController;
+import no.nav.registre.orkestratoren.service.TestnorgeAaregService;
+import no.nav.registre.orkestratoren.service.TestnorgeArenaService;
+import no.nav.registre.orkestratoren.service.TestnorgeBisysService;
+import no.nav.registre.orkestratoren.service.TestnorgeFrikortService;
+import no.nav.registre.orkestratoren.service.TestnorgeInntektService;
+import no.nav.registre.orkestratoren.service.TestnorgeInstService;
+import no.nav.registre.orkestratoren.service.TestnorgeMedlService;
+import no.nav.registre.orkestratoren.service.TestnorgeSamService;
+import no.nav.registre.orkestratoren.service.TestnorgeSigrunService;
+import no.nav.registre.orkestratoren.service.TestnorgeSkdService;
+import no.nav.registre.orkestratoren.service.TestnorgeTpService;
+
+@ExtendWith(MockitoExtension.class)
+public class JobControllerTest {
+
+    @Mock
+    private TestnorgeSkdService testnorgeSkdService;
+
+    @Mock
+    private TestnorgeInntektService testnorgeInntektService;
+
+    @Mock
+    private TestnorgeSigrunService testnorgeSigrunService;
+
+    @Mock
+    private TestnorgeAaregService testnorgeAaregService;
+
+    @Mock
+    private TestnorgeInstService testnorgeInstService;
+
+    @Mock
+    private TestnorgeBisysService testnorgeBisysService;
+
+    @Mock
+    private TestnorgeTpService testnorgeTpService;
+
+    @Mock
+    private TestnorgeSamService testnorgeSamService;
+
+    @Mock
+    private TestnorgeArenaService testnorgeArenaService;
+
+    @Mock
+    private TestnorgeMedlService testnorgeMedlService;
+
+    @Mock
+    private TestnorgeFrikortService testnorgeFrikortService;
+
+    @InjectMocks
+    private JobController jobController;
+
+    private final Long avspillergruppeId = 123L;
+    private List<String> miljoer;
+    private Map<String, Integer> antallMeldingerPerEndringskode;
+
+    @BeforeEach
+    void setUp() {
+        String miljoe = "t1";
+        miljoer = new ArrayList<>(Collections.singletonList(miljoe));
+        Map<Long, String> avspillergruppeIdMedMiljoe = new HashMap<>();
+        avspillergruppeIdMedMiljoe.put(avspillergruppeId, miljoe);
+        ReflectionTestUtils.setField(jobController, "avspillergruppeIdMedMiljoe", avspillergruppeIdMedMiljoe);
+        antallMeldingerPerEndringskode = new HashMap<>();
+        antallMeldingerPerEndringskode.put("0110", 2);
+        ReflectionTestUtils.setField(jobController, "antallSkdmeldingerPerEndringskode", antallMeldingerPerEndringskode);
+    }
+
+    @Test
+    void shouldStartTpsBatch() {
+        jobController.tpsSyntBatch();
+        verify(testnorgeSkdService).genererSkdmeldinger(avspillergruppeId, miljoer.get(0), antallMeldingerPerEndringskode);
+    }
+
+    @Test
+    @Disabled("Koden er kommentert ut")
+    void shouldStartNavBatch() {
+        jobController.navSyntBatch();
+        verify(testnorgeSkdService).genererNavmeldinger(any());
+    }
+
+    @Test
+    void shouldStartInntektBatch() {
+        jobController.inntektSyntBatch();
+        verify(testnorgeInntektService).genererInntektsmeldinger(any());
+    }
+
+    @Test
+    void shouldStartPoppBatch() {
+        jobController.poppSyntBatch();
+        verify(testnorgeSigrunService).genererSkattegrunnlag(any(), anyString());
+    }
+
+    @Test
+    void shouldStartAaregBatch() {
+        jobController.aaregSyntBatch();
+        verify(testnorgeAaregService).genererArbeidsforholdsmeldinger(any(), eq(true));
+    }
+
+    @Test
+    void shouldStartInstBatch() {
+        jobController.instSyntBatch();
+        verify(testnorgeInstService).genererInstitusjonsforhold(any());
+    }
+
+    @Test
+    void shouldStartBisysBatch() {
+        jobController.bisysSyntBatch();
+        verify(testnorgeBisysService).genererBistandsmeldinger(any());
+    }
+
+    @Test
+    void shouldStartTpBatch() {
+        when(testnorgeTpService.genererTp(any())).thenReturn(new ResponseEntity(HttpStatus.OK));
+        jobController.tpSyntBatch();
+        verify(testnorgeTpService).genererTp(any());
+    }
+
+    @Test
+    void shouldStartSamBatch() {
+        jobController.samSyntBatch();
+        verify(testnorgeSamService).genererSamordningsmeldinger(any());
+    }
+
+    @Test
+    void shouldStartMedlBatch() {
+        jobController.medlSyntBatch();
+        verify(testnorgeMedlService).genererMedlemskap(any());
+    }
+
+    @Test
+    void shouldStartFrikortBatch() {
+        jobController.frikortSyntBatch();
+        verify(testnorgeFrikortService).genererFrikortEgenmeldinger(any());
+    }
+}

--- a/apps/orkestratoren/src/test/java/no/nav/registre/orkestratoren/batch/JobControllerTest.java
+++ b/apps/orkestratoren/src/test/java/no/nav/registre/orkestratoren/batch/JobControllerTest.java
@@ -1,161 +1,161 @@
-package no.nav.registre.orkestratoren.batch;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.test.util.ReflectionTestUtils;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import no.nav.registre.orkestratoren.batch.v1.JobController;
-import no.nav.registre.orkestratoren.service.TestnorgeAaregService;
-import no.nav.registre.orkestratoren.service.TestnorgeArenaService;
-import no.nav.registre.orkestratoren.service.TestnorgeBisysService;
-import no.nav.registre.orkestratoren.service.TestnorgeFrikortService;
-import no.nav.registre.orkestratoren.service.TestnorgeInntektService;
-import no.nav.registre.orkestratoren.service.TestnorgeInstService;
-import no.nav.registre.orkestratoren.service.TestnorgeMedlService;
-import no.nav.registre.orkestratoren.service.TestnorgeSamService;
-import no.nav.registre.orkestratoren.service.TestnorgeSigrunService;
-import no.nav.registre.orkestratoren.service.TestnorgeSkdService;
-import no.nav.registre.orkestratoren.service.TestnorgeTpService;
-
-@ExtendWith(MockitoExtension.class)
-public class JobControllerTest {
-
-    @Mock
-    private TestnorgeSkdService testnorgeSkdService;
-
-    @Mock
-    private TestnorgeInntektService testnorgeInntektService;
-
-    @Mock
-    private TestnorgeSigrunService testnorgeSigrunService;
-
-    @Mock
-    private TestnorgeAaregService testnorgeAaregService;
-
-    @Mock
-    private TestnorgeInstService testnorgeInstService;
-
-    @Mock
-    private TestnorgeBisysService testnorgeBisysService;
-
-    @Mock
-    private TestnorgeTpService testnorgeTpService;
-
-    @Mock
-    private TestnorgeSamService testnorgeSamService;
-
-    @Mock
-    private TestnorgeArenaService testnorgeArenaService;
-
-    @Mock
-    private TestnorgeMedlService testnorgeMedlService;
-
-    @Mock
-    private TestnorgeFrikortService testnorgeFrikortService;
-
-    @InjectMocks
-    private JobController jobController;
-
-    private final Long avspillergruppeId = 123L;
-    private List<String> miljoer;
-    private Map<String, Integer> antallMeldingerPerEndringskode;
-
-    @BeforeEach
-    void setUp() {
-        String miljoe = "t1";
-        miljoer = new ArrayList<>(Collections.singletonList(miljoe));
-        Map<Long, String> avspillergruppeIdMedMiljoe = new HashMap<>();
-        avspillergruppeIdMedMiljoe.put(avspillergruppeId, miljoe);
-        ReflectionTestUtils.setField(jobController, "avspillergruppeIdMedMiljoe", avspillergruppeIdMedMiljoe);
-        antallMeldingerPerEndringskode = new HashMap<>();
-        antallMeldingerPerEndringskode.put("0110", 2);
-        ReflectionTestUtils.setField(jobController, "antallSkdmeldingerPerEndringskode", antallMeldingerPerEndringskode);
-    }
-
-    @Test
-    void shouldStartTpsBatch() {
-        jobController.tpsSyntBatch();
-        verify(testnorgeSkdService).genererSkdmeldinger(avspillergruppeId, miljoer.get(0), antallMeldingerPerEndringskode);
-    }
-
-    @Test
-    @Disabled("Koden er kommentert ut")
-    void shouldStartNavBatch() {
-        jobController.navSyntBatch();
-        verify(testnorgeSkdService).genererNavmeldinger(any());
-    }
-
-    @Test
-    void shouldStartInntektBatch() {
-        jobController.inntektSyntBatch();
-        verify(testnorgeInntektService).genererInntektsmeldinger(any());
-    }
-
-    @Test
-    void shouldStartPoppBatch() {
-        jobController.poppSyntBatch();
-        verify(testnorgeSigrunService).genererSkattegrunnlag(any(), anyString());
-    }
-
-    @Test
-    void shouldStartAaregBatch() {
-        jobController.aaregSyntBatch();
-        verify(testnorgeAaregService).genererArbeidsforholdsmeldinger(any(), eq(true));
-    }
-
-    @Test
-    void shouldStartInstBatch() {
-        jobController.instSyntBatch();
-        verify(testnorgeInstService).genererInstitusjonsforhold(any());
-    }
-
-    @Test
-    void shouldStartBisysBatch() {
-        jobController.bisysSyntBatch();
-        verify(testnorgeBisysService).genererBistandsmeldinger(any());
-    }
-
-    @Test
-    void shouldStartTpBatch() {
-        when(testnorgeTpService.genererTp(any())).thenReturn(new ResponseEntity(HttpStatus.OK));
-        jobController.tpSyntBatch();
-        verify(testnorgeTpService).genererTp(any());
-    }
-
-    @Test
-    void shouldStartSamBatch() {
-        jobController.samSyntBatch();
-        verify(testnorgeSamService).genererSamordningsmeldinger(any());
-    }
-
-    @Test
-    void shouldStartMedlBatch() {
-        jobController.medlSyntBatch();
-        verify(testnorgeMedlService).genererMedlemskap(any());
-    }
-
-    @Test
-    void shouldStartFrikortBatch() {
-        jobController.frikortSyntBatch();
-        verify(testnorgeFrikortService).genererFrikortEgenmeldinger(any());
-    }
-}
+//package no.nav.registre.orkestratoren.batch;
+//
+//import static org.mockito.ArgumentMatchers.any;
+//import static org.mockito.ArgumentMatchers.anyString;
+//import static org.mockito.ArgumentMatchers.eq;
+//import static org.mockito.Mockito.verify;
+//import static org.mockito.Mockito.when;
+//
+//import org.junit.jupiter.api.BeforeEach;
+//import org.junit.jupiter.api.Disabled;
+//import org.junit.jupiter.api.Test;
+//import org.junit.jupiter.api.extension.ExtendWith;
+//import org.mockito.InjectMocks;
+//import org.mockito.Mock;
+//import org.mockito.junit.jupiter.MockitoExtension;
+//import org.springframework.http.HttpStatus;
+//import org.springframework.http.ResponseEntity;
+//import org.springframework.test.util.ReflectionTestUtils;
+//
+//import java.util.ArrayList;
+//import java.util.Collections;
+//import java.util.HashMap;
+//import java.util.List;
+//import java.util.Map;
+//
+//import no.nav.registre.orkestratoren.batch.v1.JobController;
+//import no.nav.registre.orkestratoren.service.TestnorgeAaregService;
+//import no.nav.registre.orkestratoren.service.TestnorgeArenaService;
+//import no.nav.registre.orkestratoren.service.TestnorgeBisysService;
+//import no.nav.registre.orkestratoren.service.TestnorgeFrikortService;
+//import no.nav.registre.orkestratoren.service.TestnorgeInntektService;
+//import no.nav.registre.orkestratoren.service.TestnorgeInstService;
+//import no.nav.registre.orkestratoren.service.TestnorgeMedlService;
+//import no.nav.registre.orkestratoren.service.TestnorgeSamService;
+//import no.nav.registre.orkestratoren.service.TestnorgeSigrunService;
+//import no.nav.registre.orkestratoren.service.TestnorgeSkdService;
+//import no.nav.registre.orkestratoren.service.TestnorgeTpService;
+//
+//@ExtendWith(MockitoExtension.class)
+//public class JobControllerTest {
+//
+//    @Mock
+//    private TestnorgeSkdService testnorgeSkdService;
+//
+//    @Mock
+//    private TestnorgeInntektService testnorgeInntektService;
+//
+//    @Mock
+//    private TestnorgeSigrunService testnorgeSigrunService;
+//
+//    @Mock
+//    private TestnorgeAaregService testnorgeAaregService;
+//
+//    @Mock
+//    private TestnorgeInstService testnorgeInstService;
+//
+//    @Mock
+//    private TestnorgeBisysService testnorgeBisysService;
+//
+//    @Mock
+//    private TestnorgeTpService testnorgeTpService;
+//
+//    @Mock
+//    private TestnorgeSamService testnorgeSamService;
+//
+//    @Mock
+//    private TestnorgeArenaService testnorgeArenaService;
+//
+//    @Mock
+//    private TestnorgeMedlService testnorgeMedlService;
+//
+//    @Mock
+//    private TestnorgeFrikortService testnorgeFrikortService;
+//
+//    @InjectMocks
+//    private JobController jobController;
+//
+//    private final Long avspillergruppeId = 123L;
+//    private List<String> miljoer;
+//    private Map<String, Integer> antallMeldingerPerEndringskode;
+//
+//    @BeforeEach
+//    void setUp() {
+//        String miljoe = "t1";
+//        miljoer = new ArrayList<>(Collections.singletonList(miljoe));
+//        Map<Long, String> avspillergruppeIdMedMiljoe = new HashMap<>();
+//        avspillergruppeIdMedMiljoe.put(avspillergruppeId, miljoe);
+//        ReflectionTestUtils.setField(jobController, "avspillergruppeIdMedMiljoe", avspillergruppeIdMedMiljoe);
+//        antallMeldingerPerEndringskode = new HashMap<>();
+//        antallMeldingerPerEndringskode.put("0110", 2);
+//        ReflectionTestUtils.setField(jobController, "antallSkdmeldingerPerEndringskode", antallMeldingerPerEndringskode);
+//    }
+//
+//    @Test
+//    void shouldStartTpsBatch() {
+//        jobController.tpsSyntBatch();
+//        verify(testnorgeSkdService).genererSkdmeldinger(avspillergruppeId, miljoer.get(0), antallMeldingerPerEndringskode);
+//    }
+//
+//    @Test
+//    @Disabled("Koden er kommentert ut")
+//    void shouldStartNavBatch() {
+//        jobController.navSyntBatch();
+//        verify(testnorgeSkdService).genererNavmeldinger(any());
+//    }
+//
+//    @Test
+//    void shouldStartInntektBatch() {
+//        jobController.inntektSyntBatch();
+//        verify(testnorgeInntektService).genererInntektsmeldinger(any());
+//    }
+//
+//    @Test
+//    void shouldStartPoppBatch() {
+//        jobController.poppSyntBatch();
+//        verify(testnorgeSigrunService).genererSkattegrunnlag(any(), anyString());
+//    }
+//
+//    @Test
+//    void shouldStartAaregBatch() {
+//        jobController.aaregSyntBatch();
+//        verify(testnorgeAaregService).genererArbeidsforholdsmeldinger(any(), eq(true));
+//    }
+//
+//    @Test
+//    void shouldStartInstBatch() {
+//        jobController.instSyntBatch();
+//        verify(testnorgeInstService).genererInstitusjonsforhold(any());
+//    }
+//
+//    @Test
+//    void shouldStartBisysBatch() {
+//        jobController.bisysSyntBatch();
+//        verify(testnorgeBisysService).genererBistandsmeldinger(any());
+//    }
+//
+//    @Test
+//    void shouldStartTpBatch() {
+//        when(testnorgeTpService.genererTp(any())).thenReturn(new ResponseEntity(HttpStatus.OK));
+//        jobController.tpSyntBatch();
+//        verify(testnorgeTpService).genererTp(any());
+//    }
+//
+//    @Test
+//    void shouldStartSamBatch() {
+//        jobController.samSyntBatch();
+//        verify(testnorgeSamService).genererSamordningsmeldinger(any());
+//    }
+//
+//    @Test
+//    void shouldStartMedlBatch() {
+//        jobController.medlSyntBatch();
+//        verify(testnorgeMedlService).genererMedlemskap(any());
+//    }
+//
+//    @Test
+//    void shouldStartFrikortBatch() {
+//        jobController.frikortSyntBatch();
+//        verify(testnorgeFrikortService).genererFrikortEgenmeldinger(any());
+//    }
+//}


### PR DESCRIPTION
Stanser midlertidig alle batch kjøringer i orkestratoren for når ident-pool er nede for flytting til gcp.