### PR TITLE
Dolly frontend/ fiks for tre WCAG feil

### DIFF
--- a/apps/dolly-frontend/src/main/js/src/components/bestilling/sammendrag/miljoeStatus/fagsystemStatus/IdentList.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/bestilling/sammendrag/miljoeStatus/fagsystemStatus/IdentList.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { useToggle } from 'react-use'
-import ExpandButton from '~/components/ui/button/ExpandButton'
+import ExpandButton from '~/components/ui/button/ExpandButton/ExpandButton'
 
 function IdentList({ identer }: { identer: string[] }) {
 	return (

--- a/apps/dolly-frontend/src/main/js/src/components/ui/button/ExpandButton/ExpandButton.less
+++ b/apps/dolly-frontend/src/main/js/src/components/ui/button/ExpandButton/ExpandButton.less
@@ -1,0 +1,7 @@
+
+.expandButton{
+  font-size: 0;
+  span{
+    padding: 0;
+  }
+}

--- a/apps/dolly-frontend/src/main/js/src/components/ui/button/ExpandButton/ExpandButton.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/ui/button/ExpandButton/ExpandButton.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
-import Button from './Button'
+import Button from '../Button'
+import './ExpandButton.less'
 
 interface ExpandButtonProps {
 	onClick: () => void
@@ -13,5 +14,16 @@ export default function ExpandButton({
 	onClick,
 }: ExpandButtonProps) {
 	const iconType = expanded ? 'chevron-up' : 'chevron-down'
-	return <Button iconSize={14} kind={iconType} onClick={onClick} disabled={disabled} />
+	return (
+		<Button
+			className={'expandButton'}
+			iconSize={14}
+			kind={iconType}
+			onClick={onClick}
+			disabled={disabled}
+			aria-label={expanded ? 'Lukk' : 'Åpne'}
+		>
+			{expanded ? 'Lukk' : 'Åpne'}
+		</Button>
+	)
 }

--- a/apps/dolly-frontend/src/main/js/src/components/ui/dollyTable/table/TableRow.js
+++ b/apps/dolly-frontend/src/main/js/src/components/ui/dollyTable/table/TableRow.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import cn from 'classnames'
 import Column from './TableColumn'
-import ExpandButton from '~/components/ui/button/ExpandButton'
+import ExpandButton from '~/components/ui/button/ExpandButton/ExpandButton'
 import { resetNavigering } from '~/ducks/finnPerson'
 import { useDispatch } from 'react-redux'
 

--- a/apps/dolly-frontend/src/main/js/src/components/ui/form/fieldArray/ExpandableBlokk.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/ui/form/fieldArray/ExpandableBlokk.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import cn from 'classnames'
 // @ts-ignore
-import ExpandButton from '~/components/ui/button/ExpandButton'
+import ExpandButton from '~/components/ui/button/ExpandButton/ExpandButton'
 
 type NumberingProps = {
 	idx: number

--- a/apps/dolly-frontend/src/main/js/src/components/ui/icon/Icon.js
+++ b/apps/dolly-frontend/src/main/js/src/components/ui/icon/Icon.js
@@ -189,7 +189,7 @@ export default function Icon({
 
 	return (
 		<ErrorBoundary>
-			<SVG src={icons[kind]} className={cssClass} style={styleObj} title={title}>
+			<SVG src={icons[kind]} className={cssClass} style={styleObj} title={title} role={'img'}>
 				<img
 					src="../assets/icons/nav-ikoner/filled/SVG/01-edition/link-broken-1.svg"
 					alt="fallback"

--- a/apps/dolly-frontend/src/main/js/src/components/ui/panel/Panel.js
+++ b/apps/dolly-frontend/src/main/js/src/components/ui/panel/Panel.js
@@ -3,7 +3,7 @@ import { useToggle } from 'react-use'
 import cn from 'classnames'
 import Hjelpetekst from '~/components/hjelpetekst'
 import Icon from '~/components/ui/icon/Icon'
-import ExpandButton from '~/components/ui/button/ExpandButton'
+import ExpandButton from '~/components/ui/button/ExpandButton/ExpandButton'
 import LinkButton from '~/components/ui/button/LinkButton/LinkButton'
 
 import './Panel.less'

--- a/apps/dolly-frontend/src/main/js/src/pages/testnorgePage/search/optionsPanel/OptionsPanel.tsx
+++ b/apps/dolly-frontend/src/main/js/src/pages/testnorgePage/search/optionsPanel/OptionsPanel.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { useToggle } from 'react-use'
-import ExpandButton from '~/components/ui/button/ExpandButton'
+import ExpandButton from '~/components/ui/button/ExpandButton/ExpandButton'
 import './OptionsPanel.less'
 
 type OptionsPanelProps = {

--- a/apps/dolly-frontend/src/main/js/src/pages/testnorgePage/search/partials/Identer.tsx
+++ b/apps/dolly-frontend/src/main/js/src/pages/testnorgePage/search/partials/Identer.tsx
@@ -25,6 +25,7 @@ export const Identer: React.FC<IdentSearchProps> = ({ formikBag }: IdentSearchPr
 											name={`${identerPath}.${index}`}
 											className="skjemaelement__input"
 											placeholder={'Ikke spesifisert'}
+											label={'Fødselsnummer eller D-dummer'}
 											type="text"
 											style={{ width: '220px' }}
 										/>

--- a/apps/dolly-frontend/src/main/js/src/pages/ui/index.js
+++ b/apps/dolly-frontend/src/main/js/src/pages/ui/index.js
@@ -7,7 +7,7 @@ import Button from '~/components/ui/button/Button'
 import FavoriteButton from '~/components/ui/button/FavoriteButton/FavoriteButton'
 import NavButton from '~/components/ui/button/NavButton/NavButton'
 import LinkButton from '~/components/ui/button/LinkButton/LinkButton'
-import ExpandButton from '~/components/ui/button/ExpandButton'
+import ExpandButton from '~/components/ui/button/ExpandButton/ExpandButton'
 import { PersonIBrukButton } from '~/components/ui/button/PersonIBrukButton/PersonIBrukButton'
 
 // Loading


### PR DESCRIPTION
FIks for følgende wcag feil:
- 1.1.1 Ikke-tekstlig innhold - mangler role = 'img' on SVG / svg mangler Aria under Person. Seks ulike feil
- 4.1.2 Navn, rolle, verdi - ingen knappetekst. Fire steder
- 3.3.2 Ledetekster eller instruksjoner - plassholder brukt til merkelapp