### PR TITLE
Synt vedtakshistoriukk service/bosatt fiks

### DIFF
--- a/apps/synt-vedtakshistorikk-service/src/main/java/no/nav/testnav/apps/syntvedtakshistorikkservice/service/BrukerService.java
+++ b/apps/synt-vedtakshistorikk-service/src/main/java/no/nav/testnav/apps/syntvedtakshistorikkservice/service/BrukerService.java
@@ -29,7 +29,8 @@ public class BrukerService {
                         syntetiserArenaRequest.getAntallNyeIdenter(),
                         MINIMUM_ALDER,
                         MAKSIMUM_ALDER,
-                        null)
+                        false
+                )
                 .stream().map(PersonDTO::getIdent).toList();
 
         if (pdlProxyConsumer.createTags(identer, SYNT_TAGS)) {

--- a/apps/synt-vedtakshistorikk-service/src/main/java/no/nav/testnav/apps/syntvedtakshistorikkservice/service/VedtakshistorikkService.java
+++ b/apps/synt-vedtakshistorikk-service/src/main/java/no/nav/testnav/apps/syntvedtakshistorikkservice/service/VedtakshistorikkService.java
@@ -138,13 +138,12 @@ public class VedtakshistorikkService {
         try {
             var aapVedtak = vedtakshistorikk.getAlleAapVedtak();
             var maaVaereBosatt = nonNull(aapVedtak) && !aapVedtak.isEmpty();
-            LocalDate tidligsteDatoBosatt = maaVaereBosatt ? finnTidligsteDatoAap(aapVedtak) : null;
 
             List<PersonDTO> identer;
             if (nonNull(tidligsteDatoBarnetillegg)) {
-                identer = identService.getUtvalgteIdenterIAldersgruppeMedBarnUnder18(1, minimumAlder, maksimumAlder, tidligsteDatoBosatt, tidligsteDatoBarnetillegg);
+                identer = identService.getUtvalgteIdenterIAldersgruppeMedBarnUnder18(1, minimumAlder, maksimumAlder, tidligsteDatoBarnetillegg, maaVaereBosatt);
             } else {
-                identer = identService.getUtvalgteIdenterIAldersgruppe(1, minimumAlder, maksimumAlder, tidligsteDatoBosatt);
+                identer = identService.getUtvalgteIdenterIAldersgruppe(1, minimumAlder, maksimumAlder, maaVaereBosatt);
             }
 
             return identer.isEmpty() ? null : identer.get(0);

--- a/apps/synt-vedtakshistorikk-service/src/test/java/no/nav/testnav/apps/syntvedtakshistorikkservice/service/BrukerServiceTest.java
+++ b/apps/synt-vedtakshistorikk-service/src/test/java/no/nav/testnav/apps/syntvedtakshistorikkservice/service/BrukerServiceTest.java
@@ -61,7 +61,7 @@ public class BrukerServiceTest {
         var identer = Collections.singletonList(fnr1);
         var personer = Collections.singletonList(PersonDTO.builder().ident(fnr1).build());
 
-        when(identService.getUtvalgteIdenterIAldersgruppe(1, MINIMUM_ALDER, MAKSIMUM_ALDER, null)).thenReturn(personer);
+        when(identService.getUtvalgteIdenterIAldersgruppe(1, MINIMUM_ALDER, MAKSIMUM_ALDER, false)).thenReturn(personer);
         when(pdlProxyConsumer.createTags(identer, SYNT_TAGS)).thenReturn(true);
         when(arenaForvalterService
                 .opprettArbeidssoekereUtenVedtak(identer, miljoe))


### PR DESCRIPTION
Liten oppdatering for bosatt status. Ikke lenger nødvendig å sjekke dato for hvor lenge identene har vært bosatt. 