### PR TITLE
Workaround for netty-transport-native-epoll

### DIFF
--- a/apps/tps-messaging-service/build.gradle
+++ b/apps/tps-messaging-service/build.gradle
@@ -46,6 +46,10 @@ repositories {
     }
 }
 
+configurations.implementation {
+    exclude group: 'io.netty', module: 'netty-transport-native-epoll' // Avoid native Linux/Mac on non-Linux/Mac systems.
+}
+
 dependencies {
     implementation 'no.nav.testnav.libs:security-core'
     implementation 'no.nav.testnav.libs:servlet-core'
@@ -55,6 +59,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation 'io.netty:netty-transport-native-epoll' // See above exclusion.
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.cloud:spring-cloud-starter-bootstrap'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'


### PR DESCRIPTION
Forsøk på å hjelpe Gradle gjennom feil av typen "Could not find netty-transport-native-epoll-4.1.70.Final-linux-x86_64.jar (io.netty:netty-transport-native-epoll:4.1.70.Final)."

Transitiv dependency gjennom spring-boot-starter-webflux. Finnes native for Linux og Mac som alternativ til NIO, ref. https://netty.io/wiki/native-transports, men feiler altså på "andre OS".