### PR TITLE
Routing basert på query

### DIFF
--- a/libs/reactive-proxy/src/main/java/no/nav/testnav/libs/reactiveproxy/config/SecurityConfig.java
+++ b/libs/reactive-proxy/src/main/java/no/nav/testnav/libs/reactiveproxy/config/SecurityConfig.java
@@ -1,7 +1,6 @@
 package no.nav.testnav.libs.reactiveproxy.config;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -14,7 +13,6 @@ import no.nav.testnav.libs.reactivesecurity.config.SecureOAuth2ServerToServerCon
 import no.nav.testnav.libs.reactivesecurity.manager.JwtReactiveAuthenticationManager;
 
 
-@Slf4j
 @Configuration
 @EnableWebFluxSecurity
 @EnableReactiveMethodSecurity

--- a/libs/security-core/build.gradle
+++ b/libs/security-core/build.gradle
@@ -18,7 +18,7 @@ sonarqube {
 
 dependencyManagement {
     imports {
-        mavenBom 'org.springframework.boot:spring-boot-dependencies:2.5.7'
+        mavenBom 'org.springframework.boot:spring-boot-dependencies:2.6.7'
     }
 }
 

--- a/proxies/aareg-proxy/src/main/java/no/nav/testnav/proxies/aaregproxy/AaregProxyApplicationStarter.java
+++ b/proxies/aareg-proxy/src/main/java/no/nav/testnav/proxies/aaregproxy/AaregProxyApplicationStarter.java
@@ -59,7 +59,7 @@ public class AaregProxyApplicationStarter {
 
         var preprodFilter = AddAuthenticationRequestGatewayFilterFactory
             .bearerAuthenticationAndNavConsumerTokenHeaderFilter(stsPreprodOidcTokenService::getToken);
-        Stream.of("q0", "q1", "q2", "q4", "q5", "qx")
+        Stream.of("q1", "q2", "q4", "q5", "qx")
             .forEach(env -> routes
                 .route(createRoute(env, preprodFilter))
                 .route(env, createQueryBasedRoute(env, preprodFilter))
@@ -67,7 +67,7 @@ public class AaregProxyApplicationStarter {
 
         var testFilter = AddAuthenticationRequestGatewayFilterFactory
             .bearerAuthenticationAndNavConsumerTokenHeaderFilter(stsTestOidcTokenService::getToken);
-        Stream.of("t0", "t1", "t2", "t3", "t4", "t5", "t6", "t13")
+        Stream.of("t0", "t1", "t2", "t3", "t4", "t5", "t13")
             .forEach(env -> routes
                 .route(createRoute(env, testFilter))
                 .route(env, createQueryBasedRoute(env, testFilter))

--- a/proxies/aareg-proxy/src/main/java/no/nav/testnav/proxies/aaregproxy/DevVaultConfig.java
+++ b/proxies/aareg-proxy/src/main/java/no/nav/testnav/proxies/aaregproxy/DevVaultConfig.java
@@ -8,6 +8,8 @@ import org.springframework.vault.authentication.TokenAuthentication;
 import org.springframework.vault.client.VaultEndpoint;
 import org.springframework.vault.config.AbstractVaultConfiguration;
 
+import java.util.Optional;
+
 @Profile("dev")
 @Configuration
 @VaultPropertySource(value = "kv/preprod/fss/testnav-aareg-proxy/dev", ignoreSecretNotFound = false)
@@ -20,10 +22,11 @@ public class DevVaultConfig extends AbstractVaultConfiguration {
 
     @Override
     public ClientAuthentication clientAuthentication() {
-        var token = System.getProperty("spring.cloud.vault.token");
-        if (token == null) {
-            throw new IllegalArgumentException("Påkreved property 'spring.cloud.vault.token' er ikke satt.");
-        }
-        return new TokenAuthentication(System.getProperty("spring.cloud.vault.token"));
+        return new TokenAuthentication(
+            Optional
+                .ofNullable(System.getProperty("spring.cloud.vault.token"))
+                .orElseThrow(() -> new IllegalArgumentException("Påkrevd property 'spring.cloud.vault.token' er ikke satt."))
+        );
     }
+
 }

--- a/proxies/aareg-proxy/src/main/resources/application.yml
+++ b/proxies/aareg-proxy/src/main/resources/application.yml
@@ -3,7 +3,7 @@ AAD_ISSUER_URI: https://login.microsoftonline.com/62366534-1ec3-4962-8869-9b5535
 spring:
   application:
     name: testnav-aareg-proxy
-    desciption: Proxy for aareg som legger på sikkerhet og redirecter til riktig miljø.
+    description: Proxy for aareg som legger på sikkerhet og redirecter til riktig miljø.
   security:
     oauth2:
       resourceserver:

--- a/proxies/aareg-proxy/src/test/java/no/nav/testnav/proxies/aaregproxy/AaregProxyApplicationStarterTest.java
+++ b/proxies/aareg-proxy/src/test/java/no/nav/testnav/proxies/aaregproxy/AaregProxyApplicationStarterTest.java
@@ -67,7 +67,37 @@ class AaregProxyApplicationStarterTest {
         final var BODY = "I have been correctly routed from " + FROM_ACTUAL_URI + " to " + TO_EXPECTED_URI + " with header miljoe=" + env;
 
         stubFor(
-            get(urlEqualTo("/aareg-services/api/v1/arbeidsforhold/" + ID))
+            get(urlEqualTo(TO_EXPECTED_URI))
+                .withHeader("miljoe", equalTo(env))
+                .willReturn(aResponse()
+                    .withBody(BODY))
+        );
+
+        client
+            .get().uri(FROM_ACTUAL_URI)
+            .exchange()
+            .expectStatus().isOk()
+            .expectBody(String.class).isEqualTo(BODY);
+
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings =
+        {
+            "q0", "q1", "q2", "q4", "q5", "qx",
+            "t0", "t1", "t2", "t3", "t4", "t5", "t6", "t13"
+        }
+
+    )
+    void getOnUrlWithPathParamShouldBeRoutedToNewURLWithHeader(String env) {
+
+        final var ID = RANDOM.nextInt(10000, 99999);
+        final var FROM_ACTUAL_URI = "/api/v1/arbeidsforhold/" + ID + "/miljoe/" + env;
+        final var TO_EXPECTED_URI = "/aareg-services/api/v1/arbeidsforhold/" + ID;
+        final var BODY = "I have been correctly routed from " + FROM_ACTUAL_URI + " to " + TO_EXPECTED_URI + " with header miljoe=" + env;
+
+        stubFor(
+            get(urlEqualTo(TO_EXPECTED_URI))
                 .withHeader("miljoe", equalTo(env))
                 .willReturn(aResponse()
                     .withBody(BODY))

--- a/proxies/aareg-proxy/src/test/java/no/nav/testnav/proxies/aaregproxy/AaregProxyApplicationStarterTest.java
+++ b/proxies/aareg-proxy/src/test/java/no/nav/testnav/proxies/aaregproxy/AaregProxyApplicationStarterTest.java
@@ -1,0 +1,99 @@
+package no.nav.testnav.proxies.aaregproxy;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+import java.util.Random;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+@ActiveProfiles("test")
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = {
+        "app.modapp.uri.pattern=http://localhost:${wiremock.server.port}",
+        "sts.preprod.token.provider.url=http://localhost:${wiremock.server.port}/rest/v1/sts/token",
+        "sts.test.token.provider.url=http://localhost:${wiremock.server.port}/rest/v1/sts/token"}
+)
+@AutoConfigureWireMock(port = 0)
+class AaregProxyApplicationStarterTest {
+
+    private static final Random RANDOM = new Random();
+
+    @Autowired
+    private WebTestClient client;
+
+    @BeforeAll
+    public static void createStubForSts() {
+        stubFor(
+            get(urlEqualTo("/rest/v1/sts/token?grant_type=client_credentials&scope=openid"))
+                .willReturn(aResponse()
+                    .withHeader(CONTENT_TYPE, APPLICATION_JSON_VALUE)
+                    .withBody("""
+                        {
+                            "access_token": "token",
+                            "expires_in": 123
+                        }
+                        """))
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings =
+        {
+            "q0", "q1", "q2", "q4", "q5", "qx",
+            "t0", "t1", "t2", "t3", "t4", "t5", "t6", "t13"
+        }
+
+    )
+    public void getOnUrlWithQueryParamShouldBeRoutedToNewURLWithHeader(String env) {
+
+        final var ID = RANDOM.nextInt(10000, 99999);
+        final var FROM_ACTUAL_URI = "/api/v1/arbeidsforhold/" + ID + "?miljoe=" + env;
+        final var TO_EXPECTED_URI = "/aareg-services/api/v1/arbeidsforhold/" + ID;
+        final var BODY = "I have been correctly routed from " + FROM_ACTUAL_URI + " to " + TO_EXPECTED_URI + " with header miljoe=" + env;
+
+        stubFor(
+            get(urlEqualTo("/aareg-services/api/v1/arbeidsforhold/" + ID))
+                .withHeader("miljoe", equalTo(env))
+                .willReturn(aResponse()
+                    .withBody(BODY))
+        );
+
+        client
+            .get().uri(FROM_ACTUAL_URI)
+            .exchange()
+            .expectStatus().isOk()
+            .expectBody(String.class).isEqualTo(BODY);
+
+    }
+
+    @TestConfiguration
+    static class Config {
+
+        @Primary
+        @Bean
+        public SecurityWebFilterChain springSecurityFilterChain(ServerHttpSecurity http) {
+            return http
+                .authorizeExchange()
+                .pathMatchers("/api/v1/**")
+                .permitAll()
+                .and().build();
+        }
+
+    }
+
+}

--- a/proxies/aareg-proxy/src/test/java/no/nav/testnav/proxies/aaregproxy/AaregProxyApplicationStarterTest.java
+++ b/proxies/aareg-proxy/src/test/java/no/nav/testnav/proxies/aaregproxy/AaregProxyApplicationStarterTest.java
@@ -59,7 +59,7 @@ class AaregProxyApplicationStarterTest {
         }
 
     )
-    public void getOnUrlWithQueryParamShouldBeRoutedToNewURLWithHeader(String env) {
+    void getOnUrlWithQueryParamShouldBeRoutedToNewURLWithHeader(String env) {
 
         final var ID = RANDOM.nextInt(10000, 99999);
         final var FROM_ACTUAL_URI = "/api/v1/arbeidsforhold/" + ID + "?miljoe=" + env;

--- a/proxies/aareg-proxy/src/test/java/no/nav/testnav/proxies/aaregproxy/AaregProxyApplicationStarterTest.java
+++ b/proxies/aareg-proxy/src/test/java/no/nav/testnav/proxies/aaregproxy/AaregProxyApplicationStarterTest.java
@@ -54,8 +54,8 @@ class AaregProxyApplicationStarterTest {
     @ParameterizedTest
     @ValueSource(strings =
         {
-            "q0", "q1", "q2", "q4", "q5", "qx",
-            "t0", "t1", "t2", "t3", "t4", "t5", "t6", "t13"
+            "q1", "q2", "q4", "q5", "qx",
+            "t0", "t1", "t2", "t3", "t4", "t5", "t13"
         }
 
     )
@@ -84,8 +84,8 @@ class AaregProxyApplicationStarterTest {
     @ParameterizedTest
     @ValueSource(strings =
         {
-            "q0", "q1", "q2", "q4", "q5", "qx",
-            "t0", "t1", "t2", "t3", "t4", "t5", "t6", "t13"
+            "q1", "q2", "q4", "q5", "qx",
+            "t0", "t1", "t2", "t3", "t4", "t5", "t13"
         }
 
     )

--- a/proxies/aareg-proxy/src/test/resources/application-test.properties
+++ b/proxies/aareg-proxy/src/test/resources/application-test.properties
@@ -1,3 +1,8 @@
+logging.level.root=WARN
+logging.level.no.nav=INFO
+
+spring.main.allow-bean-definition-overriding=true
+
 spring.cloud.vault.token=dummy
 azure.app.client.id=dummy
 azure.app.client.secret=dummy

--- a/proxies/aareg-proxy/src/test/resources/logback-test.xml
+++ b/proxies/aareg-proxy/src/test/resources/logback-test.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/base.xml"/>
+</configuration>


### PR DESCRIPTION
Prøver å emulere endepunkt slik det brukes av dolly-backend for REST for å ende opp hos [modapp](https://modapp-q2.adeo.no/aareg-services/api/swagger-ui/index.html). Innebærer valg av miljø basert på HTTP query og setting av miljø basert på HTTP header.

Eksisterende routing er ikke berørt. Lagt til test, som SonarCloud ikke virker å detektere.