### PR TITLE
Pdl-forvalter - Fikset query for geografiske kodeverk

### DIFF
--- a/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/consumer/GeografiskeKodeverkConsumer.java
+++ b/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/consumer/GeografiskeKodeverkConsumer.java
@@ -76,7 +76,7 @@ public class GeografiskeKodeverkConsumer {
     public String getPoststedNavn(String postnummer) {
         return tokenExchange
                 .exchange(properties)
-                .flatMapMany(token -> new GeografiskeKodeverkCommand(webClient, POSTNUMMER_URL, postnummer, token.getTokenValue()).call())
+                .flatMapMany(token -> new GeografiskeKodeverkCommand(webClient, POSTNUMMER_URL, "postnummer=" + postnummer, token.getTokenValue()).call())
                 .next()
                 .blockOptional()
                 .map(GeografiskeKodeverkDTO::navn)
@@ -86,7 +86,7 @@ public class GeografiskeKodeverkConsumer {
     public String getEmbeteNavn(String embete) {
         return tokenExchange
                 .exchange(properties)
-                .flatMapMany(token -> new GeografiskeKodeverkCommand(webClient, EMBETE_URL, embete, token.getTokenValue()).call())
+                .flatMapMany(token -> new GeografiskeKodeverkCommand(webClient, EMBETE_URL, "embetekode=" + embete, token.getTokenValue()).call())
                 .next()
                 .blockOptional()
                 .map(GeografiskeKodeverkDTO::navn)


### PR DESCRIPTION
Testet kontaktinfo for dødsbo, som er den eneste som bruker postnummer kodeverket i pdl forvalteren og den fikk også lik feil som for embete. Har dermed oppdatert query for begge kall.