### PR TITLE
Inntektstub endringer for å håndtere feilende validering etter submit

### DIFF
--- a/apps/dolly-frontend/src/main/js/src/components/inntektStub/validerInntekt/index.js
+++ b/apps/dolly-frontend/src/main/js/src/components/inntektStub/validerInntekt/index.js
@@ -116,12 +116,20 @@ const InntektStub = ({ formikBag, inntektPath }) => {
 				} else {
 					setReset(false)
 				}
-				for (const [key, value] of Object.entries(values)) {
-					if (value === '') {
-						values[key] = undefined
+				const emptyableFields = Object.entries(fields).filter(
+					(field) => field?.[1]?.[0] === '<TOM>' && field?.[1]?.length > 2
+				)
+				for (const [key, val] of emptyableFields) {
+					if (!values[key] && key !== 'tilleggsinformasjonstype') {
+						values[key] = '<TOM>'
 					}
 				}
 				InntektstubService.validate(values).then((response) => setFields(response))
+				for (const [key, value] of Object.entries(values)) {
+					if (value === '' || value === '<TOM>') {
+						values[key] = undefined
+					}
+				}
 				setFormikBag(values)
 			}}
 			component={({ handleSubmit }) => (


### PR DESCRIPTION
Var ikke så rett frem som å bare sette alle undefined til TOM ved validering, da fikk vi ikke tilbake alle mulige felt.. Fikk testet en del uten å få noe feil og la ikke merke til noen manglende felt i response så tror dette løste problemet. 