### PR TITLE
Dolly frontend/inntektstub fiks

### DIFF
--- a/apps/dolly-frontend/src/main/js/src/components/inntektStub/validerInntekt/Inntekt.js
+++ b/apps/dolly-frontend/src/main/js/src/components/inntektStub/validerInntekt/Inntekt.js
@@ -10,11 +10,10 @@ import tilleggsinformasjonPaths from '../paths'
 const sjekkFelt = (formik, field, options, values, path) => {
 	const fieldValue = _get(values, path)
 	const fieldPath = tilleggsinformasjonPaths(field)
+	const val = _get(fieldValue, fieldPath)
 	if (
 		!options.includes('<TOM>') &&
-		fieldValue &&
-		!_get(fieldValue, fieldPath) &&
-		_get(fieldValue, fieldPath) !== false
+		((fieldValue && !val && val !== false) || (!optionsUtfylt(options) && !options.includes(val)))
 	) {
 		if (fieldValue['inntektstype'] !== '' && !formik.errors?.hasOwnProperty('inntektstub')) {
 			formik.setFieldError(`inntektstub.${field}`, 'Feltet er påkrevd')

--- a/apps/dolly-frontend/src/main/js/src/components/inntektStub/validerInntekt/Inntekt.js
+++ b/apps/dolly-frontend/src/main/js/src/components/inntektStub/validerInntekt/Inntekt.js
@@ -17,7 +17,6 @@ const sjekkFelt = (formik, field, options, values, path) => {
 		_get(fieldValue, fieldPath) !== false
 	) {
 		if (fieldValue['inntektstype'] !== '' && !formik.errors?.hasOwnProperty('inntektstub')) {
-			console.log('field: ', field) //TODO - SLETT MEG
 			formik.setFieldError(`inntektstub.${field}`, 'Feltet er påkrevd')
 		}
 		return { feilmelding: 'Feltet er påkrevd' }

--- a/apps/dolly-frontend/src/main/js/src/components/inntektStub/validerInntekt/Inntekt.js
+++ b/apps/dolly-frontend/src/main/js/src/components/inntektStub/validerInntekt/Inntekt.js
@@ -17,10 +17,12 @@ const sjekkFelt = (formik, field, options, values, path) => {
 		_get(fieldValue, fieldPath) !== false
 	) {
 		if (fieldValue['inntektstype'] !== '' && !formik.errors?.hasOwnProperty('inntektstub')) {
+			console.log('field: ', field) //TODO - SLETT MEG
 			formik.setFieldError(`inntektstub.${field}`, 'Feltet er påkrevd')
 		}
 		return { feilmelding: 'Feltet er påkrevd' }
 	}
+	return null
 }
 
 const dateFields = [


### PR DESCRIPTION
Liten fiks i inntektstub for sjekking av feil i felt. Nå inkluderer dette også hvis et felt er satt til en verdi som ikke lenger er inkludering i options.