### PR TITLE
Dollt frontend/kollapse inntekt visninger

### DIFF
--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/inntektstub/visning/Visning.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/inntektstub/visning/Visning.tsx
@@ -87,7 +87,7 @@ export const InntektstubVisning = ({ liste, loading }: InntekstubVisning) => {
 		<div>
 			<SubOverskrift label="A-ordningen (Inntektstub)" iconKind="inntektstub" />
 			<ErrorBoundary>
-				{sortedData?.length > 3 ? (
+				{numInntekter > 3 ? (
 					<Panel heading={`Inntektsinsinformasjon (${inntektsperiode})`}>
 						<InntektsinformasjonVisning sortedData={sortedData} numInntekter={numInntekter} />
 					</Panel>

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/inntektstub/visning/Visning.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/inntektstub/visning/Visning.tsx
@@ -9,10 +9,16 @@ import { ForskuddstrekkVisning } from './partials/ForskuddstrekkVisning'
 import { ArbeidsforholdVisning } from './partials/ArbeidsforholdVisning'
 import { ErrorBoundary } from '~/components/ui/appError/ErrorBoundary'
 import Formatters from '~/utils/DataFormatter'
+import Panel from '~/components/ui/panel/Panel'
 
 type InntekstubVisning = {
 	liste?: Array<Inntektsinformasjon>
 	loading?: boolean
+}
+
+type InfoProps = {
+	sortedData: Array<Inntektsinformasjon>
+	numInntekter: number
 }
 
 type Inntektsinformasjon = {
@@ -33,43 +39,61 @@ const getHeader = (data: Inntektsinformasjon) => {
 	}`
 }
 
+const InntektsinformasjonVisning = ({ sortedData, numInntekter }: InfoProps) => {
+	return (
+		<DollyFieldArray
+			header="Inntektsinformasjon"
+			getHeader={getHeader}
+			data={sortedData}
+			expandable={numInntekter > 1}
+		>
+			{(inntektsinformasjon: Inntektsinformasjon) => (
+				<React.Fragment>
+					<div className="person-visning_content">
+						<TitleValue title="År/måned" value={inntektsinformasjon.aarMaaned} />
+						<TitleValue
+							title="Rapporteringstidspunkt"
+							value={Formatters.formatDateTime(inntektsinformasjon.rapporteringsdato)}
+						/>
+						<TitleValue title="Virksomhet (orgnr/id)" value={inntektsinformasjon.virksomhet} />
+						<TitleValue
+							title="Opplysningspliktig (orgnr/id)"
+							value={inntektsinformasjon.opplysningspliktig}
+						/>
+					</div>
+					<InntektVisning data={inntektsinformasjon.inntektsliste} />
+					<FradragVisning data={inntektsinformasjon.fradragsliste} />
+					<ForskuddstrekkVisning data={inntektsinformasjon.forskuddstrekksliste} />
+					<ArbeidsforholdVisning data={inntektsinformasjon.arbeidsforholdsliste} />
+				</React.Fragment>
+			)}
+		</DollyFieldArray>
+	)
+}
+
 export const InntektstubVisning = ({ liste, loading }: InntekstubVisning) => {
 	if (loading) return <Loading label="Laster Inntektstub-data" />
 	if (!liste) return null
 
+	const foersteAar = liste[0]?.aarMaaned?.substring(0, 4)
+
 	const sortedData = liste.slice().reverse()
+	const numInntekter = sortedData?.length
+
+	const sisteAar = sortedData[0]?.aarMaaned?.substring(0, 4)
+	const inntektsperiode = foersteAar === sisteAar ? foersteAar : `${foersteAar} - ${sisteAar}`
 
 	return (
 		<div>
 			<SubOverskrift label="A-ordningen (Inntektstub)" iconKind="inntektstub" />
 			<ErrorBoundary>
-				<DollyFieldArray
-					header="Inntektsinformasjon"
-					getHeader={getHeader}
-					data={sortedData}
-					expandable={sortedData.length > 1}
-				>
-					{(inntektsinformasjon: Inntektsinformasjon) => (
-						<React.Fragment>
-							<div className="person-visning_content">
-								<TitleValue title="År/måned" value={inntektsinformasjon.aarMaaned} />
-								<TitleValue
-									title="Rapporteringstidspunkt"
-									value={Formatters.formatDateTime(inntektsinformasjon.rapporteringsdato)}
-								/>
-								<TitleValue title="Virksomhet (orgnr/id)" value={inntektsinformasjon.virksomhet} />
-								<TitleValue
-									title="Opplysningspliktig (orgnr/id)"
-									value={inntektsinformasjon.opplysningspliktig}
-								/>
-							</div>
-							<InntektVisning data={inntektsinformasjon.inntektsliste} />
-							<FradragVisning data={inntektsinformasjon.fradragsliste} />
-							<ForskuddstrekkVisning data={inntektsinformasjon.forskuddstrekksliste} />
-							<ArbeidsforholdVisning data={inntektsinformasjon.arbeidsforholdsliste} />
-						</React.Fragment>
-					)}
-				</DollyFieldArray>
+				{sortedData?.length > 3 ? (
+					<Panel heading={`Inntektsinsinformasjon (${inntektsperiode})`}>
+						<InntektsinformasjonVisning sortedData={sortedData} numInntekter={numInntekter} />
+					</Panel>
+				) : (
+					<InntektsinformasjonVisning sortedData={sortedData} numInntekter={numInntekter} />
+				)}
 			</ErrorBoundary>
 		</div>
 	)

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/inntektstub/visning/Visning.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/inntektstub/visning/Visning.tsx
@@ -87,7 +87,8 @@ export const InntektstubVisning = ({ liste, loading }: InntekstubVisning) => {
 		<div>
 			<SubOverskrift label="A-ordningen (Inntektstub)" iconKind="inntektstub" />
 			<ErrorBoundary>
-				{numInntekter > 3 ? (
+				{numInntekter > 5 ? (
+					// @ts-ignore
 					<Panel heading={`Inntektsinsinformasjon (${inntektsperiode})`}>
 						<InntektsinformasjonVisning sortedData={sortedData} numInntekter={numInntekter} />
 					</Panel>

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/pensjon/visning/PensjonVisning.js
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/pensjon/visning/PensjonVisning.js
@@ -19,7 +19,6 @@ export const PensjonVisning = ({ data, loading }) => {
 			<SubOverskrift label="Pensjonsgivende inntekt (POPP)" iconKind="pensjon" />
 
 			<Panel heading={`Pensjonsgivende inntekter (${foerste} - ${siste})`}>
-				{' '}
 				<DollyFieldArray data={data.inntekter} nested>
 					{(inntekt, idx) => (
 						<div className="person-visning_content" key={idx}>

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/sigrunstub/visning/Visning.js
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/sigrunstub/visning/Visning.js
@@ -4,56 +4,75 @@ import { TitleValue } from '~/components/ui/titleValue/TitleValue'
 import { DollyFieldArray } from '~/components/ui/form/fieldArray/DollyFieldArray'
 import Loading from '~/components/ui/loading/Loading'
 import { ErrorBoundary } from '~/components/ui/appError/ErrorBoundary'
+import Panel from '~/components/ui/panel/Panel'
+
+const FastlandVisning = ({ data }) => {
+	if (!data || data.length === 0) return false
+	return (
+		<DollyFieldArray header="Fastlands-Norge" data={data} nested expandable>
+			{(inntekt, idx) => (
+				<React.Fragment key={idx}>
+					<TitleValue title="Inntektsår" value={inntekt.inntektsaar} />
+					<TitleValue title="Tjeneste" value={inntekt.tjeneste} />
+					<TitleValue title="Type inntekt" value={inntekt.grunnlag} kodeverk={inntekt.tjeneste} />
+					<TitleValue title="Beløp" value={inntekt.verdi} />
+				</React.Fragment>
+			)}
+		</DollyFieldArray>
+	)
+}
+
+const SvalbardVisning = ({ data }) => {
+	if (!data || data.length === 0) return false
+	return (
+		<DollyFieldArray header="Svalbard" data={data} nested>
+			{(inntekt, idx) => (
+				<React.Fragment key={idx}>
+					<TitleValue title="Inntektsår" value={inntekt.inntektsaar} />
+					<TitleValue title="Tjeneste" value={inntekt.tjeneste} />
+					<TitleValue title="Type inntekt" value={inntekt.grunnlag} kodeverk={inntekt.tjeneste} />
+					<TitleValue title="Beløp" value={inntekt.verdi} />
+				</React.Fragment>
+			)}
+		</DollyFieldArray>
+	)
+}
+
+const getInntektsperiode = (fastlandsData, svalbardsData) => {
+	const fastland = fastlandsData?.map((f) => f.inntektsaar)
+	const svalbard = svalbardsData?.map((s) => s.inntektsaar)
+	const foersteAar = Math.min(...fastland.concat(...svalbard))
+	const sisteAar = Math.max(...fastland.concat(...svalbard))
+	return foersteAar === sisteAar ? foersteAar : `${foersteAar} - ${sisteAar}`
+}
 
 export const SigrunstubVisning = ({ data, loading, visTittel = true }) => {
 	if (loading) return <Loading label="Laster sigrunstub-data" />
 	if (!data || data.length === 0) return false
-	const grunnlag = data[0].grunnlag.length > 0
-	const svalbardGrunnlag = data[0].svalbardGrunnlag.length > 0
+	const grunnlag = data[0].grunnlag
+	const svalbardGrunnlag = data[0].svalbardGrunnlag
 
 	const sortedData = (data) => (Array.isArray(data) ? data.slice().reverse() : data)
 
+	const inntektsperiode = getInntektsperiode(grunnlag, svalbardGrunnlag)
 	return (
 		<div>
 			{visTittel && <SubOverskrift label="Skatteoppgjør (Sigrun)" iconKind="sigrun" />}
-			<div className="person-visning_content">
-				{grunnlag && (
-					<ErrorBoundary>
-						<DollyFieldArray header="Fastlands-Norge" data={sortedData(data[0].grunnlag)} nested>
-							{(inntekt, idx) => (
-								<React.Fragment key={idx}>
-									<TitleValue title="Inntektsår" value={inntekt.inntektsaar} />
-									<TitleValue title="Tjeneste" value={inntekt.tjeneste} />
-									<TitleValue
-										title="Type inntekt"
-										value={inntekt.grunnlag}
-										kodeverk={inntekt.tjeneste}
-									/>
-									<TitleValue title="Beløp" value={inntekt.verdi} />
-								</React.Fragment>
-							)}
-						</DollyFieldArray>
-					</ErrorBoundary>
+			<ErrorBoundary>
+				{grunnlag?.length + svalbardGrunnlag?.length > 5 ? (
+					<Panel heading={`Skatteoppgjør (${inntektsperiode})`}>
+						<div className="person-visning_content">
+							<FastlandVisning data={sortedData(grunnlag)} />
+							<SvalbardVisning data={sortedData(svalbardGrunnlag)} />
+						</div>
+					</Panel>
+				) : (
+					<div className="person-visning_content">
+						<FastlandVisning data={sortedData(grunnlag)} />
+						<SvalbardVisning data={sortedData(svalbardGrunnlag)} />
+					</div>
 				)}
-				{svalbardGrunnlag && (
-					<ErrorBoundary>
-						<DollyFieldArray header="Svalbard" data={sortedData(data[0].svalbardGrunnlag)} nested>
-							{(inntekt, idx) => (
-								<React.Fragment key={idx}>
-									<TitleValue title="Inntektsår" value={inntekt.inntektsaar} />
-									<TitleValue title="Tjeneste" value={inntekt.tjeneste} />
-									<TitleValue
-										title="Type inntekt"
-										value={inntekt.grunnlag}
-										kodeverk={inntekt.tjeneste}
-									/>
-									<TitleValue title="Beløp" value={inntekt.verdi} />
-								</React.Fragment>
-							)}
-						</DollyFieldArray>
-					</ErrorBoundary>
-				)}
-			</div>
+			</ErrorBoundary>
 		</div>
 	)
 }


### PR DESCRIPTION
Har oppdatert vising for sigrunstub og inntektsub. Hvis det nå er mer enn 5 inntekter så blir visningen kollapset inn i et panel. 