### PR TITLE
Dolly frontend - Byttet til fritekst sok

### DIFF
--- a/apps/dolly-frontend/src/main/js/src/components/adresseVelger/AdresseSok.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/adresseVelger/AdresseSok.tsx
@@ -9,7 +9,7 @@ import styled from 'styled-components'
 import { Søkeknapp } from 'nav-frontend-ikonknapper'
 
 type Props = {
-	onSubmit: (search: { adressenavn?: string; postnummer?: string; kommunenummer?: string }) => void
+	onSubmit: (search: { fritekst?: string; postnummer?: string; kommunenummer?: string }) => void
 	loading?: boolean
 }
 
@@ -21,7 +21,7 @@ const HeaderGroup = styled.div`
 `
 
 export default ({ onSubmit, loading = false }: Props) => {
-	const [adressenavn, setAdressenavn] = useState<string>('')
+	const [fritekst, setFritekst] = useState<string>('')
 	const [postnummer, setPostnummer] = useState<string>(null)
 	const [kommunenummer, setKommunenummer] = useState<string>(null)
 
@@ -38,8 +38,8 @@ export default ({ onSubmit, loading = false }: Props) => {
 				<DollyTextInput
 					name="adressenavn"
 					label="Adressenavn"
-					value={adressenavn}
-					onChange={(e: any) => setAdressenavn(e.target.value)}
+					value={fritekst}
+					onChange={(e: any) => setFritekst(e.target.value)}
 				/>
 				<DollySelect
 					name="postnummer"
@@ -59,7 +59,7 @@ export default ({ onSubmit, loading = false }: Props) => {
 				/>
 			</InputGroup>
 			<Søkeknapp
-				onClick={() => onSubmit({ adressenavn, postnummer, kommunenummer })}
+				onClick={() => onSubmit({ fritekst, postnummer, kommunenummer })}
 				disabled={loading}
 				spinner={loading}
 			>

--- a/apps/dolly-frontend/src/main/js/src/components/adresseVelger/AdresseVelger.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/adresseVelger/AdresseVelger.tsx
@@ -12,7 +12,7 @@ const StyledAdresseVelger = styled.div`
 	margin-bottom: 20px;
 `
 type Search = {
-	adressenavn?: string
+	fritekst?: string
 	postnummer?: string
 	kommunenummer?: string
 }


### PR DESCRIPTION
Endret adressesøk for vegadresse til å søke etter fritekst i stedet for adressenavn. Dette gjør at du ikke må ha fullstendig match for adressenavn når du søker.