### PR TITLE
Workaround for netty-transport-native-epoll

### DIFF
--- a/apps/import-fra-tpsf-service/build.gradle
+++ b/apps/import-fra-tpsf-service/build.gradle
@@ -46,6 +46,10 @@ repositories {
     }
 }
 
+configurations.implementation {
+    exclude group: 'io.netty', module: 'netty-transport-native-epoll' // Avoid native Linux/Mac on non-Linux/Mac systems.
+}
+
 dependencies {
     implementation 'no.nav.testnav.libs:reactive-core'
     implementation 'no.nav.testnav.libs:reactive-proxy'
@@ -55,6 +59,7 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation 'io.netty:netty-transport-native-epoll' // See above exclusion.
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.cloud:spring-cloud-starter-bootstrap'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'


### PR DESCRIPTION
Forsøk på å hjelpe Gradle gjennom feil av typen "Could not find netty-transport-native-epoll-4.1.70.Final-linux-x86_64.jar (io.netty:netty-transport-native-epoll:4.1.70.Final)."

Se også https://github.com/navikt/testnorge/pull/2550.