### PR TITLE
Lagt til helsepersonell-service i inbound

### DIFF
--- a/apps/dolly-backend/config.yml
+++ b/apps/dolly-backend/config.yml
@@ -20,6 +20,8 @@ spec:
         - application: etterlatte-testdata
           cluster: dev-gcp
           namespace: etterlatte
+        - application: testnav-helsepersonell-service
+          cluster: dev-gcp
     outbound:
       rules:
         - application: testnav-helsepersonell-service

--- a/proxies/pdl-proxy/config.yml
+++ b/proxies/pdl-proxy/config.yml
@@ -40,6 +40,8 @@ spec:
           cluster: dev-gcp
         - application: testnav-synt-sykemelding-api
           cluster: dev-gcp
+        - application: testnav-helsepersonell-service
+          cluster: dev-gcp
   liveness:
     path: /internal/isAlive
     initialDelay: 4


### PR DESCRIPTION
Jobber med ny versjon av helsepersonell-service som bruker dolly og pdl i stedet for hodejegeren for å hente info om helsepersonell. Har dermed lagt til appen i inbound rules for dolly-backend og pdl-proxy for å kunne teste ny versjon. 