### PR TITLE
Stoppet deploy av testnorge inst og testnorge skd

### DIFF
--- a/.github/workflows/app.testnorge-inst.yml
+++ b/.github/workflows/app.testnorge-inst.yml
@@ -23,14 +23,3 @@ jobs:
       app-name: 'testnav-inst'
     secrets:
       NAV_TOKEN: ${{ secrets.NAV_TOKEN }}
-  deploy:
-    name: Deploy
-    uses: navikt/testnorge/.github/workflows/common.deploy.yml@master
-    needs: build
-    if: ${{ github.ref == 'refs/heads/master' }}
-    with:
-      resource: 'apps/testnorge-inst/nais.yaml'
-      app-name: 'testnav-inst'
-      cluster: 'dev-fss'
-    secrets:
-      API_KEY: ${{ secrets.NAIS_DOLLY_DEPLOY_API_KEY }}

--- a/.github/workflows/app.testnorge-skd.yml
+++ b/.github/workflows/app.testnorge-skd.yml
@@ -23,14 +23,3 @@ jobs:
       app-name: 'testnav-skd'
     secrets:
       NAV_TOKEN: ${{ secrets.NAV_TOKEN }}
-  deploy:
-    name: Deploy
-    uses: navikt/testnorge/.github/workflows/common.deploy.yml@master
-    needs: build
-    if: ${{ github.ref == 'refs/heads/master' }}
-    with:
-      resource: 'apps/testnorge-skd/nais.yaml'
-      app-name: 'testnav-skd'
-      cluster: 'dev-fss'
-    secrets:
-      API_KEY: ${{ secrets.NAIS_DOLLY_DEPLOY_API_KEY }}

--- a/apps/testnorge-inst/nais.yaml
+++ b/apps/testnorge-inst/nais.yaml
@@ -36,8 +36,6 @@ spec:
       rules:
         - application: team-dolly-lokal-app
           cluster: dev-fss
-        - application: testnav-testnorge-inst-proxy
-          cluster: dev-fss
   azure:
     application:
       enabled: true


### PR DESCRIPTION
Stopper deploy av testnorge-inst og testnorge-skd (og tar ned deployet versjon) da disse skal ikke være i bruk lenger. Venter litt med å fjerne dem fra monorepo.