### PR TITLE
Personvalg tom gruppe + visning person uten id

### DIFF
--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdl/visning/partials/relasjoner/PdlForeldreBarn.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdl/visning/partials/relasjoner/PdlForeldreBarn.tsx
@@ -5,6 +5,7 @@ import React from 'react'
 import { ForeldreBarnRelasjon } from '~/components/fagsystem/pdlf/PdlTypes'
 import SubOverskrift from '~/components/ui/subOverskrift/SubOverskrift'
 import Formatters from '~/utils/DataFormatter'
+import { RelatertPersonUtenId } from '~/components/fagsystem/pdlf/visning/partials/RelatertPersonUtenId'
 
 type VisningProps = {
 	relasjon: ForeldreBarnRelasjon
@@ -16,17 +17,29 @@ type PdlForeldreBarnProps = {
 }
 
 const Visning = ({ relasjon, idx }: VisningProps) => {
+	const relatertPersonUtenId = relasjon.relatertPersonUtenFolkeregisteridentifikator
+
 	return (
 		<>
-			<h4 style={{ width: '100%', marginTop: '0' }}>
-				{Formatters.showLabel('pdlRelasjonTyper', relasjon.relatertPersonsRolle)}
-			</h4>
-			<div key={idx} className="person-visning_content">
-				<TitleValue title="Ident" value={relasjon.relatertPersonsIdent} visKopier />
-				{relasjon.relatertPersonsRolle === 'BARN' && (
-					<TitleValue title="Forhold til barn" value={relasjon.minRolleForPerson} size="medium" />
-				)}
-			</div>
+			{relatertPersonUtenId ? (
+				<RelatertPersonUtenId
+					data={relatertPersonUtenId}
+					tittel={Formatters.showLabel('pdlRelasjonTyper', relasjon.relatertPersonsRolle)}
+					rolle={relasjon.relatertPersonsRolle === 'BARN' && relasjon.minRolleForPerson}
+				/>
+			) : (
+				<>
+					<h4 style={{ width: '100%', marginTop: '0' }}>
+						{Formatters.showLabel('pdlRelasjonTyper', relasjon.relatertPersonsRolle)}
+					</h4>
+					<div key={idx} className="person-visning_content">
+						<TitleValue title="Ident" value={relasjon.relatertPersonsIdent} visKopier />
+						{relasjon.relatertPersonsRolle === 'BARN' && (
+							<TitleValue title="Rolle for barn" value={relasjon.minRolleForPerson} size="medium" />
+						)}
+					</div>
+				</>
+			)}
 		</>
 	)
 }

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/form/partials/pdlPerson/PdlEksisterendePerson.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/form/partials/pdlPerson/PdlEksisterendePerson.tsx
@@ -9,6 +9,7 @@ import { Option, SelectOptionsOppslag } from '~/service/SelectOptionsOppslag'
 import { useBoolean } from 'react-use'
 import { FormikProps } from 'formik'
 import { NyIdent } from '~/components/fagsystem/pdlf/PdlTypes'
+import { AlertStripeInfo } from 'nav-frontend-alertstriper'
 
 interface PdlEksisterendePersonValues {
 	nyPersonPath?: string
@@ -49,9 +50,9 @@ export const PdlEksisterendePerson = ({
 		: nyPersonPath && !isEmpty(_get(formikBag?.values, nyPersonPath))
 
 	return (
-		<>
+		<div className={'flexbox--full-width'}>
 			{loadingIdentOptions && <Loading label="Henter valg for eksisterende ident..." />}
-			{identOptions?.length > 0 && (
+			{identOptions?.length > 0 ? (
 				<FormikSelect
 					name={eksisterendePersonPath}
 					label={label}
@@ -59,7 +60,13 @@ export const PdlEksisterendePerson = ({
 					size={'xlarge'}
 					disabled={hasNyPersonValues || disabled}
 				/>
+			) : (
+				!loadingIdentOptions && (
+					<AlertStripeInfo style={{ marginBottom: '15px' }}>
+						Det finnes ingen eksisterende personer i denne gruppen.
+					</AlertStripeInfo>
+				)
 			)}
-		</>
+		</div>
 	)
 }

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/visning/partials/RelatertPersonUtenId.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/visning/partials/RelatertPersonUtenId.tsx
@@ -7,9 +7,10 @@ import { PersonUtenIdData } from '~/components/fagsystem/pdlf/PdlTypes'
 type RelatertPersonUtenIdData = {
 	data: PersonUtenIdData
 	tittel: string
+	rolle?: string
 }
 
-export const RelatertPersonUtenId = ({ data, tittel }: RelatertPersonUtenIdData) => {
+export const RelatertPersonUtenId = ({ data, tittel, rolle = null }: RelatertPersonUtenIdData) => {
 	if (!data) return null
 
 	return (
@@ -25,6 +26,7 @@ export const RelatertPersonUtenId = ({ data, tittel }: RelatertPersonUtenIdData)
 				value={data.statsborgerskap}
 				kodeverk={AdresseKodeverk.StatsborgerskapLand}
 			/>
+			<TitleValue title="Rolle for barn" value={rolle} size="medium" />
 		</div>
 	)
 }


### PR DESCRIPTION
* Infoboks ved valg av eksisterende person i tom gruppe.
* Fix visning av forelder/barn uten id på pdl-visning.