### PR TITLE
Oversikt frontend - Oppdatert default header link

### DIFF
--- a/apps/oversikt-frontend/src/main/js/src/pages/Page/Page.tsx
+++ b/apps/oversikt-frontend/src/main/js/src/pages/Page/Page.tsx
@@ -39,7 +39,7 @@ const Page = ({ children, loggedIn = true }: Props) => (
 						Magic Token
 					</HeaderLink>
 					<HeaderLink
-						href="/access-token/dev-fss.dolly.dolly-backend"
+						href="/access-token/dev-gcp.dolly.dolly-backend"
 						isActive={() => window.location.pathname.includes('/access-token')}
 					>
 						Access Token


### PR DESCRIPTION
Oppdatert headerlink sånn at du får token for dolly-backend dev-gcp og ikke dev-fss.