### PR TITLE
Feature/rydde i inbound rules

### DIFF
--- a/apps/adresse-service/nais.yml
+++ b/apps/adresse-service/nais.yml
@@ -57,8 +57,6 @@ spec:
           cluster: dev-gcp
         - application: dolly-frontend
           cluster: dev-gcp
-        - application: synthdata-tps-gcp
-          cluster: dev-gcp
         - application: app-1
           namespace: plattformsikkerhet
           cluster: dev-gcp

--- a/apps/inntektsmelding-generator-service/config.yml
+++ b/apps/inntektsmelding-generator-service/config.yml
@@ -21,8 +21,6 @@ spec:
           cluster: dev-fss
         - application: testnav-oversikt-frontend
           cluster: dev-gcp
-        - application: testnorge-inntekt
-          cluster: dev-fss
         - application: testnav-inntektsmelding-service
           cluster: dev-gcp
   liveness:

--- a/apps/inntektsmelding-service/config.yml
+++ b/apps/inntektsmelding-service/config.yml
@@ -21,8 +21,6 @@ spec:
           cluster: dev-fss
         - application: testnav-oversikt-frontend
           cluster: dev-gcp
-        - application: testnorge-inntekt
-          cluster: dev-fss
         - application: dolly-backend
           cluster: dev-gcp
         - application: dolly-backend-dev

--- a/apps/mn-organisasjon-api/config.yml
+++ b/apps/mn-organisasjon-api/config.yml
@@ -20,7 +20,6 @@ spec:
       rules:
         - application: team-dolly-lokal-app
           cluster: dev-fss
-        - application: mn-synt-arbeidsforhold-service
         - application: testnav-oversikt-frontend
           cluster: dev-gcp
   liveness:

--- a/apps/mn-synt-arbeidsforhold-service/src/main/resources/application.yml
+++ b/apps/mn-synt-arbeidsforhold-service/src/main/resources/application.yml
@@ -3,17 +3,6 @@ AAD_ISSUER_URI: https://login.microsoftonline.com/62366534-1ec3-4962-8869-9b5535
 consumers:
   hodejegeren:
     url: https://testnorge-hodejegeren.dev.intern.nav.no
-  arbeidsforholdapi:
-    clientId: 1b2f24c8-a426-47b1-8ff1-7905d6dfddb5
-    cluster: dev-fss
-    namespace: dolly
-    name: testnorge-arbeidsforhold-api
-    url: https://testnorge-arbeidsforhold-api.dev.adeo.no
-  mnorganisasjonapi:
-    cluster: dev-fss
-    namespace: dolly
-    name: mn-organisasjon-api
-    url: https://mn-organisasjon-api.dev.adeo.no
   synt-amelding:
     cluster: dev-gcp
     namespace: dolly

--- a/apps/person-service/config.yml
+++ b/apps/person-service/config.yml
@@ -25,8 +25,6 @@ spec:
           cluster: dev-gcp
         - application: testnav-oversikt-frontend
           cluster: dev-gcp
-        - application: testnorge-skd
-          cluster: dev-fss
         - application: dolly-backend
           cluster: dev-fss
         - application: dolly-backend-dev

--- a/apps/testnav-ident-pool/nais.yml
+++ b/apps/testnav-ident-pool/nais.yml
@@ -48,8 +48,6 @@ spec:
           cluster: dev-gcp
         - application: testnav-pdl-forvalter-dev
           cluster: dev-gcp
-        - application: testnorge-skd
-          cluster: dev-fss
         - application: team-dolly-lokal-app
           cluster: dev-fss
         - application: testnav-oversikt-frontend

--- a/apps/tps-messaging-service/nais.yml
+++ b/apps/tps-messaging-service/nais.yml
@@ -68,8 +68,6 @@ spec:
           cluster: dev-gcp
         - application: testnav-ident-pool
           cluster: dev-gcp
-        - application: synthdata-tps-gcp
-          cluster: dev-gcp
         - application: app-1
           namespace: plattformsikkerhet
           cluster: dev-gcp


### PR DESCRIPTION
Fjernet testnorge-skd, testnorge-inntekt og synthdata-tps-gcp fra inbound rules i andre apper.