### PR TITLE
Synt vedtakshistorikk service/oppretter tag på partner også

### DIFF
--- a/apps/synt-vedtakshistorikk-service/src/main/java/no/nav/testnav/apps/syntvedtakshistorikkservice/provider/BatchController.java
+++ b/apps/synt-vedtakshistorikk-service/src/main/java/no/nav/testnav/apps/syntvedtakshistorikkservice/provider/BatchController.java
@@ -21,7 +21,7 @@ import static no.nav.testnav.apps.syntvedtakshistorikkservice.service.util.Servi
 @Slf4j
 @Getter
 @Component
-//@EnableScheduling
+@EnableScheduling
 @RequiredArgsConstructor
 public class BatchController {
 

--- a/apps/synt-vedtakshistorikk-service/src/main/java/no/nav/testnav/apps/syntvedtakshistorikkservice/provider/BatchController.java
+++ b/apps/synt-vedtakshistorikk-service/src/main/java/no/nav/testnav/apps/syntvedtakshistorikkservice/provider/BatchController.java
@@ -63,7 +63,6 @@ public class BatchController {
                         MAKSIMUM_ALDER,
                         false
                 );
-//                .stream().map(PersonDTO::getIdent).toList();
 
         if (tagsService.opprettetTagsPaaIdenterOgPartner(personer)) {
             arenaForvalterService.opprettArbeidssoekereUtenVedtak(personer.stream().map(PersonDTO::getIdent).toList(), miljoe);

--- a/apps/synt-vedtakshistorikk-service/src/main/java/no/nav/testnav/apps/syntvedtakshistorikkservice/provider/BatchController.java
+++ b/apps/synt-vedtakshistorikk-service/src/main/java/no/nav/testnav/apps/syntvedtakshistorikkservice/provider/BatchController.java
@@ -57,16 +57,16 @@ public class BatchController {
      */
     @Scheduled(cron = "0 30 0 * * *")
     public void genererBrukereMedOppfoelgingBatch() {
-        var identer = identService.getUtvalgteIdenterIAldersgruppe(
+        var personer = identService.getUtvalgteIdenterIAldersgruppe(
                         antallBrukere,
                         MINIMUM_ALDER,
                         MAKSIMUM_ALDER,
                         false
-                )
-                .stream().map(PersonDTO::getIdent).toList();
+                );
+//                .stream().map(PersonDTO::getIdent).toList();
 
-        if (tagsService.opprettetTagsPaaIdenter(identer)) {
-            arenaForvalterService.opprettArbeidssoekereUtenVedtak(identer, miljoe);
+        if (tagsService.opprettetTagsPaaIdenterOgPartner(personer)) {
+            arenaForvalterService.opprettArbeidssoekereUtenVedtak(personer.stream().map(PersonDTO::getIdent).toList(), miljoe);
         }
     }
 

--- a/apps/synt-vedtakshistorikk-service/src/main/java/no/nav/testnav/apps/syntvedtakshistorikkservice/provider/BrukerController.java
+++ b/apps/synt-vedtakshistorikk-service/src/main/java/no/nav/testnav/apps/syntvedtakshistorikkservice/provider/BrukerController.java
@@ -38,17 +38,16 @@ public class BrukerController {
     ) {
         validateMiljoe(syntetiserArenaRequest.getMiljoe());
 
-        var identer = identService.getUtvalgteIdenterIAldersgruppe(
+        var personer = identService.getUtvalgteIdenterIAldersgruppe(
                         syntetiserArenaRequest.getAntallNyeIdenter(),
                         MINIMUM_ALDER,
                         MAKSIMUM_ALDER,
                         false
-                )
-                .stream().map(PersonDTO::getIdent).toList();
+                );
 
-        if (tagsService.opprettetTagsPaaIdenter(identer)) {
+        if (tagsService.opprettetTagsPaaIdenterOgPartner(personer)) {
             return arenaForvalterService.opprettArbeidssoekereUtenVedtak(
-                    identer,
+                    personer.stream().map(PersonDTO::getIdent).toList(),
                     syntetiserArenaRequest.getMiljoe());
         } else {
             return Collections.emptyMap();

--- a/apps/synt-vedtakshistorikk-service/src/main/java/no/nav/testnav/apps/syntvedtakshistorikkservice/service/ArenaDagpengerService.java
+++ b/apps/synt-vedtakshistorikk-service/src/main/java/no/nav/testnav/apps/syntvedtakshistorikkservice/service/ArenaDagpengerService.java
@@ -46,7 +46,7 @@ public class ArenaDagpengerService {
             var dato = LocalDate.now().minusMonths(rand.nextInt(Math.toIntExact(ChronoUnit.MONTHS.between(minDate, LocalDate.now()))));
             if (inntektService.opprettetInntektPaaIdentFoerDato(ident.getIdent(), dato)) {
                 try {
-                    arenaForvalterService.opprettArbeidssoekerDagpenger(ident.getIdent(), miljoe, dato);
+                    arenaForvalterService.opprettArbeidssoekerDagpenger(ident, miljoe, dato);
                 } catch (Exception e) {
                     log.error(e.getMessage());
                     inntektService.deleteInntekterPaaIdent(ident.getIdent());
@@ -58,7 +58,10 @@ public class ArenaDagpengerService {
             }
         }
         if (!responses.isEmpty()) {
-            tagsService.opprettetTagsPaaIdenter(new ArrayList<>(responses.keySet()));
+            var identer = new ArrayList<>(responses.keySet());
+            var personer = utvalgteIdenter.stream().filter(person -> identer.contains(person.getIdent())).toList();
+            //TODO flytte opprettelse tags til før innsending
+            tagsService.opprettetTagsPaaIdenterOgPartner(personer);
         }
         return responses;
     }

--- a/apps/synt-vedtakshistorikk-service/src/main/java/no/nav/testnav/apps/syntvedtakshistorikkservice/service/ArenaDagpengerService.java
+++ b/apps/synt-vedtakshistorikk-service/src/main/java/no/nav/testnav/apps/syntvedtakshistorikkservice/service/ArenaDagpengerService.java
@@ -60,7 +60,7 @@ public class ArenaDagpengerService {
         if (!responses.isEmpty()) {
             var identer = new ArrayList<>(responses.keySet());
             var personer = utvalgteIdenter.stream().filter(person -> identer.contains(person.getIdent())).toList();
-            //TODO flytte opprettelse tags til før innsending
+            //TODO flytte opprettelse tags til før innsending av dagpenger
             tagsService.opprettetTagsPaaIdenterOgPartner(personer);
         }
         return responses;

--- a/apps/synt-vedtakshistorikk-service/src/main/java/no/nav/testnav/apps/syntvedtakshistorikkservice/service/ArenaForvalterService.java
+++ b/apps/synt-vedtakshistorikk-service/src/main/java/no/nav/testnav/apps/syntvedtakshistorikkservice/service/ArenaForvalterService.java
@@ -12,6 +12,7 @@ import no.nav.testnav.libs.domain.dto.arena.testnorge.brukere.Kvalifiseringsgrup
 import no.nav.testnav.libs.domain.dto.arena.testnorge.brukere.NyBruker;
 import no.nav.testnav.libs.domain.dto.arena.testnorge.brukere.NyEndreInnsatsbehov;
 import no.nav.testnav.libs.domain.dto.arena.testnorge.vedtak.*;
+import no.nav.testnav.libs.dto.personsearchservice.v1.PersonDTO;
 import no.nav.testnav.libs.dto.syntvedtakshistorikkservice.v1.DagpengerRequestDTO;
 import no.nav.testnav.libs.dto.syntvedtakshistorikkservice.v1.DagpengerResponseDTO;
 import org.apache.commons.lang3.StringUtils;
@@ -98,24 +99,24 @@ public class ArenaForvalterService {
     }
 
     public void opprettArbeidssoekerVedtakshistorikk(
-            String personident,
+            PersonDTO person,
             String miljoe,
             NyttVedtak senesteVedtak,
             LocalDate aktiveringsDato
     ) {
         if (senesteVedtak.getRettighetType() == RettighetType.AAP) {
-            opprettArbeidssoekerAap(personident, miljoe, ((NyttVedtakAap) senesteVedtak).getAktivitetsfase(), aktiveringsDato);
+            opprettArbeidssoekerAap(person, miljoe, ((NyttVedtakAap) senesteVedtak).getAktivitetsfase(), aktiveringsDato);
         } else if (senesteVedtak.getRettighetType() == RettighetType.TILTAK) {
-            opprettArbeidssoeker(personident, miljoe, random.nextBoolean() ? Kvalifiseringsgrupper.BATT : Kvalifiseringsgrupper.BFORM, aktiveringsDato);
+            opprettArbeidssoeker(person, miljoe, random.nextBoolean() ? Kvalifiseringsgrupper.BATT : Kvalifiseringsgrupper.BFORM, aktiveringsDato);
         } else if (senesteVedtak.getRettighetType() == RettighetType.TILLEGG) {
-            opprettArbeidssoeker(personident, miljoe, random.nextBoolean() ? Kvalifiseringsgrupper.BATT : Kvalifiseringsgrupper.BFORM, aktiveringsDato);
+            opprettArbeidssoeker(person, miljoe, random.nextBoolean() ? Kvalifiseringsgrupper.BATT : Kvalifiseringsgrupper.BFORM, aktiveringsDato);
         } else {
             throw new VedtakshistorikkException("Mangler støtte for rettighettype: " + senesteVedtak.getRettighetType());
         }
     }
 
     public Kvalifiseringsgrupper opprettArbeidssoekerTiltaksdeltakelse(
-            String personident,
+            PersonDTO person,
             String miljoe,
             RettighetType rettighetType,
             LocalDate aktiveringsDato
@@ -131,18 +132,18 @@ public class ArenaForvalterService {
             throw new VedtakshistorikkException("Mangler støtte for rettighettype: " + rettighetType);
         }
 
-        opprettArbeidssoeker(personident, miljoe, kvalifiseringsgruppe, aktiveringsDato);
+        opprettArbeidssoeker(person, miljoe, kvalifiseringsgruppe, aktiveringsDato);
         return kvalifiseringsgruppe;
     }
 
     private void opprettArbeidssoekerAap(
-            String personident,
+            PersonDTO person,
             String miljoe,
             String aktivitetsfase,
             LocalDate aktiveringsDato
     ) {
         if (isNull(aktivitetsfase) || aktivitetsfase.isBlank()) {
-            opprettArbeidssoeker(personident, miljoe, Kvalifiseringsgrupper.BATT, aktiveringsDato);
+            opprettArbeidssoeker(person, miljoe, Kvalifiseringsgrupper.BATT, aktiveringsDato);
         } else {
             var formidlingsgruppe = arenaBrukerUtils.velgFormidlingsgruppeBasertPaaAktivitetsfase(aktivitetsfase);
             var kvalifiseringsgruppe = arenaBrukerUtils.velgKvalifiseringsgruppeBasertPaaFormidlingsgruppe(aktivitetsfase, formidlingsgruppe);
@@ -151,7 +152,7 @@ public class ArenaForvalterService {
             while (kvalifiseringsgruppe == Kvalifiseringsgrupper.BKART){
                 kvalifiseringsgruppe = arenaBrukerUtils.velgKvalifiseringsgruppeBasertPaaFormidlingsgruppe(aktivitetsfase, formidlingsgruppe);
             }
-            opprettArbeidssoeker(personident, miljoe, kvalifiseringsgruppe, aktiveringsDato);
+            opprettArbeidssoeker(person, miljoe, kvalifiseringsgruppe, aktiveringsDato);
 
             if (formidlingsgruppe.equals("IARBS")) {
                 try {
@@ -160,42 +161,42 @@ public class ArenaForvalterService {
                     Thread.currentThread().interrupt();
                     log.warn("Thread interrupted");
                 }
-                endreFormidlingsgruppeForBrukerTilIarbs(personident, miljoe, kvalifiseringsgruppe);
+                endreFormidlingsgruppeForBrukerTilIarbs(person.getIdent(), miljoe, kvalifiseringsgruppe);
             }
         }
     }
 
     public void opprettArbeidssoekerDagpenger(
-            String personident,
+            PersonDTO person,
             String miljoe,
             LocalDate aktiveringsDato
     ) {
         var kvalifiseringsgruppe = Kvalifiseringsgrupper.IKVAL;
-        opprettArbeidssoeker(personident, miljoe, kvalifiseringsgruppe, aktiveringsDato);
+        opprettArbeidssoeker(person, miljoe, kvalifiseringsgruppe, aktiveringsDato);
     }
 
     private void opprettArbeidssoeker(
-            String personident,
+            PersonDTO person,
             String miljoe,
             Kvalifiseringsgrupper kvalifiseringsgruppe,
             LocalDate aktiveringsDato
     ) {
-        if (arbeidssoekerIkkeOpprettetIArena(personident)) {
-            var nyeBrukereResponse = sendArbeidssoekereTilArenaForvalter(Collections.singletonList(personident), miljoe, kvalifiseringsgruppe, INGEN_OPPFOELGING, aktiveringsDato);
-            checkNyeBrukereResponse(nyeBrukereResponse, personident);
+        if (arbeidssoekerIkkeOpprettetIArena(person.getIdent())) {
+            var nyeBrukereResponse = sendArbeidssoekereTilArenaForvalter(Collections.singletonList(person.getIdent()), miljoe, kvalifiseringsgruppe, INGEN_OPPFOELGING, aktiveringsDato);
+            checkNyeBrukereResponse(nyeBrukereResponse, person);
         }
     }
 
-    private void checkNyeBrukereResponse(NyeBrukereResponse nyeBrukereResponse, String personident) {
+    private void checkNyeBrukereResponse(NyeBrukereResponse nyeBrukereResponse, PersonDTO person) {
         String feilmelding = null;
         if (isNull(nyeBrukereResponse)) {
-            feilmelding = String.format("Kunne ikke opprette ny bruker med fnr %s i Arena: %s", personident, "Ukjent feil.");
+            feilmelding = String.format("Kunne ikke opprette ny bruker med fnr %s i Arena: %s", person.getIdent(), "Ukjent feil.");
         } else if (nonNull(nyeBrukereResponse.getNyBrukerFeilList()) && !nyeBrukereResponse.getNyBrukerFeilList().isEmpty()) {
-            feilmelding = String.format("Kunne ikke opprette ny bruker med fnr %s i Arena: %s", personident, nyeBrukereResponse.getNyBrukerFeilList().get(0).getMelding());
+            feilmelding = String.format("Kunne ikke opprette ny bruker med fnr %s i Arena: %s", person.getIdent(), nyeBrukereResponse.getNyBrukerFeilList().get(0).getMelding());
         }
         if (StringUtils.isNotBlank(feilmelding)) {
             log.error(feilmelding);
-            tagsService.removeTagsPaaIdent(personident);
+            tagsService.removeTagsPaaIdentOgPartner(person);
             throw new ArbeidssoekerException("Kunne ikke opprette bruker i Arena");
         }
     }

--- a/apps/synt-vedtakshistorikk-service/src/main/java/no/nav/testnav/apps/syntvedtakshistorikkservice/service/ArenaTiltakService.java
+++ b/apps/synt-vedtakshistorikk-service/src/main/java/no/nav/testnav/apps/syntvedtakshistorikkservice/service/ArenaTiltakService.java
@@ -19,6 +19,7 @@ import no.nav.testnav.libs.domain.dto.arena.testnorge.vedtak.NyttVedtak;
 import no.nav.testnav.libs.domain.dto.arena.testnorge.vedtak.NyttVedtakAap;
 import no.nav.testnav.libs.domain.dto.arena.testnorge.vedtak.NyttVedtakTiltak;
 
+import no.nav.testnav.libs.dto.personsearchservice.v1.PersonDTO;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
@@ -85,7 +86,7 @@ public class ArenaTiltakService {
 
     public void oppdaterTiltaksdeltakelse(
             Vedtakshistorikk historikk,
-            String personident,
+            PersonDTO person,
             String miljoe,
             List<NyttVedtakTiltak> tiltaksliste,
             NyttVedtak senesteVedtak,
@@ -95,7 +96,7 @@ public class ArenaTiltakService {
         if (nonNull(tiltaksdeltakelser) && !tiltaksdeltakelser.isEmpty()) {
             Kvalifiseringsgrupper kvalifiseringsgruppe;
             try {
-                kvalifiseringsgruppe = arenaForvalterService.opprettArbeidssoekerTiltaksdeltakelse(personident, miljoe, senesteVedtak.getRettighetType(), tidligsteDato);
+                kvalifiseringsgruppe = arenaForvalterService.opprettArbeidssoekerTiltaksdeltakelse(person, miljoe, senesteVedtak.getRettighetType(), tidligsteDato);
             } catch (Exception e) {
                 historikk.setTiltaksdeltakelse(Collections.emptyList());
                 return;
@@ -105,11 +106,11 @@ public class ArenaTiltakService {
                 if (harIkkeGyldigTiltakKode(deltakelse, kvalifiseringsgruppe)) {
                     deltakelse.setTiltakKode(getGyldigTiltakKode(deltakelse, kvalifiseringsgruppe));
                 }
-                deltakelse.setFodselsnr(personident);
+                deltakelse.setFodselsnr(person.getIdent());
                 deltakelse.setTiltakYtelse("J");
             });
             tiltaksdeltakelser.forEach(deltakelse -> {
-                var tiltak = arenaForvalterService.finnTiltak(personident, miljoe, deltakelse);
+                var tiltak = arenaForvalterService.finnTiltak(person.getIdent(), miljoe, deltakelse);
 
                 if (nonNull(tiltak)) {
                     deltakelse.setTiltakId(tiltak.getTiltakId());

--- a/apps/synt-vedtakshistorikk-service/src/main/java/no/nav/testnav/apps/syntvedtakshistorikkservice/service/IdentService.java
+++ b/apps/synt-vedtakshistorikk-service/src/main/java/no/nav/testnav/apps/syntvedtakshistorikkservice/service/IdentService.java
@@ -11,7 +11,6 @@ import no.nav.testnav.apps.syntvedtakshistorikkservice.consumer.response.pdl.Pdl
 import no.nav.testnav.apps.syntvedtakshistorikkservice.consumer.response.pdl.PdlPersonBolk;
 import no.nav.testnav.apps.syntvedtakshistorikkservice.domain.IdentMedKontonr;
 import no.nav.testnav.apps.syntvedtakshistorikkservice.domain.Kontoinfo;
-import no.nav.testnav.libs.dto.personsearchservice.v1.FolkeregisterpersonstatusDTO;
 import no.nav.testnav.libs.dto.personsearchservice.v1.PersonDTO;
 import no.nav.testnav.libs.dto.personsearchservice.v1.search.AlderSearch;
 import no.nav.testnav.libs.dto.personsearchservice.v1.search.PersonSearch;

--- a/apps/synt-vedtakshistorikk-service/src/main/java/no/nav/testnav/apps/syntvedtakshistorikkservice/service/TagsService.java
+++ b/apps/synt-vedtakshistorikk-service/src/main/java/no/nav/testnav/apps/syntvedtakshistorikkservice/service/TagsService.java
@@ -3,24 +3,42 @@ package no.nav.testnav.apps.syntvedtakshistorikkservice.service;
 import lombok.RequiredArgsConstructor;
 import no.nav.testnav.apps.syntvedtakshistorikkservice.consumer.PdlProxyConsumer;
 import no.nav.testnav.apps.syntvedtakshistorikkservice.domain.Tags;
+import no.nav.testnav.libs.dto.personsearchservice.v1.PersonDTO;
+import no.nav.testnav.libs.dto.personsearchservice.v1.SivilstandDTO;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+
+import static java.util.Objects.nonNull;
 
 @Service
 @RequiredArgsConstructor
 public class TagsService {
     public static final List<Tags> SYNT_TAGS = List.of(Tags.ARENASYNT);
+    private static final List<String> GYLDIG_SIVILSTAND = Arrays.asList("GIFT", "REGISTRERT_PARTNER", "SEPARERT", "SEPARERT_PARTNER");
 
     private final PdlProxyConsumer pdlProxyConsumer;
 
-    public boolean opprettetTagsPaaIdenter(List<String> identer) {
+    public boolean opprettetTagsPaaIdenterOgPartner(List<PersonDTO> personer) {
+        var identer = new ArrayList<>(personer.stream().map(PersonDTO::getIdent).toList());
+        var partnere = personer.stream()
+                .map(PersonDTO::getSivilstand)
+                .filter(sivilstand -> GYLDIG_SIVILSTAND.contains(sivilstand.getType()))
+                .map(SivilstandDTO::getRelatertVedSivilstand)
+                .toList();
+
+        identer.addAll(partnere);
         return pdlProxyConsumer.createTags(identer, SYNT_TAGS);
     }
 
-    public void removeTagsPaaIdent(String ident) {
-        pdlProxyConsumer.deleteTags(Collections.singletonList(ident), SYNT_TAGS);
+    public void removeTagsPaaIdentOgPartner(PersonDTO person) {
+        if (nonNull(person.getSivilstand()) && GYLDIG_SIVILSTAND.contains(person.getSivilstand().getType())) {
+            pdlProxyConsumer.deleteTags(Arrays.asList(person.getIdent(), person.getSivilstand().getRelatertVedSivilstand()), SYNT_TAGS);
+        } else {
+            pdlProxyConsumer.deleteTags(Collections.singletonList(person.getIdent()), SYNT_TAGS);
+        }
     }
 }

--- a/apps/synt-vedtakshistorikk-service/src/main/java/no/nav/testnav/apps/syntvedtakshistorikkservice/service/TagsService.java
+++ b/apps/synt-vedtakshistorikk-service/src/main/java/no/nav/testnav/apps/syntvedtakshistorikkservice/service/TagsService.java
@@ -12,7 +12,7 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 public class TagsService {
-    public static final List<Tags> SYNT_TAGS = Arrays.asList(Tags.DOLLY, Tags.ARENASYNT);
+    public static final List<Tags> SYNT_TAGS = List.of(Tags.ARENASYNT);
 
     private final PdlProxyConsumer pdlProxyConsumer;
 

--- a/apps/synt-vedtakshistorikk-service/src/main/java/no/nav/testnav/apps/syntvedtakshistorikkservice/service/VedtakshistorikkService.java
+++ b/apps/synt-vedtakshistorikk-service/src/main/java/no/nav/testnav/apps/syntvedtakshistorikkservice/service/VedtakshistorikkService.java
@@ -100,7 +100,7 @@ public class VedtakshistorikkService {
                 log.error("Kunne ikke opprette vedtakshistorikk på ident med minimum alder {}.", minimumAlder);
             } else {
                 var utvalgtIdent = getUtvalgtIdentIAldersgruppe(vedtakshistorikk, tidligsteDatoBarnetillegg, minimumAlder, maksimumAlder);
-                if (nonNull(utvalgtIdent) && tagsService.opprettetTagsPaaIdenter(Collections.singletonList(utvalgtIdent.getIdent()))) {
+                if (nonNull(utvalgtIdent) && tagsService.opprettetTagsPaaIdenterOgPartner(Collections.singletonList(utvalgtIdent))) {
                     responses.putAll(opprettHistorikkOgSendTilArena(utvalgtIdent, miljoe, vedtakshistorikk, tidligsteDato));
                 }
             }
@@ -169,7 +169,7 @@ public class VedtakshistorikkService {
         arenaAapService.opprettVedtakUngUfoer(vedtakshistorikk, person, miljoe, rettigheter);
         arenaAapService.opprettVedtakTvungenForvaltning(vedtakshistorikk, personident, miljoe, rettigheter);
         arenaAapService.opprettVedtakFritakMeldekort(vedtakshistorikk, personident, miljoe, rettigheter);
-        arenaTiltakService.oppdaterTiltaksdeltakelse(vedtakshistorikk, personident, miljoe, tiltak, senesteVedtak, tidligsteDato);
+        arenaTiltakService.oppdaterTiltaksdeltakelse(vedtakshistorikk, person, miljoe, tiltak, senesteVedtak, tidligsteDato);
         arenaTiltakService.opprettVedtakTiltaksdeltakelse(vedtakshistorikk, personident, miljoe, rettigheter);
         arenaTiltakService.opprettFoersteVedtakEndreDeltakerstatus(vedtakshistorikk, personident, miljoe, rettigheter);
         arenaTiltakService.opprettVedtakTiltakspenger(vedtakshistorikk, personident, miljoe, rettigheter);
@@ -179,12 +179,12 @@ public class VedtakshistorikkService {
 
         if (!rettigheter.isEmpty()) {
             if (!opprettetNoedvendigInfoIPopp(vedtakshistorikk, person, miljoe)) {
-                tagsService.removeTagsPaaIdent(personident);
+                tagsService.removeTagsPaaIdentOgPartner(person);
                 arenaForvalterService.slettArbeidssoekerIArena(personident, miljoe);
                 return Collections.emptyMap();
             }
             try {
-                arenaForvalterService.opprettArbeidssoekerVedtakshistorikk(personident, miljoe, senesteVedtak, tidligsteDato);
+                arenaForvalterService.opprettArbeidssoekerVedtakshistorikk(person, miljoe, senesteVedtak, tidligsteDato);
             } catch (Exception e) {
                 log.error(e.getMessage());
                 return Collections.emptyMap();

--- a/apps/synt-vedtakshistorikk-service/src/test/java/no/nav/testnav/apps/syntvedtakshistorikkservice/consumer/PdlConsumerTest.java
+++ b/apps/synt-vedtakshistorikk-service/src/test/java/no/nav/testnav/apps/syntvedtakshistorikkservice/consumer/PdlConsumerTest.java
@@ -136,7 +136,7 @@ class PdlConsumerTest {
     }
 
     private void stubOpprettTags() {
-        stubFor(post(urlEqualTo("/pdl/pdl-testdata/api/v1/bestilling/tags?tags=DOLLY&tags=ARENASYNT"))
+        stubFor(post(urlEqualTo("/pdl/pdl-testdata/api/v1/bestilling/tags?tags=ARENASYNT"))
                 .willReturn(ok()
                         .withHeader("Content-Type", "application/json")
                 )

--- a/apps/synt-vedtakshistorikk-service/src/test/java/no/nav/testnav/apps/syntvedtakshistorikkservice/consumer/SyntVedtakshistorikkConsumerTest.java
+++ b/apps/synt-vedtakshistorikk-service/src/test/java/no/nav/testnav/apps/syntvedtakshistorikkservice/consumer/SyntVedtakshistorikkConsumerTest.java
@@ -44,7 +44,7 @@ class SyntVedtakshistorikkConsumerTest {
     }
 
     @Test
-    void shoudlGetVedtakshistorikk(){
+    void shouldGetVedtakshistorikk(){
         stubHistorikkResponse();
         var response = syntVedtakshistorikkConsumer.syntetiserVedtakshistorikk(2);
 

--- a/apps/synt-vedtakshistorikk-service/src/test/java/no/nav/testnav/apps/syntvedtakshistorikkservice/provider/BrukerControllerTest.java
+++ b/apps/synt-vedtakshistorikk-service/src/test/java/no/nav/testnav/apps/syntvedtakshistorikkservice/provider/BrukerControllerTest.java
@@ -71,7 +71,7 @@ public class BrukerControllerTest {
         var personer = Collections.singletonList(PersonDTO.builder().ident(fnr1).build());
 
         when(identService.getUtvalgteIdenterIAldersgruppe(1, MINIMUM_ALDER, MAKSIMUM_ALDER, false)).thenReturn(personer);
-        when(tagsService.opprettetTagsPaaIdenter(identer)).thenReturn(true);
+        when(tagsService.opprettetTagsPaaIdenterOgPartner(personer)).thenReturn(true);
         when(arenaForvalterService
                 .opprettArbeidssoekereUtenVedtak(identer, miljoe))
                 .thenReturn(oppfoelgingResponse);

--- a/apps/synt-vedtakshistorikk-service/src/test/java/no/nav/testnav/apps/syntvedtakshistorikkservice/service/ArenaTiltakServiceTest.java
+++ b/apps/synt-vedtakshistorikk-service/src/test/java/no/nav/testnav/apps/syntvedtakshistorikkservice/service/ArenaTiltakServiceTest.java
@@ -7,6 +7,7 @@ import no.nav.testnav.libs.domain.dto.arena.testnorge.brukere.Kvalifiseringsgrup
 import no.nav.testnav.libs.domain.dto.arena.testnorge.historikk.Vedtakshistorikk;
 import no.nav.testnav.libs.domain.dto.arena.testnorge.vedtak.NyttVedtakAap;
 import no.nav.testnav.libs.domain.dto.arena.testnorge.vedtak.NyttVedtakTiltak;
+import no.nav.testnav.libs.dto.personsearchservice.v1.PersonDTO;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -41,7 +42,11 @@ public class ArenaTiltakServiceTest {
     private NyttVedtakTiltak tiltaksdeltakelse;
     private NyttVedtakTiltak tiltakspenger;
     private NyttVedtakTiltak tiltak;
+
     private String fnr1 = "12345678910";
+
+    private PersonDTO person = PersonDTO.builder()
+            .ident(fnr1).build();
     private String miljoe = "test";
 
     @Before
@@ -73,14 +78,14 @@ public class ArenaTiltakServiceTest {
     @Test
     public void shouldFilterOutTiltaksdeltakelseWithoutTiltak() {
         when(arenaForvalterService.opprettArbeidssoekerTiltaksdeltakelse(
-                fnr1, miljoe, tiltaksdeltakelse.getRettighetType(), LocalDate.now())).thenReturn(Kvalifiseringsgrupper.BATT);
+                person, miljoe, tiltaksdeltakelse.getRettighetType(), LocalDate.now())).thenReturn(Kvalifiseringsgrupper.BATT);
 
         when(arenaForvalterService.finnTiltak(fnr1, miljoe, tiltaksdeltakelse)).thenReturn(null);
 
         var historikk = Vedtakshistorikk.builder()
                 .tiltaksdeltakelse(Collections.singletonList(tiltaksdeltakelse))
                 .build();
-        arenaTiltakService.oppdaterTiltaksdeltakelse(historikk, fnr1, miljoe, Collections.emptyList(), tiltaksdeltakelse, LocalDate.now());
+        arenaTiltakService.oppdaterTiltaksdeltakelse(historikk, person, miljoe, Collections.emptyList(), tiltaksdeltakelse, LocalDate.now());
 
         assertThat(historikk.getTiltaksdeltakelse()).isEmpty();
     }
@@ -88,7 +93,7 @@ public class ArenaTiltakServiceTest {
     @Test
     public void shouldUpdateTiltaksdeltakelse() {
         when(arenaForvalterService.opprettArbeidssoekerTiltaksdeltakelse(
-                fnr1, miljoe, tiltaksdeltakelse.getRettighetType(), LocalDate.now())).thenReturn(Kvalifiseringsgrupper.BATT);
+                person, miljoe, tiltaksdeltakelse.getRettighetType(), LocalDate.now())).thenReturn(Kvalifiseringsgrupper.BATT);
 
         when(arenaForvalterService.finnTiltak(fnr1, miljoe, tiltaksdeltakelse)).thenReturn(tiltak);
 
@@ -96,7 +101,7 @@ public class ArenaTiltakServiceTest {
                 .tiltaksdeltakelse(Collections.singletonList(tiltaksdeltakelse))
                 .build();
         List<NyttVedtakTiltak> tiltaksliste = new ArrayList<>();
-        arenaTiltakService.oppdaterTiltaksdeltakelse(historikk, fnr1, miljoe, tiltaksliste, tiltaksdeltakelse, LocalDate.now());
+        arenaTiltakService.oppdaterTiltaksdeltakelse(historikk, person, miljoe, tiltaksliste, tiltaksdeltakelse, LocalDate.now());
 
         assertThat(historikk.getTiltaksdeltakelse()).hasSize(1);
         assertThat(historikk.getTiltaksdeltakelse().get(0).getTiltakId()).isEqualTo(1);


### PR DESCRIPTION
Fjernet oppretting av tag "DOLLY" og endret det sånn at ident og eventuell partner til ident begge kun får tag "ARENASYNT"