### PR TITLE
Dolly frontend - Flyttet adressebeskyttelse option

### DIFF
--- a/apps/dolly-frontend/src/main/js/src/pages/testnorgePage/search/partials/Adresser.tsx
+++ b/apps/dolly-frontend/src/main/js/src/pages/testnorgePage/search/partials/Adresser.tsx
@@ -12,6 +12,7 @@ type AdresserProps = {
 }
 
 const paths = {
+	adressebeskyttelse: 'identifikasjon.adressebeskyttelse',
 	borINorge: 'adresser.bostedsadresse.borINorge',
 	postnummer: 'adresser.bostedsadresse.postnummer',
 	bydelsnummer: 'adresser.bostedsadresse.bydelsnummer',
@@ -23,6 +24,12 @@ const paths = {
 	kontakt: 'adresser.harKontaktadresse',
 	opphold: 'adresser.harOppholdsadresse',
 }
+
+const adressebeskyttelseOptions = [
+	{ value: 'FORTROLIG', label: 'Fortrolig' },
+	{ value: 'STRENGT_FORTROLIG', label: 'Strengt fortrolig' },
+	{ value: 'INGEN', label: 'Ingen' },
+]
 
 export const Adresser = ({ formikBag }: AdresserProps) => {
 	const bostedOptions = [
@@ -38,6 +45,13 @@ export const Adresser = ({ formikBag }: AdresserProps) => {
 	]
 	return (
 		<section>
+			<div className="options-title-bold">Adressebeskyttelse</div>
+			<FormikSelect
+				name={paths.adressebeskyttelse}
+				label="Velg type"
+				options={adressebeskyttelseOptions}
+				size="medium"
+			/>
 			<div className="options-title-bold">Bostedsadresse</div>
 			<RadioGroupOptions
 				formikBag={formikBag}

--- a/apps/dolly-frontend/src/main/js/src/pages/testnorgePage/search/partials/Identifikasjon.tsx
+++ b/apps/dolly-frontend/src/main/js/src/pages/testnorgePage/search/partials/Identifikasjon.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import { FormikProps } from 'formik'
 import { FormikCheckbox } from '~/components/ui/form/inputs/checbox/Checkbox'
 import { RadioGroupOptions } from '~/pages/testnorgePage/search/radioGroupOptions/RadioGroupOptions'
-import { FormikSelect } from '~/components/ui/form/inputs/select/Select'
 
 interface IdentifikasjonProps {
 	formikBag: FormikProps<{}>
@@ -26,7 +25,6 @@ const options = {
 
 const paths = {
 	identtype: 'identifikasjon.identtype',
-	adressebeskyttelse: 'identifikasjon.adressebeskyttelse',
 	falsk: 'identifikasjon.falskIdentitet',
 	utenlandsk: 'identifikasjon.utenlandskIdentitet',
 	kjoenn: 'kjoenn',
@@ -43,12 +41,6 @@ export const Identifikasjon: React.FC<IdentifikasjonProps> = ({
 				path={paths.identtype}
 				legend={'Velg identifikatortype'}
 				options={options.identtype}
-			/>
-			<FormikSelect
-				name={paths.adressebeskyttelse}
-				label="Adressebeskyttelse"
-				options={options.adressebeskyttelse}
-				size="medium"
 			/>
 			<div className="options-title">Identitet</div>
 			<FormikCheckbox name={paths.falsk} label="Har falsk identitet" />


### PR DESCRIPTION
Flyttet adressebeskyttelse option i testnorge søk fra under "Identifikasjon" til øverst under "Adresser":

<img width="334" alt="Skjermbilde 2022-11-23 kl  09 00 01" src="https://user-images.githubusercontent.com/58416744/203496763-423b3390-d2ad-4f30-8642-1a15f58723aa.png">
