### PR TITLE
Oppdatert inbound rules

### DIFF
--- a/apps/arbeidsforhold-service/config.yml
+++ b/apps/arbeidsforhold-service/config.yml
@@ -27,6 +27,8 @@ spec:
           cluster: dev-gcp
         - application: testnorge-synt-sykemelding-api
           cluster: dev-fss
+        - application: testnav-synt-sykemelding-api
+          cluster: dev-gcp
     outbound:
       external:
         - host: testnav-aareg-proxy.dev-fss-pub.nais.io

--- a/apps/helsepersonell-service/config.yml
+++ b/apps/helsepersonell-service/config.yml
@@ -28,6 +28,8 @@ spec:
           cluster: dev-gcp
         - application: testnorge-synt-sykemelding-api
           cluster: dev-fss
+        - application: testnav-synt-sykemelding-api
+          cluster: dev-gcp
     outbound:
       external:
         - host: testnav-hodejegeren-proxy.dev-fss-pub.nais.io

--- a/apps/organisasjon-service/config.yml
+++ b/apps/organisasjon-service/config.yml
@@ -27,6 +27,8 @@ spec:
           cluster: dev-gcp
         - application: testnorge-synt-sykemelding-api
           cluster: dev-fss
+        - application: testnav-synt-sykemelding-api
+          cluster: dev-gcp
         - application: testnav-organisasjon-forvalter
           cluster: dev-gcp
         - application: testnav-oversikt-frontend

--- a/proxies/pdl-proxy/config.yml
+++ b/proxies/pdl-proxy/config.yml
@@ -38,6 +38,8 @@ spec:
           cluster: dev-gcp
         - application: testnav-person-search-service
           cluster: dev-gcp
+        - application: testnav-synt-sykemelding-api
+          cluster: dev-gcp
   liveness:
     path: /internal/isAlive
     initialDelay: 4


### PR DESCRIPTION
Jobber med å flytte testnorge-synt-sykemelding-api ut på gcp. Har dermed lagt til ny app i inbound rules for å teste at ny versjon funker som den skal.