### PR TITLE
Dolly frontend/fikse visning test norge identer

### DIFF
--- a/apps/dolly-frontend/src/main/js/src/components/bestillingsveileder/stegVelger/steg/steg1/attributtVelger/AttributtVelger.less
+++ b/apps/dolly-frontend/src/main/js/src/components/bestillingsveileder/stegVelger/steg/steg1/attributtVelger/AttributtVelger.less
@@ -20,6 +20,9 @@
       font-size: 1rem;
       margin: 0 0 12px;
     }
+    .navds-label{
+      font-size: 1em;
+    }
   }
 
   &_panelsubcontent {

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdl/visning/PdlVisning.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdl/visning/PdlVisning.tsx
@@ -31,9 +31,15 @@ type PdlVisningProps = {
 	pdlData: PdlData
 	loading?: boolean
 	environments?: string[]
+	miljoeVisning?: boolean
 }
 
-export const PdlVisning = ({ pdlData, loading = false, environments }: PdlVisningProps) => {
+export const PdlVisning = ({
+	pdlData,
+	loading = false,
+	environments,
+	miljoeVisning = false,
+}: PdlVisningProps) => {
 	if (loading) {
 		return <Loading label="Laster PDL-data" />
 	}
@@ -65,7 +71,7 @@ export const PdlVisning = ({ pdlData, loading = false, environments }: PdlVisnin
 
 	return (
 		<ErrorBoundary>
-			<div className="boks">
+			<div className={miljoeVisning ? 'boks' : ''}>
 				<PdlPersonInfo
 					data={hentPerson}
 					tpsMessagingData={tpsMessaging?.tpsMessagingData}

--- a/apps/dolly-frontend/src/main/js/src/pages/gruppe/PersonVisning/PersonMiljoeinfo/PdlDataVisning.tsx
+++ b/apps/dolly-frontend/src/main/js/src/pages/gruppe/PersonVisning/PersonMiljoeinfo/PdlDataVisning.tsx
@@ -47,7 +47,9 @@ export const PdlDataVisning = ({ ident }: PdlDataVisningProps) => {
 				</div>
 			)
 		}
-		return <PdlVisning pdlData={pdlMiljoe ? pdlDataQ1 : pdlData} loading={pdlLoading} />
+		return (
+			<PdlVisning pdlData={pdlMiljoe ? pdlDataQ1 : pdlData} loading={pdlLoading} miljoeVisning />
+		)
 	}
 
 	if (!ident) {


### PR DESCRIPTION
Fikset PDL visning for test-norge identer sånn at alle komponenter strekker seg helt ut til siden. Har også fikset størrelsen (gjort den mindre) på subtittel i bestilling steg 1. 