### PR TITLE
Dolly- Frontend / Fikset manglende visning dødsfall og boadresse tps

### DIFF
--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/visning/Visning.js
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/visning/Visning.js
@@ -43,11 +43,6 @@ export const PdlfVisning = ({ data, tpsfData, loading, tmpPersoner, environments
 	const ident = data ? data.person?.ident : tpsfData?.ident
 	const tpsMessaging = TpsMessagingData(ident, environments)
 
-	const harTpsAdresse =
-		tpsfData?.boadresse?.length > 0 ||
-		tpsfData?.postadresse?.length > 0 ||
-		tpsfData?.midlertidigAdresse?.length > 0
-
 	return (
 		<ErrorBoundary>
 			<div>
@@ -93,40 +88,32 @@ export const PdlfVisning = ({ data, tpsfData, loading, tmpPersoner, environments
 							: tpsfData?.bankkontonrNorsk
 					}
 				/>
-
-				{master === 'PDLF' || !harTpsAdresse ? (
-					<>
-						<Boadresse
-							data={data?.person?.bostedsadresse}
-							tmpPersoner={tmpPersoner}
-							ident={ident}
-							identtype={data?.person?.identtype}
-						/>
-						<DeltBosted data={data?.person?.deltBosted} />
-						<Oppholdsadresse
-							data={data?.person?.oppholdsadresse}
-							tmpPersoner={tmpPersoner}
-							ident={ident}
-						/>
-						<Kontaktadresse
-							data={data?.person?.kontaktadresse}
-							tmpPersoner={tmpPersoner}
-							ident={ident}
-						/>
-						<Adressebeskyttelse
-							data={data?.person?.adressebeskyttelse}
-							tmpPersoner={tmpPersoner}
-							ident={ident}
-							identtype={data?.person?.identtype}
-						/>
-					</>
-				) : (
-					<>
-						<TpsfBoadresse boadresse={tpsfData?.boadresse} />
-						<Postadresse postadresse={tpsfData?.postadresse} />
-						<MidlertidigAdresse midlertidigAdresse={tpsfData?.midlertidigAdresse} />
-					</>
-				)}
+				<Boadresse
+					data={data?.person?.bostedsadresse}
+					tmpPersoner={tmpPersoner}
+					ident={ident}
+					identtype={data?.person?.identtype}
+				/>
+				{!data?.person?.bostedsadresse && <TpsfBoadresse boadresse={tpsfData?.boadresse} />}
+				<DeltBosted data={data?.person?.deltBosted} />
+				<Postadresse postadresse={tpsfData?.postadresse} />
+				<MidlertidigAdresse midlertidigAdresse={tpsfData?.midlertidigAdresse} />
+				<Oppholdsadresse
+					data={data?.person?.oppholdsadresse}
+					tmpPersoner={tmpPersoner}
+					ident={ident}
+				/>
+				<Kontaktadresse
+					data={data?.person?.kontaktadresse}
+					tmpPersoner={tmpPersoner}
+					ident={ident}
+				/>
+				<Adressebeskyttelse
+					data={data?.person?.adressebeskyttelse}
+					tmpPersoner={tmpPersoner}
+					ident={ident}
+					identtype={data?.person?.identtype}
+				/>
 
 				{master === 'PDLF' ? (
 					<>

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/visning/Visning.js
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/visning/Visning.js
@@ -31,6 +31,7 @@ import {
 	UtenlandskBankkonto,
 	TpsfVergemaal,
 	TpsfNasjonalitet,
+	TpsfBoadresse,
 } from '~/components/fagsystem/tpsf/visning/partials'
 import { PdlSikkerhetstiltak } from '~/components/fagsystem/pdl/visning/partials/PdlSikkerhetstiltak'
 import { TpsMessagingData } from '~/components/fagsystem/tpsmessaging/form/TpsMessagingData'
@@ -70,6 +71,7 @@ export const PdlfVisning = ({ data, tpsfData, loading, tmpPersoner, environments
 				) : (
 					<>
 						<TpsfPersoninfo data={tpsfData} environments={environments} />
+						<Doedsfall data={data?.person?.doedsfall} tmpPersoner={tmpPersoner} ident={ident} />
 						<TpsfNasjonalitet data={tpsfData} />
 						<Telefonnummer data={tpsfData?.telefonnumre} />
 						<TpsfVergemaal data={tpsfData?.vergemaal} />
@@ -120,7 +122,7 @@ export const PdlfVisning = ({ data, tpsfData, loading, tmpPersoner, environments
 					</>
 				) : (
 					<>
-						<Boadresse boadresse={tpsfData?.boadresse} />
+						<TpsfBoadresse boadresse={tpsfData?.boadresse} />
 						<Postadresse postadresse={tpsfData?.postadresse} />
 						<MidlertidigAdresse midlertidigAdresse={tpsfData?.midlertidigAdresse} />
 					</>

--- a/apps/dolly-frontend/src/main/js/src/ducks/fagsystem/index.js
+++ b/apps/dolly-frontend/src/main/js/src/ducks/fagsystem/index.js
@@ -446,7 +446,8 @@ export const selectPersonListe = (identer, bestillingStatuser, fagsystem) => {
 	return identListe.map((ident) => {
 		if (ident.master === 'TPSF') {
 			const tpsfIdent = fagsystem.tpsf[ident.ident]
-			return getTpsfIdentInfo(ident, bestillingStatuser, tpsfIdent)
+			const pdlfIdent = fagsystem.pdlforvalter?.[ident.ident]?.person
+			return getTpsfIdentInfo(ident, bestillingStatuser, tpsfIdent, pdlfIdent)
 		} else if (ident.master === 'PDLF') {
 			const pdlfIdent = fagsystem.pdlforvalter[ident.ident]?.person
 			return getPdlfIdentInfo(ident, bestillingStatuser, pdlfIdent)
@@ -459,7 +460,7 @@ export const selectPersonListe = (identer, bestillingStatuser, fagsystem) => {
 	})
 }
 
-const getTpsfIdentInfo = (ident, bestillingStatuser, tpsfIdent) => {
+const getTpsfIdentInfo = (ident, bestillingStatuser, tpsfIdent, pdlfIdent) => {
 	if (!tpsfIdent) {
 		return getDefaultInfo(ident, bestillingStatuser, 'TPS')
 	}
@@ -473,7 +474,10 @@ const getTpsfIdentInfo = (ident, bestillingStatuser, tpsfIdent) => {
 		kilde: 'TPS',
 		navn: `${tpsfIdent.fornavn} ${mellomnavn} ${tpsfIdent.etternavn}`,
 		kjonn: Formatters.kjonn(tpsfIdent.kjonn, tpsfIdent.alder),
-		alder: Formatters.formatAlder(tpsfIdent.alder, tpsfIdent.doedsdato),
+		alder: Formatters.formatAlder(
+			tpsfIdent.alder,
+			tpsfIdent.doedsdato ? tpsfIdent.doedsdato : getPdlDoedsdato(pdlfIdent)
+		),
 		status: hentPersonStatus(ident.ident, bestillingStatuser?.byId[ident.bestillingId[0]]),
 	}
 }
@@ -504,10 +508,14 @@ const getPdlfIdentInfo = (ident, bestillingStatuser, pdlIdent) => {
 		kjonn: pdlIdent.kjoenn?.[0]?.kjoenn,
 		alder: Formatters.formatAlder(
 			pdlAlder(pdlIdent?.foedsel?.[0]?.foedselsdato),
-			pdlIdent?.doedsfall?.[0]?.doedsdato
+			getPdlDoedsdato(pdlIdent)
 		),
 		status: hentPersonStatus(ident?.ident, bestillingStatuser?.byId[ident.bestillingId[0]]),
 	}
+}
+
+const getPdlDoedsdato = (pdlIdent) => {
+	return pdlIdent?.doedsfall?.filter((doed) => !doed?.metadata?.historisk)?.[0]?.doedsdato
 }
 
 const getPdlIdentInfo = (ident, bestillingStatuser, pdlData) => {


### PR DESCRIPTION
Fikset manglende visning av dødsfall og boadresse for TPS identer. 
Fikset også sånn at det står (død) etter alder for TPS identer når det er blitt opprettet dødsfall via PDL.