### PR TITLE
Dolly frontend/filtrere sokeresultat

### DIFF
--- a/apps/dolly-frontend/src/main/js/src/pages/gruppeOversikt/FinnPersonBestilling.tsx
+++ b/apps/dolly-frontend/src/main/js/src/pages/gruppeOversikt/FinnPersonBestilling.tsx
@@ -174,20 +174,26 @@ const FinnPersonBestilling = ({
 
 		const personer: Array<Option> = []
 
-		if (tpsfValues?.status === 'fulfilled') {
-			const tpsfPersoner = tpsfValues.value?.data
-			mapToPersoner(tpsfPersoner, personer)
-			setTpsfIdenter(tpsfPersoner)
-		} else {
-			setError(tpsfValues?.reason?.message)
-		}
-
+		let pdlfPersoner = []
 		if (pdlfValues?.status === 'fulfilled') {
-			const pdlfPersoner = pdlfValues.value?.data
+			pdlfPersoner = pdlfValues.value?.data
 			mapToPersoner(pdlfPersoner, personer)
 			setPdlfIdenter(pdlfPersoner)
 		} else {
 			setError(pdlfValues?.reason?.message)
+		}
+
+		if (tpsfValues?.status === 'fulfilled') {
+			let tpsfPersoner = tpsfValues.value?.data
+			if (Array.isArray(tpsfPersoner) && Array.isArray(pdlfPersoner)) {
+				tpsfPersoner = tpsfPersoner.filter(
+					(person: Person) => !pdlfIdenter.map((p: Person) => p.ident).includes(person.ident)
+				)
+			}
+			mapToPersoner(tpsfPersoner, personer)
+			setTpsfIdenter(tpsfPersoner)
+		} else {
+			setError(tpsfValues?.reason?.message)
 		}
 
 		if (pdlValues?.status === 'fulfilled') {

--- a/apps/dolly-frontend/src/main/js/src/pages/gruppeOversikt/FinnPersonBestilling.tsx
+++ b/apps/dolly-frontend/src/main/js/src/pages/gruppeOversikt/FinnPersonBestilling.tsx
@@ -187,7 +187,7 @@ const FinnPersonBestilling = ({
 			let tpsfPersoner = tpsfValues.value?.data
 			if (Array.isArray(tpsfPersoner) && Array.isArray(pdlfPersoner)) {
 				tpsfPersoner = tpsfPersoner.filter(
-					(person: Person) => !pdlfIdenter.map((p: Person) => p.ident).includes(person.ident)
+					(person: Person) => !pdlfPersoner.map((p: Person) => p.ident).includes(person.ident)
 				)
 			}
 			mapToPersoner(tpsfPersoner, personer)


### PR DESCRIPTION
Har lagt til filtering på søkeresultat fra TPSF. Hvis en ident fra TPSF allerede finnes i søkeresultatet fra PDLF så blir ikke TPSF objectet lagt til (dette for å unngå duplikater med forskjellig navn). Fikk ikke testet ordentlig da jeg ikke kunne gjenskape feilen med duplikater lokalt.