### PR TITLE
Dolly frontend/velg alle og fjern alle attributter fiks

### DIFF
--- a/apps/dolly-frontend/src/main/js/src/components/bestillingsveileder/stateModifier.js
+++ b/apps/dolly-frontend/src/main/js/src/components/bestillingsveileder/stateModifier.js
@@ -5,11 +5,13 @@ import _isEmpty from 'lodash/isEmpty'
 import _get from 'lodash/get'
 import { useDispatch } from 'react-redux'
 
-export const stateModifierFns = (initial, setInitial, options = null) => {
+export const stateModifierFns = (initial, setInitial, options = null, dispatch = null) => {
+	if (dispatch == null) {
+		dispatch = useDispatch()
+	}
 	const opts = options
 	const set = (path, value) => setInitial(_set(path, value, initial))
 	const has = (path) => _has(initial, path)
-	const dispatch = useDispatch()
 	const del = (path) => {
 		let newObj = _omit(initial, path)
 
@@ -40,7 +42,7 @@ export const stateModifierFns = (initial, setInitial, options = null) => {
 			const ignores = Array.isArray(ignoreKeys) ? ignoreKeys : [ignoreKeys]
 			if (ignores.includes(curr)) return acc
 
-			const sm_local = stateModifierFns(acc, (newState) => (acc = newState), opts)(fn)
+			const sm_local = stateModifierFns(acc, (newState) => (acc = newState), opts, dispatch)(fn)
 			sm_local.attrs[curr][key]()
 			return acc
 		}, Object.assign({}, initial))

--- a/apps/dolly-frontend/src/main/js/src/components/bestillingsveileder/stegVelger/steg/steg1/paneler/Arena.js
+++ b/apps/dolly-frontend/src/main/js/src/components/bestillingsveileder/stegVelger/steg/steg1/paneler/Arena.js
@@ -16,7 +16,11 @@ export const ArenaPanel = ({ stateModifier, formikBag }) => {
 	return (
 		<Panel
 			heading={ArenaPanel.heading}
-			checkAttributeArray={sm.batchAdd}
+			checkAttributeArray={() => {
+				if (!sm.attrs.ingenYtelser.checked && !sm.attrs.ikkeServicebehov.checked) {
+					sm.batchAdd(['ikkeServicebehov', 'ingenYtelser'])
+				}
+			}}
 			uncheckAttributeArray={sm.batchRemove}
 			iconType="arena"
 			startOpen={harValgtAttributt(formikBag.values, [arenaPath])}

--- a/apps/dolly-frontend/src/main/js/src/components/bestillingsveileder/stegVelger/steg/steg1/paneler/Personinformasjon.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/bestillingsveileder/stegVelger/steg/steg1/paneler/Personinformasjon.tsx
@@ -44,19 +44,26 @@ export const PersoninformasjonPanel = ({ stateModifier, testnorgeIdent }) => {
 	const harFnr = opts.identtype === 'FNR'
 	//Noen egenskaper kan ikke endres når personen opprettes fra eksisterende eller videreføres med legg til
 
+	const getIgnoreKeys = () => {
+		const ignoreKeys = testnorgeIdent ? [...ignoreKeysTestnorge] : ['identtype']
+		if (sm.attrs.utenlandskBankkonto.checked) {
+			ignoreKeys.push('norskBankkonto')
+		} else {
+			ignoreKeys.push('utenlandskBankkonto')
+		}
+		if (!testnorgeIdent && !harFnr) {
+			ignoreKeys.push('utvandretTilLand')
+		}
+		return ignoreKeys
+	}
+
 	if (testnorgeIdent) {
 		return (
 			// @ts-ignore
 			<Panel
 				heading={PersoninformasjonPanel.heading}
 				startOpen
-				checkAttributeArray={() => {
-					if (sm.attrs.utenlandskBankkonto.checked) {
-						sm.batchAdd([...ignoreKeysTestnorge, 'norskBankkonto'])
-					} else {
-						sm.batchAdd([...ignoreKeysTestnorge, 'utenlandskBankkonto'])
-					}
-				}}
+				checkAttributeArray={() => sm.batchAdd(getIgnoreKeys())}
 				uncheckAttributeArray={sm.batchRemove}
 				iconType={'personinformasjon'}
 			>
@@ -81,13 +88,7 @@ export const PersoninformasjonPanel = ({ stateModifier, testnorgeIdent }) => {
 		<Panel
 			heading={PersoninformasjonPanel.heading}
 			startOpen
-			checkAttributeArray={() => {
-				if (sm.attrs.utenlandskBankkonto.checked) {
-					sm.batchAdd(['identtype', 'norskBankkonto'])
-				} else {
-					sm.batchAdd(['identtype', 'utenlandskBankkonto'])
-				}
-			}}
+			checkAttributeArray={() => sm.batchAdd(getIgnoreKeys())}
 			uncheckAttributeArray={sm.batchRemove}
 			iconType={'personinformasjon'}
 		>

--- a/apps/dolly-frontend/src/main/js/src/components/bestillingsveileder/stegVelger/steg/steg1/paneler/Personinformasjon.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/bestillingsveileder/stegVelger/steg/steg1/paneler/Personinformasjon.tsx
@@ -17,6 +17,23 @@ import {
 	initialVergemaal,
 } from '~/components/fagsystem/pdlf/form/initialValues'
 
+const ignoreKeysTestnorge = [
+	'alder',
+	'foedsel',
+	'doedsdato',
+	'statsborgerskap',
+	'innvandretFraLand',
+	'utvandretTilLand',
+	'identtype',
+	'kjonn',
+	'navn',
+	'telefonnummer',
+	'vergemaal',
+	'fullmakt',
+	'sikkerhetstiltak',
+	'tilrettelagtKommunikasjon',
+]
+
 // @ts-ignore
 export const PersoninformasjonPanel = ({ stateModifier, testnorgeIdent }) => {
 	const sm = stateModifier(PersoninformasjonPanel.initialValues)
@@ -33,7 +50,13 @@ export const PersoninformasjonPanel = ({ stateModifier, testnorgeIdent }) => {
 			<Panel
 				heading={PersoninformasjonPanel.heading}
 				startOpen
-				checkAttributeArray={() => sm.batchAdd('identtype')}
+				checkAttributeArray={() => {
+					if (sm.attrs.utenlandskBankkonto.checked) {
+						sm.batchAdd([...ignoreKeysTestnorge, 'norskBankkonto'])
+					} else {
+						sm.batchAdd([...ignoreKeysTestnorge, 'utenlandskBankkonto'])
+					}
+				}}
 				uncheckAttributeArray={sm.batchRemove}
 				iconType={'personinformasjon'}
 			>
@@ -58,7 +81,13 @@ export const PersoninformasjonPanel = ({ stateModifier, testnorgeIdent }) => {
 		<Panel
 			heading={PersoninformasjonPanel.heading}
 			startOpen
-			checkAttributeArray={() => sm.batchAdd('identtype')}
+			checkAttributeArray={() => {
+				if (sm.attrs.utenlandskBankkonto.checked) {
+					sm.batchAdd(['identtype', 'norskBankkonto'])
+				} else {
+					sm.batchAdd(['identtype', 'utenlandskBankkonto'])
+				}
+			}}
 			uncheckAttributeArray={sm.batchRemove}
 			iconType={'personinformasjon'}
 		>

--- a/apps/dolly-frontend/src/main/js/src/components/bestillingsveileder/stegVelger/steg/steg3/IdentVelger.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/bestillingsveileder/stegVelger/steg/steg3/IdentVelger.tsx
@@ -87,13 +87,6 @@ export const IdentVelger = ({ formikBag }: Form) => {
 					handleIdentTypeChange((e.target as HTMLTextAreaElement).value as IdentType)
 				}
 			/>
-
-			{erArenaBestilling && type === IdentType.SYNTETISK && (
-				<AlertStripeAdvarsel>
-					Syntetisk ident er foreløpig ikke støttet for Arbeidsytelser (Arena), velg standard ident
-					for gyldig bestilling.
-				</AlertStripeAdvarsel>
-			)}
 		</IdentVelgerField>
 	)
 }

--- a/apps/dolly-frontend/src/main/js/src/components/bestillingsveileder/stegVelger/steg/steg3/IdentVelger.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/bestillingsveileder/stegVelger/steg/steg3/IdentVelger.tsx
@@ -4,7 +4,6 @@ import styled from 'styled-components'
 import { RadioPanelGruppe } from 'nav-frontend-skjema'
 import Hjelpetekst from '~/components/hjelpetekst'
 import { FormikProps } from 'formik'
-import { AlertStripeAdvarsel } from 'nav-frontend-alertstriper'
 
 type Form = {
 	formikBag: FormikProps<{}>
@@ -55,8 +54,6 @@ const informasjonstekst =
 	'Om ikke lenge kommer Dolly til å gå fra å opprette personer som har ekte identifikasjonsnummer til å kun opprette personer med syntetisk identifikasjonsnummer. Frem til det vil det være mulig å velge selv om man ønsker å opprette personene med standard eller syntetisk identifikasjonsnummer. Siden syntetisk identifikasjonsnummer en dag kommer til å bli den nye standarden oppfordrer vi alle til å ta dette i bruk allerede nå.'
 
 export const IdentVelger = ({ formikBag }: Form) => {
-	const erArenaBestilling = formikBag.values.hasOwnProperty('arenaforvalter')
-
 	const [type, setType] = useState(
 		_get(formikBag.values, `pdldata.opprettNyPerson.syntetisk`) === true
 			? IdentType.SYNTETISK


### PR DESCRIPTION
Fiks for "Velg alle" og "Fjern alle" knappene i steg 1 i bestilling (disse funket ikke i det hele tatt).

Fjernet også arena-advarsel for nav-syntetisk ident da det støttes nå.