### PR TITLE
Oppdatert brukerveiledning Dolly

### DIFF
--- a/docs/applications/dolly/brukerveiledning.md
+++ b/docs/applications/dolly/brukerveiledning.md
@@ -188,8 +188,12 @@ For personer som ikke eksisterer i Dolly må disse først hentes inn ved å oppr
 ![Tvungen utlogging](assets/logged_out_error.png)
 
 Dersom du har gjentatte problemer med å få logget inn (eller du blir konstant logget ut) kan det være et problem med 
-cookies på nettsiden. Dette er noe vi prøver å finne en løsning for, men imens anbefaler vi våre brukere å prøve å 
-cleare cookies når dette skjer. Nedenfor finner du en demo-video for hvordan dette kan gjøres. 
+cookies på nettsiden. Det er to ting du kan gjøre for å prøve for å fikse problemet:
+
+* Logg ut manuelt:
+    * Du kan manuelt logge ut av Dolly ved å trykke på den følgende linken: https://dolly.ekstern.dev.nav.no/logout
+* Clear cookies i nettleser:
+  * Nedenfor finner du en demo-video for hvordan dette kan gjøres. 
 
 <video src="https://user-images.githubusercontent.com/58416744/159910685-f4bcbe86-c856-459c-a220-b242c46a59cd.mov"
        controls="controls" style="max-width: 730px;">


### PR DESCRIPTION
Oppdatert brukerveiledning for Dolly til å inkludere link til manuell utlogging i Dolly, som kan brukes hvis du har problemer med å logge inn (som følge av feil med cookies i nettleseren)