### PR TITLE
Dolly frontend/innvandring utvandring begrensing

### DIFF
--- a/apps/dolly-frontend/src/main/js/src/components/bestillingsveileder/stegVelger/steg/steg1/paneler/Personinformasjon.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/bestillingsveileder/stegVelger/steg/steg1/paneler/Personinformasjon.tsx
@@ -265,7 +265,7 @@ PersoninformasjonPanel.initialValues = ({ set, setMulti, del, has, opts }) => {
 							{
 								fraflyttingsland: '',
 								fraflyttingsstedIUtlandet: '',
-								innflyttingsdato: '',
+								innflyttingsdato: null as string,
 								master: 'FREG',
 								kilde: 'Dolly',
 							},
@@ -285,7 +285,7 @@ PersoninformasjonPanel.initialValues = ({ set, setMulti, del, has, opts }) => {
 							{
 								tilflyttingsland: '',
 								tilflyttingsstedIUtlandet: '',
-								utflyttingsdato: '',
+								utflyttingsdato: null as string,
 								master: 'FREG',
 								kilde: 'Dolly',
 							},

--- a/apps/dolly-frontend/src/main/js/src/components/bestillingsveileder/stegVelger/steg/steg1/paneler/Personinformasjon.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/bestillingsveileder/stegVelger/steg/steg1/paneler/Personinformasjon.tsx
@@ -69,7 +69,7 @@ const getDisabledNasjonalitetField = (opts: any) => {
 		}
 	}
 
-	return false
+	return ''
 }
 
 // @ts-ignore

--- a/apps/dolly-frontend/src/main/js/src/components/bestillingsveileder/stegVelger/steg/steg1/paneler/Personinformasjon.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/bestillingsveileder/stegVelger/steg/steg1/paneler/Personinformasjon.tsx
@@ -56,12 +56,13 @@ const getDisabledNasjonalitetField = (opts: any) => {
 		return innvandret
 	} else {
 		const sisteInnflytting = getSisteDato(
-			innflytting?.map(
-				(val: InnflyttingTilNorge) => new Date(val.folkeregistermetadata?.gyldighetstidspunkt)
-			)
+			innflytting
+				.map((val: InnflyttingTilNorge) => val?.folkeregistermetadata?.gyldighetstidspunkt)
+				.filter((val: string) => val)
+				.map((val: string) => new Date(val))
 		)
 		const sisteUtflytting = getSisteDato(
-			utflytting?.map((val: UtflyttingFraNorge) => new Date(val.utflyttingsdato))
+			utflytting.map((val: UtflyttingFraNorge) => new Date(val.utflyttingsdato))
 		)
 
 		return sisteInnflytting > sisteUtflytting ? innvandret : utvandret

--- a/apps/dolly-frontend/src/main/js/src/components/bestillingsveileder/stegVelger/steg/steg1/paneler/Personinformasjon.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/bestillingsveileder/stegVelger/steg/steg1/paneler/Personinformasjon.tsx
@@ -20,6 +20,7 @@ import {
 	InnflyttingTilNorge,
 	UtflyttingFraNorge,
 } from '~/pages/gruppe/PersonVisning/PersonMiljoeinfo/PdlDataTyper'
+import { getSisteDato } from '~/components/bestillingsveileder/utils'
 
 const ignoreKeysTestnorge = [
 	'alder',
@@ -56,12 +57,12 @@ const getDisabledNasjonalitetField = (opts: any) => {
 		} else if (antallInnflyttet === 0 && antallUtflyttet > 0) {
 			return utField
 		} else {
-			const sisteInnflytting = Math.max(
+			const sisteInnflytting = getSisteDato(
 				innflytting?.map(
 					(val: InnflyttingTilNorge) => new Date(val.folkeregistermetadata?.gyldighetstidspunkt)
 				)
 			)
-			const sisteUtflytting = Math.max(
+			const sisteUtflytting = getSisteDato(
 				utflytting?.map((val: UtflyttingFraNorge) => new Date(val.utflyttingsdato))
 			)
 
@@ -121,6 +122,8 @@ export const PersoninformasjonPanel = ({ stateModifier, testnorgeIdent }) => {
 		)
 	}
 
+	const disabledInnUtflyttingField = getDisabledNasjonalitetField(opts)
+
 	return (
 		// @ts-ignore
 		<Panel
@@ -140,11 +143,11 @@ export const PersoninformasjonPanel = ({ stateModifier, testnorgeIdent }) => {
 				<Attributt attr={sm.attrs.statsborgerskap} />
 				<Attributt
 					attr={sm.attrs.innvandretFraLand}
-					disabled={getDisabledNasjonalitetField(opts) === 'innflytting'}
+					disabled={disabledInnUtflyttingField === 'innflytting'}
 				/>
 				<Attributt
 					attr={sm.attrs.utvandretTilLand}
-					disabled={!harFnr || getDisabledNasjonalitetField(opts) === 'utflytting'}
+					disabled={!harFnr || disabledInnUtflyttingField === 'utflytting'}
 					title={
 						!harFnr
 							? 'Personer med identtype DNR eller NPID kan ikke utvandre fordi de ikke har norsk statsborgerskap'

--- a/apps/dolly-frontend/src/main/js/src/components/bestillingsveileder/stegVelger/steg/steg1/paneler/Personinformasjon.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/bestillingsveileder/stegVelger/steg/steg1/paneler/Personinformasjon.tsx
@@ -270,7 +270,7 @@ PersoninformasjonPanel.initialValues = ({ set, setMulti, del, has, opts }) => {
 							{
 								fraflyttingsland: '',
 								fraflyttingsstedIUtlandet: '',
-								innflyttingsdato: new Date(),
+								innflyttingsdato: '',
 								master: 'FREG',
 								kilde: 'Dolly',
 							},
@@ -290,7 +290,7 @@ PersoninformasjonPanel.initialValues = ({ set, setMulti, del, has, opts }) => {
 							{
 								tilflyttingsland: '',
 								tilflyttingsstedIUtlandet: '',
-								utflyttingsdato: new Date(),
+								utflyttingsdato: '',
 								master: 'FREG',
 								kilde: 'Dolly',
 							},

--- a/apps/dolly-frontend/src/main/js/src/components/bestillingsveileder/stegVelger/steg/steg1/paneler/Personinformasjon.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/bestillingsveileder/stegVelger/steg/steg1/paneler/Personinformasjon.tsx
@@ -43,35 +43,29 @@ const innvandret = 'innvandretFraLand'
 const utvandret = 'utvandretTilLand'
 
 const getDisabledNasjonalitetField = (opts: any) => {
-	if (opts.is.leggTil) {
-		const personFoerLeggTil = opts.personFoerLeggTil
-		const innflytting = personFoerLeggTil?.pdl?.hentPerson?.innflyttingTilNorge
-		const utflytting = personFoerLeggTil?.pdl?.hentPerson?.utflyttingFraNorge
+	const personFoerLeggTil = opts.personFoerLeggTil
+	const innflytting = personFoerLeggTil?.pdl?.hentPerson?.innflyttingTilNorge
+	const utflytting = personFoerLeggTil?.pdl?.hentPerson?.utflyttingFraNorge
 
-		const antallInnflyttet = innflytting ? innflytting.length : 0
-		const antallUtflyttet = utflytting ? utflytting.length : 0
+	const antallInnflyttet = innflytting ? innflytting.length : 0
+	const antallUtflyttet = utflytting ? utflytting.length : 0
 
-		if (antallInnflyttet === 0 && antallUtflyttet === 0) {
-			return innvandret
-		} else if (antallInnflyttet > 0 && antallUtflyttet === 0) {
-			return innvandret
-		} else if (antallInnflyttet === 0 && antallUtflyttet > 0) {
-			return utvandret
-		} else {
-			const sisteInnflytting = getSisteDato(
-				innflytting?.map(
-					(val: InnflyttingTilNorge) => new Date(val.folkeregistermetadata?.gyldighetstidspunkt)
-				)
+	if (antallInnflyttet === 0) {
+		return antallUtflyttet > 0 ? utvandret : innvandret
+	} else if (antallUtflyttet === 0) {
+		return innvandret
+	} else {
+		const sisteInnflytting = getSisteDato(
+			innflytting?.map(
+				(val: InnflyttingTilNorge) => new Date(val.folkeregistermetadata?.gyldighetstidspunkt)
 			)
-			const sisteUtflytting = getSisteDato(
-				utflytting?.map((val: UtflyttingFraNorge) => new Date(val.utflyttingsdato))
-			)
+		)
+		const sisteUtflytting = getSisteDato(
+			utflytting?.map((val: UtflyttingFraNorge) => new Date(val.utflyttingsdato))
+		)
 
-			return sisteInnflytting > sisteUtflytting ? innvandret : utvandret
-		}
+		return sisteInnflytting > sisteUtflytting ? innvandret : utvandret
 	}
-
-	return ''
 }
 
 // @ts-ignore
@@ -84,7 +78,7 @@ export const PersoninformasjonPanel = ({ stateModifier, testnorgeIdent }) => {
 	const harFnr = opts.identtype === 'FNR'
 	//Noen egenskaper kan ikke endres når personen opprettes fra eksisterende eller videreføres med legg til
 
-	const disabledInnUtflyttingField = getDisabledNasjonalitetField(opts)
+	const disabledInnUtflyttingField = leggTil ? getDisabledNasjonalitetField(opts) : ''
 
 	const getIgnoreKeys = () => {
 		const ignoreKeys = testnorgeIdent ? [...ignoreKeysTestnorge] : ['identtype']

--- a/apps/dolly-frontend/src/main/js/src/components/bestillingsveileder/stegVelger/steg/steg1/paneler/Personinformasjon.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/bestillingsveileder/stegVelger/steg/steg1/paneler/Personinformasjon.tsx
@@ -64,11 +64,8 @@ const getDisabledNasjonalitetField = (opts: any) => {
 			const sisteUtflytting = Math.max(
 				utflytting?.map((val: UtflyttingFraNorge) => new Date(val.utflyttingsdato))
 			)
-			if (sisteInnflytting > sisteUtflytting) {
-				return innField
-			} else {
-				return utField
-			}
+
+			return sisteInnflytting > sisteUtflytting ? innField : utField
 		}
 	}
 

--- a/apps/dolly-frontend/src/main/js/src/components/bestillingsveileder/stegVelger/steg/steg1/paneler/Personinformasjon.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/bestillingsveileder/stegVelger/steg/steg1/paneler/Personinformasjon.tsx
@@ -39,9 +39,10 @@ const ignoreKeysTestnorge = [
 	'tilrettelagtKommunikasjon',
 ]
 
+const innvandret = 'innvandretFraLand'
+const utvandret = 'utvandretTilLand'
+
 const getDisabledNasjonalitetField = (opts: any) => {
-	const innField = 'innflytting'
-	const utField = 'utflytting'
 	if (opts.is.leggTil) {
 		const personFoerLeggTil = opts.personFoerLeggTil
 		const innflytting = personFoerLeggTil?.pdl?.hentPerson?.innflyttingTilNorge
@@ -51,11 +52,11 @@ const getDisabledNasjonalitetField = (opts: any) => {
 		const antallUtflyttet = utflytting ? utflytting.length : 0
 
 		if (antallInnflyttet === 0 && antallUtflyttet === 0) {
-			return innField
+			return innvandret
 		} else if (antallInnflyttet > 0 && antallUtflyttet === 0) {
-			return innField
+			return innvandret
 		} else if (antallInnflyttet === 0 && antallUtflyttet > 0) {
-			return utField
+			return utvandret
 		} else {
 			const sisteInnflytting = getSisteDato(
 				innflytting?.map(
@@ -66,7 +67,7 @@ const getDisabledNasjonalitetField = (opts: any) => {
 				utflytting?.map((val: UtflyttingFraNorge) => new Date(val.utflyttingsdato))
 			)
 
-			return sisteInnflytting > sisteUtflytting ? innField : utField
+			return sisteInnflytting > sisteUtflytting ? innvandret : utvandret
 		}
 	}
 
@@ -93,12 +94,10 @@ export const PersoninformasjonPanel = ({ stateModifier, testnorgeIdent }) => {
 			ignoreKeys.push('utenlandskBankkonto')
 		}
 		if (!testnorgeIdent && !harFnr) {
-			ignoreKeys.push('utvandretTilLand')
+			ignoreKeys.push(utvandret)
 		}
 		if (!testnorgeIdent && disabledInnUtflyttingField !== '') {
-			ignoreKeys.push(
-				disabledInnUtflyttingField === 'innflytting' ? 'innvandretFraLand' : 'utvandretTilLand'
-			)
+			ignoreKeys.push(disabledInnUtflyttingField)
 		}
 
 		return ignoreKeys
@@ -149,11 +148,11 @@ export const PersoninformasjonPanel = ({ stateModifier, testnorgeIdent }) => {
 				<Attributt attr={sm.attrs.statsborgerskap} />
 				<Attributt
 					attr={sm.attrs.innvandretFraLand}
-					disabled={disabledInnUtflyttingField === 'innflytting'}
+					disabled={disabledInnUtflyttingField === innvandret}
 				/>
 				<Attributt
 					attr={sm.attrs.utvandretTilLand}
-					disabled={!harFnr || disabledInnUtflyttingField === 'utflytting'}
+					disabled={!harFnr || disabledInnUtflyttingField === utvandret}
 					title={
 						!harFnr
 							? 'Personer med identtype DNR eller NPID kan ikke utvandre fordi de ikke har norsk statsborgerskap'

--- a/apps/dolly-frontend/src/main/js/src/components/bestillingsveileder/stegVelger/steg/steg1/paneler/Personinformasjon.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/bestillingsveileder/stegVelger/steg/steg1/paneler/Personinformasjon.tsx
@@ -83,6 +83,8 @@ export const PersoninformasjonPanel = ({ stateModifier, testnorgeIdent }) => {
 	const harFnr = opts.identtype === 'FNR'
 	//Noen egenskaper kan ikke endres når personen opprettes fra eksisterende eller videreføres med legg til
 
+	const disabledInnUtflyttingField = getDisabledNasjonalitetField(opts)
+
 	const getIgnoreKeys = () => {
 		const ignoreKeys = testnorgeIdent ? [...ignoreKeysTestnorge] : ['identtype']
 		if (sm.attrs.utenlandskBankkonto.checked) {
@@ -93,6 +95,12 @@ export const PersoninformasjonPanel = ({ stateModifier, testnorgeIdent }) => {
 		if (!testnorgeIdent && !harFnr) {
 			ignoreKeys.push('utvandretTilLand')
 		}
+		if (!testnorgeIdent && disabledInnUtflyttingField !== '') {
+			ignoreKeys.push(
+				disabledInnUtflyttingField === 'innflytting' ? 'innvandretFraLand' : 'utvandretTilLand'
+			)
+		}
+
 		return ignoreKeys
 	}
 
@@ -121,8 +129,6 @@ export const PersoninformasjonPanel = ({ stateModifier, testnorgeIdent }) => {
 			</Panel>
 		)
 	}
-
-	const disabledInnUtflyttingField = getDisabledNasjonalitetField(opts)
 
 	return (
 		// @ts-ignore

--- a/apps/dolly-frontend/src/main/js/src/components/bestillingsveileder/utils.js
+++ b/apps/dolly-frontend/src/main/js/src/components/bestillingsveileder/utils.js
@@ -81,3 +81,7 @@ export const getLeggTilIdent = (personFoerLeggTil, identMaster) => {
 	if (identMaster === 'PDLF') return personFoerLeggTil.pdlforvalter?.person?.ident
 	return undefined
 }
+
+export const getSisteDato = (dates) => {
+	return new Date(Math.max.apply(null, dates))
+}

--- a/apps/dolly-frontend/src/main/js/src/components/bestillingsveileder/utils.js
+++ b/apps/dolly-frontend/src/main/js/src/components/bestillingsveileder/utils.js
@@ -83,7 +83,7 @@ export const getLeggTilIdent = (personFoerLeggTil, identMaster) => {
 }
 
 export const getSisteDato = (dates) => {
-	if (dates.length > 0) {
+	if (dates?.length > 0) {
 		return new Date(Math.max.apply(null, dates))
 	}
 	return null

--- a/apps/dolly-frontend/src/main/js/src/components/bestillingsveileder/utils.js
+++ b/apps/dolly-frontend/src/main/js/src/components/bestillingsveileder/utils.js
@@ -83,5 +83,8 @@ export const getLeggTilIdent = (personFoerLeggTil, identMaster) => {
 }
 
 export const getSisteDato = (dates) => {
-	return new Date(Math.max.apply(null, dates))
+	if (dates.length > 0) {
+		return new Date(Math.max.apply(null, dates))
+	}
+	return null
 }

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/form/initialValues.ts
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/form/initialValues.ts
@@ -198,7 +198,7 @@ export const initialFalskIdentitetValues = {
 export const initialInnvandring = {
 	fraflyttingsland: '',
 	fraflyttingsstedIUtlandet: '',
-	innflyttingsdato: new Date(),
+	innflyttingsdato: '',
 	master: 'FREG',
 	kilde: 'Dolly',
 }
@@ -206,7 +206,7 @@ export const initialInnvandring = {
 export const initialUtvandring = {
 	tilflyttingsland: '',
 	tilflyttingsstedIUtlandet: '',
-	utflyttingsdato: new Date(),
+	utflyttingsdato: '',
 	master: 'FREG',
 	kilde: 'Dolly',
 }

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/form/initialValues.ts
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/form/initialValues.ts
@@ -198,7 +198,7 @@ export const initialFalskIdentitetValues = {
 export const initialInnvandring = {
 	fraflyttingsland: '',
 	fraflyttingsstedIUtlandet: '',
-	innflyttingsdato: '',
+	innflyttingsdato: null as string,
 	master: 'FREG',
 	kilde: 'Dolly',
 }
@@ -206,7 +206,7 @@ export const initialInnvandring = {
 export const initialUtvandring = {
 	tilflyttingsland: '',
 	tilflyttingsstedIUtlandet: '',
-	utflyttingsdato: '',
+	utflyttingsdato: null as string,
 	master: 'FREG',
 	kilde: 'Dolly',
 }

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/form/partials/innvandring/Innvandring.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/form/partials/innvandring/Innvandring.tsx
@@ -64,6 +64,7 @@ export const Innvandring = () => {
 				header="Innvandring"
 				newEntry={initialInnvandring}
 				canBeEmpty={false}
+				maxEntries={1}
 			>
 				{(path: string, _idx: number) => <InnvandringForm path={path} minDate={datoBegresning} />}
 			</FormikDollyFieldArray>

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/form/partials/innvandring/Innvandring.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/form/partials/innvandring/Innvandring.tsx
@@ -1,11 +1,9 @@
 import React, { useContext } from 'react'
 // @ts-ignore
 import { FormikSelect } from '~/components/ui/form/inputs/select/Select'
-import { FormikDollyFieldArray } from '~/components/ui/form/fieldArray/DollyFieldArray'
 import { AvansertForm } from '~/components/fagsystem/pdlf/form/partials/avansert/AvansertForm'
 import { FormikTextInput } from '~/components/ui/form/inputs/textInput/TextInput'
 import { FormikDatepicker } from '~/components/ui/form/inputs/datepicker/Datepicker'
-import { initialInnvandring } from '~/components/fagsystem/pdlf/form/initialValues'
 import { AdresseKodeverk } from '~/config/kodeverk'
 import { DatepickerWrapper } from '~/components/ui/form/inputs/datepicker/DatepickerStyled'
 import { BestillingsveilederContext } from '~/components/bestillingsveileder/Bestillingsveileder'
@@ -58,16 +56,8 @@ export const Innvandring = () => {
 	const datoBegresning = sisteDatoUtvandring()
 
 	return (
-		<div className="flexbox--flex-wrap">
-			<FormikDollyFieldArray
-				name={'pdldata.person.innflytting'}
-				header="Innvandring"
-				newEntry={initialInnvandring}
-				canBeEmpty={false}
-				maxEntries={1}
-			>
-				{(path: string, _idx: number) => <InnvandringForm path={path} minDate={datoBegresning} />}
-			</FormikDollyFieldArray>
+		<div className="person-visning_content">
+			<InnvandringForm path={'pdldata.person.innflytting[0]'} minDate={datoBegresning} />
 		</div>
 	)
 }

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/form/partials/innvandring/Innvandring.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/form/partials/innvandring/Innvandring.tsx
@@ -47,7 +47,9 @@ export const Innvandring = () => {
 			let siste = getSisteDato(
 				utflytting?.map((val: UtflyttingFraNorge) => new Date(val.utflyttingsdato))
 			)
-			siste.setDate(siste.getDate() + 1)
+			if (siste !== null) {
+				siste.setDate(siste.getDate() + 1)
+			}
 			return siste
 		}
 		return null

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/form/partials/innvandring/Innvandring.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/form/partials/innvandring/Innvandring.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useContext } from 'react'
 // @ts-ignore
 import { FormikSelect } from '~/components/ui/form/inputs/select/Select'
 import { FormikDollyFieldArray } from '~/components/ui/form/fieldArray/DollyFieldArray'
@@ -8,12 +8,16 @@ import { FormikDatepicker } from '~/components/ui/form/inputs/datepicker/Datepic
 import { initialInnvandring } from '~/components/fagsystem/pdlf/form/initialValues'
 import { AdresseKodeverk } from '~/config/kodeverk'
 import { DatepickerWrapper } from '~/components/ui/form/inputs/datepicker/DatepickerStyled'
+import { BestillingsveilederContext } from '~/components/bestillingsveileder/Bestillingsveileder'
+import { UtflyttingFraNorge } from '~/pages/gruppe/PersonVisning/PersonMiljoeinfo/PdlDataTyper'
+import { getSisteDato } from '~/components/bestillingsveileder/utils'
 
 type InnvandringTypes = {
 	path: string
+	minDate?: Date
 }
 
-export const InnvandringForm = ({ path }: InnvandringTypes) => {
+export const InnvandringForm = ({ path, minDate }: InnvandringTypes) => {
 	return (
 		<>
 			<FormikSelect
@@ -25,7 +29,11 @@ export const InnvandringForm = ({ path }: InnvandringTypes) => {
 			/>
 			<FormikTextInput name={`${path}.fraflyttingsstedIUtlandet`} label="Fraflyttingssted" />
 			<DatepickerWrapper>
-				<FormikDatepicker name={`${path}.innflyttingsdato`} label="Innflyttingsdato" />
+				<FormikDatepicker
+					name={`${path}.innflyttingsdato`}
+					label="Innflyttingsdato"
+					minDate={minDate}
+				/>
 			</DatepickerWrapper>
 			<AvansertForm path={path} kanVelgeMaster={false} />
 		</>
@@ -33,6 +41,22 @@ export const InnvandringForm = ({ path }: InnvandringTypes) => {
 }
 
 export const Innvandring = () => {
+	const opts = useContext(BestillingsveilederContext)
+
+	const sisteDatoUtvandring = () => {
+		if (opts.is.leggTil) {
+			const utflytting = opts?.personFoerLeggTil?.pdl?.hentPerson?.utflyttingFraNorge
+			let siste = getSisteDato(
+				utflytting?.map((val: UtflyttingFraNorge) => new Date(val.utflyttingsdato))
+			)
+			siste.setDate(siste.getDate() + 1)
+			return siste
+		}
+		return null
+	}
+
+	const datoBegresning = sisteDatoUtvandring()
+
 	return (
 		<div className="flexbox--flex-wrap">
 			<FormikDollyFieldArray
@@ -41,7 +65,7 @@ export const Innvandring = () => {
 				newEntry={initialInnvandring}
 				canBeEmpty={false}
 			>
-				{(path: string, _idx: number) => <InnvandringForm path={path} />}
+				{(path: string, _idx: number) => <InnvandringForm path={path} minDate={datoBegresning} />}
 			</FormikDollyFieldArray>
 		</div>
 	)

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/form/partials/utvandring/Utvandring.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/form/partials/utvandring/Utvandring.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useContext } from 'react'
 // @ts-ignore
 import { FormikSelect } from '~/components/ui/form/inputs/select/Select'
 import { FormikDollyFieldArray } from '~/components/ui/form/fieldArray/DollyFieldArray'
@@ -8,12 +8,16 @@ import { FormikDatepicker } from '~/components/ui/form/inputs/datepicker/Datepic
 import { initialUtvandring } from '~/components/fagsystem/pdlf/form/initialValues'
 import { AdresseKodeverk } from '~/config/kodeverk'
 import { DatepickerWrapper } from '~/components/ui/form/inputs/datepicker/DatepickerStyled'
+import { BestillingsveilederContext } from '~/components/bestillingsveileder/Bestillingsveileder'
+import { InnflyttingTilNorge } from '~/pages/gruppe/PersonVisning/PersonMiljoeinfo/PdlDataTyper'
+import { getSisteDato } from '~/components/bestillingsveileder/utils'
 
 type UtvandringTypes = {
 	path: string
+	minDate?: Date
 }
 
-export const UtvandringForm = ({ path }: UtvandringTypes) => {
+export const UtvandringForm = ({ path, minDate }: UtvandringTypes) => {
 	return (
 		<>
 			<FormikSelect
@@ -25,7 +29,11 @@ export const UtvandringForm = ({ path }: UtvandringTypes) => {
 			/>
 			<FormikTextInput name={`${path}.tilflyttingsstedIUtlandet`} label="Tilflyttingssted" />
 			<DatepickerWrapper>
-				<FormikDatepicker name={`${path}.utflyttingsdato`} label="Utflyttingsdato" />
+				<FormikDatepicker
+					name={`${path}.utflyttingsdato`}
+					label="Utflyttingsdato"
+					minDate={minDate}
+				/>
 			</DatepickerWrapper>
 			<AvansertForm path={path} kanVelgeMaster={false} />
 		</>
@@ -33,6 +41,23 @@ export const UtvandringForm = ({ path }: UtvandringTypes) => {
 }
 
 export const Utvandring = () => {
+	const opts = useContext(BestillingsveilederContext)
+
+	const sisteDatoInnflytting = () => {
+		if (opts.is.leggTil) {
+			const innflytting = opts?.personFoerLeggTil?.pdl?.hentPerson?.innflyttingTilNorge
+			let siste = getSisteDato(
+				innflytting?.map(
+					(val: InnflyttingTilNorge) => new Date(val.folkeregistermetadata?.gyldighetstidspunkt)
+				)
+			)
+			siste.setDate(siste.getDate() + 1)
+			return siste
+		}
+		return null
+	}
+
+	const datoBegresning = sisteDatoInnflytting()
 	return (
 		<div className="flexbox--flex-wrap">
 			<FormikDollyFieldArray
@@ -41,7 +66,7 @@ export const Utvandring = () => {
 				newEntry={initialUtvandring}
 				canBeEmpty={false}
 			>
-				{(path: string, _idx: number) => <UtvandringForm path={path} />}
+				{(path: string, _idx: number) => <UtvandringForm path={path} minDate={datoBegresning} />}
 			</FormikDollyFieldArray>
 		</div>
 	)

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/form/partials/utvandring/Utvandring.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/form/partials/utvandring/Utvandring.tsx
@@ -65,6 +65,7 @@ export const Utvandring = () => {
 				header="Utvandring"
 				newEntry={initialUtvandring}
 				canBeEmpty={false}
+				maxEntries={1}
 			>
 				{(path: string, _idx: number) => <UtvandringForm path={path} minDate={datoBegresning} />}
 			</FormikDollyFieldArray>

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/form/partials/utvandring/Utvandring.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/form/partials/utvandring/Utvandring.tsx
@@ -45,11 +45,14 @@ export const Utvandring = () => {
 		if (opts.is.leggTil) {
 			const innflytting = opts?.personFoerLeggTil?.pdl?.hentPerson?.innflyttingTilNorge
 			let siste = getSisteDato(
-				innflytting?.map(
-					(val: InnflyttingTilNorge) => new Date(val.folkeregistermetadata?.gyldighetstidspunkt)
-				)
+				innflytting
+					?.map((val: InnflyttingTilNorge) => val?.folkeregistermetadata?.gyldighetstidspunkt)
+					.filter((val: string) => val)
+					.map((val: string) => new Date(val))
 			)
-			siste.setDate(siste.getDate() + 1)
+			if (siste !== null) {
+				siste.setDate(siste.getDate() + 1)
+			}
 			return siste
 		}
 		return null

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/form/partials/utvandring/Utvandring.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/form/partials/utvandring/Utvandring.tsx
@@ -59,16 +59,8 @@ export const Utvandring = () => {
 
 	const datoBegresning = sisteDatoInnflytting()
 	return (
-		<div className="flexbox--flex-wrap">
-			<FormikDollyFieldArray
-				name={'pdldata.person.utflytting'}
-				header="Utvandring"
-				newEntry={initialUtvandring}
-				canBeEmpty={false}
-				maxEntries={1}
-			>
-				{(path: string, _idx: number) => <UtvandringForm path={path} minDate={datoBegresning} />}
-			</FormikDollyFieldArray>
+		<div className="person-visning_content">
+			<UtvandringForm path={'pdldata.person.utflytting[0]'} minDate={datoBegresning} />
 		</div>
 	)
 }

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/form/partials/utvandring/Utvandring.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/form/partials/utvandring/Utvandring.tsx
@@ -1,11 +1,9 @@
 import React, { useContext } from 'react'
 // @ts-ignore
 import { FormikSelect } from '~/components/ui/form/inputs/select/Select'
-import { FormikDollyFieldArray } from '~/components/ui/form/fieldArray/DollyFieldArray'
 import { AvansertForm } from '~/components/fagsystem/pdlf/form/partials/avansert/AvansertForm'
 import { FormikTextInput } from '~/components/ui/form/inputs/textInput/TextInput'
 import { FormikDatepicker } from '~/components/ui/form/inputs/datepicker/Datepicker'
-import { initialUtvandring } from '~/components/fagsystem/pdlf/form/initialValues'
 import { AdresseKodeverk } from '~/config/kodeverk'
 import { DatepickerWrapper } from '~/components/ui/form/inputs/datepicker/DatepickerStyled'
 import { BestillingsveilederContext } from '~/components/bestillingsveileder/Bestillingsveileder'

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/form/validation.js
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/form/validation.js
@@ -4,7 +4,6 @@ import _get from 'lodash/get'
 import { differenceInWeeks, isAfter, isBefore, isEqual, isSameDay } from 'date-fns'
 import { landkoder, landkodeIsoMapping } from '~/service/services/kontoregister/landkoder'
 import { isNil } from 'lodash'
-import _isNil from 'lodash/isNil'
 
 const testTelefonnummer = () =>
 	Yup.string()

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/visning/VisningRedigerbar.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/visning/VisningRedigerbar.tsx
@@ -39,6 +39,7 @@ type VisningTypes = {
 	path: string
 	ident: string
 	identtype?: string
+	disableSlett?: boolean
 }
 
 enum Modus {
@@ -95,6 +96,7 @@ export const VisningRedigerbar = ({
 	path,
 	ident,
 	identtype,
+	disableSlett = false,
 }: VisningTypes) => {
 	const [visningModus, setVisningModus] = useState(Modus.Les)
 	const [errorMessagePdlf, setErrorMessagePdlf] = useState(null)
@@ -228,7 +230,12 @@ export const VisningRedigerbar = ({
 					{dataVisning}
 					<EditDeleteKnapper>
 						<Button kind="edit" onClick={() => setVisningModus(Modus.Skriv)} title="Endre" />
-						<Button kind="trashcan" onClick={() => openModal()} title="Slett" />
+						<Button
+							kind="trashcan"
+							onClick={() => openModal()}
+							title="Slett"
+							disabled={disableSlett}
+						/>
 						<DollyModal isOpen={modalIsOpen} closeModal={closeModal} width="40%" overflow="auto">
 							<div className="slettModal">
 								<div className="slettModal slettModal-content">

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/visning/partials/Innvandring.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/visning/partials/Innvandring.tsx
@@ -1,18 +1,23 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { DollyFieldArray } from '~/components/ui/form/fieldArray/DollyFieldArray'
 import { TitleValue } from '~/components/ui/titleValue/TitleValue'
 import { AdresseKodeverk } from '~/config/kodeverk'
 import Formatters from '~/utils/DataFormatter'
 import { ErrorBoundary } from '~/components/ui/appError/ErrorBoundary'
-import { InnvandringValues } from '~/pages/gruppe/PersonVisning/PersonMiljoeinfo/PdlDataTyper'
+import {
+	InnvandringValues,
+	UtvandringValues,
+} from '~/pages/gruppe/PersonVisning/PersonMiljoeinfo/PdlDataTyper'
 import _cloneDeep from 'lodash/cloneDeep'
 import { initialInnvandring } from '~/components/fagsystem/pdlf/form/initialValues'
 import _get from 'lodash/get'
 import VisningRedigerbarConnector from '~/components/fagsystem/pdlf/visning/VisningRedigerbarConnector'
 import { PersonData } from '~/components/fagsystem/pdlf/PdlTypes'
+import { getSisteDato } from '~/components/bestillingsveileder/utils'
 
 type InnvandringTypes = {
 	data: Array<InnvandringValues>
+	utflyttingData?: Array<UtvandringValues>
 	tmpPersoner?: Array<PersonData>
 	ident?: string
 	erPdlVisning?: boolean
@@ -21,14 +26,46 @@ type InnvandringTypes = {
 type InnvandringVisningTypes = {
 	innvandringData: InnvandringValues
 	idx: number
+	sisteDato?: Date
+}
+
+export const getSisteDatoInnUtvandring = (
+	innflyttingData: Array<InnvandringValues>,
+	utflyttingData: Array<UtvandringValues>,
+	tmpPersoner?: Array<PersonData>,
+	ident?: string
+) => {
+	const tmpPerson = tmpPersoner?.hasOwnProperty(ident)
+
+	const innflytting = tmpPerson ? _get(tmpPersoner, `${ident}.person.innflytting`) : innflyttingData
+	const utflytting = tmpPerson ? _get(tmpPersoner, `${ident}.person.utflytting`) : utflyttingData
+
+	let sisteInnflytting = getSisteDato(
+		innflytting?.map((val: InnvandringValues) => new Date(val.innflyttingsdato))
+	)
+	let sisteUtflytting = getSisteDato(
+		utflytting?.map((val: UtvandringValues) => new Date(val.utflyttingsdato))
+	)
+	return sisteInnflytting > sisteUtflytting ? sisteInnflytting : sisteUtflytting
 }
 
 export const Innvandring = ({
 	data,
+	utflyttingData,
 	tmpPersoner,
 	ident,
 	erPdlVisning = false,
 }: InnvandringTypes) => {
+	const [sisteDato, setSisteDato] = useState(
+		getSisteDatoInnUtvandring(data, utflyttingData, tmpPersoner, ident)
+	)
+
+	useEffect(() => {
+		if (data?.length > 0) {
+			setSisteDato(getSisteDatoInnUtvandring(data, utflyttingData, tmpPersoner, ident))
+		}
+	}, [tmpPersoner])
+
 	if (data.length < 1) {
 		return null
 	}
@@ -53,7 +90,7 @@ export const Innvandring = ({
 		)
 	}
 
-	const InnvandringVisning = ({ innvandringData, idx }: InnvandringVisningTypes) => {
+	const InnvandringVisning = ({ innvandringData, idx, sisteDato }: InnvandringVisningTypes) => {
 		const initInnvandring = Object.assign(_cloneDeep(initialInnvandring), data[idx])
 		const initialValues = { innflytting: initInnvandring }
 
@@ -80,6 +117,7 @@ export const Innvandring = ({
 				redigertAttributt={redigertInnvandringValues}
 				path="innflytting"
 				ident={ident}
+				disableSlett={new Date(innvandringData.innflyttingsdato) < sisteDato}
 			/>
 		)
 	}
@@ -89,7 +127,7 @@ export const Innvandring = ({
 			<ErrorBoundary>
 				<DollyFieldArray data={data} header="Innvandret" nested>
 					{(innvandring: InnvandringValues, idx: number) => (
-						<InnvandringVisning innvandringData={innvandring} idx={idx} />
+						<InnvandringVisning innvandringData={innvandring} idx={idx} sisteDato={sisteDato} />
 					)}
 				</DollyFieldArray>
 			</ErrorBoundary>

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/visning/partials/Nasjonalitet.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/visning/partials/Nasjonalitet.tsx
@@ -45,6 +45,7 @@ export const Nasjonalitet = ({
 			{innflytting?.length > 0 && (
 				<Innvandring
 					data={innflytting}
+					utflyttingData={utflytting}
 					tmpPersoner={tmpPersoner}
 					ident={ident}
 					erPdlVisning={erPdlVisning}
@@ -53,6 +54,7 @@ export const Nasjonalitet = ({
 			{utflytting?.length > 0 && (
 				<Utvandring
 					data={utflytting}
+					innflyttingData={innflytting}
 					tmpPersoner={tmpPersoner}
 					ident={ident}
 					erPdlVisning={erPdlVisning}

--- a/apps/dolly-frontend/src/main/js/src/components/ui/form/fieldArray/DollyFieldArray.js
+++ b/apps/dolly-frontend/src/main/js/src/components/ui/form/fieldArray/DollyFieldArray.js
@@ -217,35 +217,42 @@ export const FormikDollyFieldArray = ({
 							const handleRemove = () => {
 								handleRemoveEntry ? handleRemoveEntry(idx) : arrayHelpers.remove(idx)
 							}
-							return nested ? (
-								<DollyFaBlokkNested key={idx} idx={idx} handleRemove={handleRemove}>
-									{children(path, idx, curr)}
-								</DollyFaBlokkNested>
-							) : isOrganisasjon ? (
-								<DollyFaBlokkOrg
-									key={idx}
-									idx={idx}
-									number={number}
-									header={header}
-									hjelpetekst={hjelpetekst}
-									handleRemove={handleRemove}
-									showDeleteButton={showDeleteButton}
-								>
-									{children(path, idx, curr, number)}
-								</DollyFaBlokkOrg>
-							) : (
-								<DollyFaBlokk
-									key={idx}
-									idx={idx}
-									number={number}
-									header={header}
-									hjelpetekst={hjelpetekst}
-									handleRemove={handleRemove}
-									showDeleteButton={showDeleteButton}
-								>
-									{children(path, idx, curr, number)}
-								</DollyFaBlokk>
-							)
+
+							if (nested) {
+								return (
+									<DollyFaBlokkNested key={idx} idx={idx} handleRemove={handleRemove}>
+										{children(path, idx, curr)}
+									</DollyFaBlokkNested>
+								)
+							} else if (isOrganisasjon) {
+								return (
+									<DollyFaBlokkOrg
+										key={idx}
+										idx={idx}
+										number={number}
+										header={header}
+										hjelpetekst={hjelpetekst}
+										handleRemove={handleRemove}
+										showDeleteButton={showDeleteButton}
+									>
+										{children(path, idx, curr, number)}
+									</DollyFaBlokkOrg>
+								)
+							} else {
+								return (
+									<DollyFaBlokk
+										key={idx}
+										idx={idx}
+										number={number}
+										header={header}
+										hjelpetekst={hjelpetekst}
+										handleRemove={handleRemove}
+										showDeleteButton={showDeleteButton}
+									>
+										{children(path, idx, curr, number)}
+									</DollyFaBlokk>
+								)
+							}
 						})}
 						<FieldArrayAddButton
 							hoverText={title || (maxEntries === values.length && maxReachedDescription)}


### PR DESCRIPTION
Har oppdatert bestilling av inn- og utvandring. Du kan nå kun bestille en av hver om gangen. Og hvis en person allerede er innvandret så er bestilling av innvandring disabled. Det samme gjelder også for utvandring. 

I tillegg så kan du nå bare legge til innvandring/utvandring med dato etter siste utvandring/innvandring. Når du lager en ny person kan du velge både inn- og utvandring, men disse kan ikke ha samme dato. 