### PR TITLE
Dolly frontend/fiks string konvertering addHours

### DIFF
--- a/apps/dolly-frontend/src/main/js/src/components/ui/form/inputs/datepicker/Datepicker.js
+++ b/apps/dolly-frontend/src/main/js/src/components/ui/form/inputs/datepicker/Datepicker.js
@@ -70,7 +70,7 @@ const P_FormikDatepicker = ({ fastfield, addHour = false, ...props }) => (
 				if (props.afterChange) props.afterChange(date)
 				let val = date
 				if (addHour) {
-					val = addHours(new Date(date), 1)
+					val = addHours(new Date(date), 1) + ''
 				}
 				return field.onChange(SyntEvent(field.name, val))
 			}

--- a/apps/dolly-frontend/src/main/js/src/components/ui/form/inputs/datepicker/Datepicker.js
+++ b/apps/dolly-frontend/src/main/js/src/components/ui/form/inputs/datepicker/Datepicker.js
@@ -70,7 +70,7 @@ const P_FormikDatepicker = ({ fastfield, addHour = false, ...props }) => (
 				if (props.afterChange) props.afterChange(date)
 				let val = date
 				if (addHour) {
-					val = addHours(new Date(date), 1) + ''
+					val = addHours(new Date(date), 1).toISOString()
 				}
 				return field.onChange(SyntEvent(field.name, val))
 			}


### PR DESCRIPTION
Fiks for string konvertering når man bruker addHours i bostedadresse. Må konvertere den for at validering av dato når man redigerer bostedadresse direkte i personvisning skal funke.