### PR TITLE
Dolly frontend - Vise land utenlandskadresse

### DIFF
--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/visning/partials/UtenlandskAdresse.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/visning/partials/UtenlandskAdresse.tsx
@@ -2,6 +2,11 @@ import React from 'react'
 import { TitleValue } from '~/components/ui/titleValue/TitleValue'
 import Formatters from '~/utils/DataFormatter'
 import { AdresseKodeverk } from '~/config/kodeverk'
+import KodeverkConnector from '~/components/kodeverk/KodeverkConnector'
+import {
+	Kodeverk,
+	KodeverkValues,
+} from '~/pages/gruppe/PersonVisning/PersonMiljoeinfo/PdlDataTyper'
 
 type AdresseData = {
 	adresse: {
@@ -41,7 +46,15 @@ export const UtenlandskAdresse = ({ adresse, idx }: AdresseData) => {
 				<TitleValue title="Postnummer og -navn" value={postboksNummerNavn} />
 				<TitleValue title="Postkode" value={postkode} />
 				<TitleValue title="By eller sted" value={bySted} />
-				<TitleValue title="Land" value={landkode} kodeverk={AdresseKodeverk.StatsborgerskapLand} />
+				<TitleValue title="Land">
+					{landkode && (
+						<KodeverkConnector navn="StatsborgerskapFreg" value={landkode}>
+							{(v: Kodeverk, verdi: KodeverkValues) => (
+								<span>{verdi ? verdi.label : landkode}</span>
+							)}
+						</KodeverkConnector>
+					)}
+				</TitleValue>
 				<TitleValue title="Bygg-/leilighetsinfo" value={bygningEtasjeLeilighet} />
 				<TitleValue title="Region/distrikt/område" value={regionDistriktOmraade} />
 				<TitleValue title="Angitt flyttedato" value={Formatters.formatDate(angittFlyttedato)} />

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/visning/partials/UtenlandskAdresse.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/visning/partials/UtenlandskAdresse.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { TitleValue } from '~/components/ui/titleValue/TitleValue'
 import Formatters from '~/utils/DataFormatter'
-import { AdresseKodeverk } from '~/config/kodeverk'
 import KodeverkConnector from '~/components/kodeverk/KodeverkConnector'
 import {
 	Kodeverk,


### PR DESCRIPTION
Oppdatert utenlandsk adresse til å vise navnet på landet og ikke bare landkode.