### PR TITLE
Sender ikke orgStatus kall for organisasjon dersom det er identbestilling

### DIFF
--- a/apps/dolly-frontend/src/main/js/src/components/bestilling/statusListe/BestillingProgresjon/BestillingProgresjon.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/bestilling/statusListe/BestillingProgresjon/BestillingProgresjon.tsx
@@ -41,7 +41,7 @@ export const BestillingProgresjon = ({
 		}
 	}
 
-	const { bestillingStatus } = useOrganisasjonBestillingStatus(bestilling.id, true)
+	const { bestillingStatus } = useOrganisasjonBestillingStatus(bestilling.id, erOrganisasjon, true)
 
 	useEffect(() => {
 		if (erOrganisasjon) {

--- a/apps/dolly-frontend/src/main/js/src/utils/hooks/useOrganisasjoner.tsx
+++ b/apps/dolly-frontend/src/main/js/src/utils/hooks/useOrganisasjoner.tsx
@@ -95,11 +95,21 @@ export const useOrganisasjonBestilling = (brukerId: string, autoRefresh = false)
 	}
 }
 
-export const useOrganisasjonBestillingStatus = (bestillingId: number, autoRefresh = false) => {
+export const useOrganisasjonBestillingStatus = (
+	bestillingId: number,
+	erOrganisasjon: boolean,
+	autoRefresh = false
+) => {
+	if (erOrganisasjon) {
+		return {
+			loading: false,
+			error: 'Bestilling er ikke org!',
+		}
+	}
 	if (!bestillingId) {
 		return {
 			loading: false,
-			error: 'bestillingId mangler!',
+			error: 'BestillingId mangler!',
 		}
 	}
 	const { data, error } = useSWR<Bestillingsstatus[], Error>(


### PR DESCRIPTION
Tror ikke dette skal føre til noen feil med gjeldende implementasjon siden erOrganisasjon sjekken blir utført i useEffect under hvor statusen tas i bruk, men er jo et unødvendig kall så greit å fjerne😅 