### PR TITLE
Dolly frontend/inn utvandring slett disabling

### DIFF
--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/visning/VisningRedigerbar.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/visning/VisningRedigerbar.tsx
@@ -39,7 +39,7 @@ type VisningTypes = {
 	path: string
 	ident: string
 	identtype?: string
-	slettDisabled?: boolean
+	disableSlett?: boolean
 }
 
 enum Modus {
@@ -96,7 +96,7 @@ export const VisningRedigerbar = ({
 	path,
 	ident,
 	identtype,
-	slettDisabled = false,
+	disableSlett = false,
 }: VisningTypes) => {
 	const [visningModus, setVisningModus] = useState(Modus.Les)
 	const [errorMessagePdlf, setErrorMessagePdlf] = useState(null)
@@ -234,7 +234,7 @@ export const VisningRedigerbar = ({
 							kind="trashcan"
 							onClick={() => openModal()}
 							title="Slett"
-							disabled={slettDisabled}
+							disabled={disableSlett}
 						/>
 						<DollyModal isOpen={modalIsOpen} closeModal={closeModal} width="40%" overflow="auto">
 							<div className="slettModal">

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/visning/VisningRedigerbar.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/visning/VisningRedigerbar.tsx
@@ -39,6 +39,7 @@ type VisningTypes = {
 	path: string
 	ident: string
 	identtype?: string
+	slettDisabled?: boolean
 }
 
 enum Modus {
@@ -95,6 +96,7 @@ export const VisningRedigerbar = ({
 	path,
 	ident,
 	identtype,
+	slettDisabled = false,
 }: VisningTypes) => {
 	const [visningModus, setVisningModus] = useState(Modus.Les)
 	const [errorMessagePdlf, setErrorMessagePdlf] = useState(null)
@@ -228,7 +230,12 @@ export const VisningRedigerbar = ({
 					{dataVisning}
 					<EditDeleteKnapper>
 						<Button kind="edit" onClick={() => setVisningModus(Modus.Skriv)} title="Endre" />
-						<Button kind="trashcan" onClick={() => openModal()} title="Slett" />
+						<Button
+							kind="trashcan"
+							onClick={() => openModal()}
+							title="Slett"
+							disabled={slettDisabled}
+						/>
 						<DollyModal isOpen={modalIsOpen} closeModal={closeModal} width="40%" overflow="auto">
 							<div className="slettModal">
 								<div className="slettModal slettModal-content">

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/visning/partials/Innvandring.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/visning/partials/Innvandring.tsx
@@ -5,7 +5,6 @@ import { AdresseKodeverk } from '~/config/kodeverk'
 import Formatters from '~/utils/DataFormatter'
 import { ErrorBoundary } from '~/components/ui/appError/ErrorBoundary'
 import {
-	InnflyttingTilNorge,
 	InnvandringValues,
 	UtvandringValues,
 } from '~/pages/gruppe/PersonVisning/PersonMiljoeinfo/PdlDataTyper'

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/visning/partials/Innvandring.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/visning/partials/Innvandring.tsx
@@ -101,7 +101,7 @@ export const Innvandring = ({
 				redigertAttributt={redigertInnvandringValues}
 				path="innflytting"
 				ident={ident}
-				slettDisabled={new Date(innvandringData.innflyttingsdato) < sisteDato}
+				disableSlett={new Date(innvandringData.innflyttingsdato) < sisteDato}
 			/>
 		)
 	}

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/visning/partials/Nasjonalitet.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/visning/partials/Nasjonalitet.tsx
@@ -45,6 +45,7 @@ export const Nasjonalitet = ({
 			{innflytting?.length > 0 && (
 				<Innvandring
 					data={innflytting}
+					utflyttingData={utflytting}
 					tmpPersoner={tmpPersoner}
 					ident={ident}
 					erPdlVisning={erPdlVisning}
@@ -53,6 +54,7 @@ export const Nasjonalitet = ({
 			{utflytting?.length > 0 && (
 				<Utvandring
 					data={utflytting}
+					innflyttingData={innflytting}
 					tmpPersoner={tmpPersoner}
 					ident={ident}
 					erPdlVisning={erPdlVisning}

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/visning/partials/Utvandring.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/visning/partials/Utvandring.tsx
@@ -4,15 +4,21 @@ import { TitleValue } from '~/components/ui/titleValue/TitleValue'
 import { AdresseKodeverk } from '~/config/kodeverk'
 import Formatters from '~/utils/DataFormatter'
 import { ErrorBoundary } from '~/components/ui/appError/ErrorBoundary'
-import { UtvandringValues } from '~/pages/gruppe/PersonVisning/PersonMiljoeinfo/PdlDataTyper'
+import {
+	InnvandringValues,
+	UtvandringValues,
+} from '~/pages/gruppe/PersonVisning/PersonMiljoeinfo/PdlDataTyper'
 import { PersonData } from '~/components/fagsystem/pdlf/PdlTypes'
 import _cloneDeep from 'lodash/cloneDeep'
 import { initialUtvandring } from '~/components/fagsystem/pdlf/form/initialValues'
 import _get from 'lodash/get'
 import VisningRedigerbarConnector from '~/components/fagsystem/pdlf/visning/VisningRedigerbarConnector'
+import { getSisteDatoInnUtvandring } from '~/components/fagsystem/pdlf/visning/partials/Innvandring'
+import { utflytting } from '~/components/fagsystem/pdlf/form/validation'
 
 type UtvandringTypes = {
 	data: Array<UtvandringValues>
+	innflyttingData?: Array<InnvandringValues>
 	tmpPersoner?: Array<PersonData>
 	ident?: string
 	erPdlVisning?: boolean
@@ -21,9 +27,16 @@ type UtvandringTypes = {
 type UtvandringVisningTypes = {
 	utvandringData: UtvandringValues
 	idx: number
+	sisteDato?: Date
 }
 
-export const Utvandring = ({ data, tmpPersoner, ident, erPdlVisning }: UtvandringTypes) => {
+export const Utvandring = ({
+	data,
+	innflyttingData,
+	tmpPersoner,
+	ident,
+	erPdlVisning,
+}: UtvandringTypes) => {
 	if (data.length < 1) {
 		return null
 	}
@@ -48,7 +61,7 @@ export const Utvandring = ({ data, tmpPersoner, ident, erPdlVisning }: Utvandrin
 		)
 	}
 
-	const UtvandringVisning = ({ utvandringData, idx }: UtvandringVisningTypes) => {
+	const UtvandringVisning = ({ utvandringData, idx, sisteDato }: UtvandringVisningTypes) => {
 		const initUtvandring = Object.assign(_cloneDeep(initialUtvandring), data[idx])
 		const initialValues = { utflytting: initUtvandring }
 
@@ -75,16 +88,23 @@ export const Utvandring = ({ data, tmpPersoner, ident, erPdlVisning }: Utvandrin
 				redigertAttributt={redigertUtvandringValues}
 				path="utflytting"
 				ident={ident}
+				slettDisabled={new Date(utvandringData.utflyttingsdato) < sisteDato}
 			/>
 		)
 	}
+
+	const sisteDatoForVandring = getSisteDatoInnUtvandring(innflyttingData, data)
 
 	return (
 		<div className="person-visning_content" style={{ marginTop: '-20px' }}>
 			<ErrorBoundary>
 				<DollyFieldArray data={data} header={'Utvandret'} nested>
 					{(utvandring: UtvandringValues, idx: number) => (
-						<UtvandringVisning utvandringData={utvandring} idx={idx} />
+						<UtvandringVisning
+							utvandringData={utvandring}
+							idx={idx}
+							sisteDato={sisteDatoForVandring}
+						/>
 					)}
 				</DollyFieldArray>
 			</ErrorBoundary>

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/visning/partials/Utvandring.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/visning/partials/Utvandring.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { DollyFieldArray } from '~/components/ui/form/fieldArray/DollyFieldArray'
 import { TitleValue } from '~/components/ui/titleValue/TitleValue'
 import { AdresseKodeverk } from '~/config/kodeverk'
@@ -36,6 +36,16 @@ export const Utvandring = ({
 	ident,
 	erPdlVisning,
 }: UtvandringTypes) => {
+	const [sisteDato, setSisteDato] = useState(
+		getSisteDatoInnUtvandring(innflyttingData, data, tmpPersoner, ident)
+	)
+
+	useEffect(() => {
+		if (data?.length > 0) {
+			setSisteDato(getSisteDatoInnUtvandring(innflyttingData, data, tmpPersoner, ident))
+		}
+	}, [tmpPersoner])
+
 	if (data.length < 1) {
 		return null
 	}
@@ -92,18 +102,12 @@ export const Utvandring = ({
 		)
 	}
 
-	const sisteDatoForVandring = getSisteDatoInnUtvandring(innflyttingData, data)
-
 	return (
 		<div className="person-visning_content" style={{ marginTop: '-20px' }}>
 			<ErrorBoundary>
 				<DollyFieldArray data={data} header={'Utvandret'} nested>
 					{(utvandring: UtvandringValues, idx: number) => (
-						<UtvandringVisning
-							utvandringData={utvandring}
-							idx={idx}
-							sisteDato={sisteDatoForVandring}
-						/>
+						<UtvandringVisning utvandringData={utvandring} idx={idx} sisteDato={sisteDato} />
 					)}
 				</DollyFieldArray>
 			</ErrorBoundary>

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/visning/partials/Utvandring.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/visning/partials/Utvandring.tsx
@@ -88,7 +88,7 @@ export const Utvandring = ({
 				redigertAttributt={redigertUtvandringValues}
 				path="utflytting"
 				ident={ident}
-				slettDisabled={new Date(utvandringData.utflyttingsdato) < sisteDato}
+				disableSlett={new Date(utvandringData.utflyttingsdato) < sisteDato}
 			/>
 		)
 	}

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/visning/partials/Utvandring.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/visning/partials/Utvandring.tsx
@@ -14,7 +14,6 @@ import { initialUtvandring } from '~/components/fagsystem/pdlf/form/initialValue
 import _get from 'lodash/get'
 import VisningRedigerbarConnector from '~/components/fagsystem/pdlf/visning/VisningRedigerbarConnector'
 import { getSisteDatoInnUtvandring } from '~/components/fagsystem/pdlf/visning/partials/Innvandring'
-import { utflytting } from '~/components/fagsystem/pdlf/form/validation'
 
 type UtvandringTypes = {
 	data: Array<UtvandringValues>


### PR DESCRIPTION
Har lagt til at kun den siste Inn-eller utvandring kan bli slettet fra personvisning. Du kan altså ikke slette en utvandring hvis personen har innvandret etter utvandringen og vice versa.

Merger denne inn i den andre pr-en jeg har for inn- og utvandring begrensninger. 