### PR TITLE
Dolly frontend/fikset sonarcloud issue med nested components

### DIFF
--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/visning/partials/Adressebeskyttelse.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/visning/partials/Adressebeskyttelse.tsx
@@ -21,6 +21,79 @@ type AdressebeskyttelseTypes = {
 type AdressebeskyttelseVisningTypes = {
 	adressebeskyttelse: AdressebeskyttelseData
 	idx: number
+	data: Array<AdressebeskyttelseData>
+	tmpPersoner: Array<AdressebeskyttelseData>
+	ident?: string
+	identtype?: string
+	erPdlVisning?: boolean
+}
+
+type AdressebeskyttelseLesTypes = {
+	adressebeskyttelse: AdressebeskyttelseData
+	idx: number
+}
+
+const AdressebeskyttelseLes = ({ adressebeskyttelse, idx }: AdressebeskyttelseLesTypes) => {
+	return (
+		<>
+			<div className="person-visning_content" key={idx}>
+				<TitleValue
+					title="Gradering"
+					value={Formatters.showLabel('gradering', adressebeskyttelse.gradering)}
+				/>
+			</div>
+		</>
+	)
+}
+
+const AdressebeskyttelseVisning = ({
+	adressebeskyttelse,
+	idx,
+	data,
+	tmpPersoner,
+	ident,
+	identtype,
+	erPdlVisning,
+}: AdressebeskyttelseVisningTypes) => {
+	const initAdressebeskyttelse = Object.assign(_cloneDeep(initialAdressebeskyttelse), data[idx])
+	const initialValues = { adressebeskyttelse: initAdressebeskyttelse }
+
+	const redigertAdressebeskyttelsePdlf = _get(
+		tmpPersoner,
+		`${ident}.person.adressebeskyttelse`
+	)?.find((a: Person) => a.id === adressebeskyttelse.id)
+	const slettetAdressebeskyttelsePdlf =
+		tmpPersoner?.hasOwnProperty(ident) && !redigertAdressebeskyttelsePdlf
+	if (slettetAdressebeskyttelsePdlf) {
+		return <pre style={{ margin: '0' }}>Opplysning slettet</pre>
+	}
+
+	const adressebeskyttelseValues = redigertAdressebeskyttelsePdlf
+		? redigertAdressebeskyttelsePdlf
+		: adressebeskyttelse
+	const redigertAdressebeskyttelseValues = redigertAdressebeskyttelsePdlf
+		? {
+				adressebeskyttelse: Object.assign(
+					_cloneDeep(initialAdressebeskyttelse),
+					redigertAdressebeskyttelsePdlf
+				),
+		  }
+		: null
+
+	return erPdlVisning ? (
+		<AdressebeskyttelseLes adressebeskyttelse={adressebeskyttelse} idx={idx} />
+	) : (
+		<VisningRedigerbarConnector
+			dataVisning={
+				<AdressebeskyttelseLes adressebeskyttelse={adressebeskyttelseValues} idx={idx} />
+			}
+			initialValues={initialValues}
+			redigertAttributt={redigertAdressebeskyttelseValues}
+			path="adressebeskyttelse"
+			ident={ident}
+			identtype={identtype}
+		/>
+	)
 }
 
 export const Adressebeskyttelse = ({
@@ -34,64 +107,6 @@ export const Adressebeskyttelse = ({
 		return null
 	}
 
-	const AdressebeskyttelseLes = ({ adressebeskyttelse, idx }: AdressebeskyttelseVisningTypes) => {
-		return (
-			<>
-				<div className="person-visning_content" key={idx}>
-					<TitleValue
-						title="Gradering"
-						value={Formatters.showLabel('gradering', adressebeskyttelse.gradering)}
-					/>
-				</div>
-			</>
-		)
-	}
-
-	const AdressebeskyttelseVisning = ({
-		adressebeskyttelse,
-		idx,
-	}: AdressebeskyttelseVisningTypes) => {
-		const initAdressebeskyttelse = Object.assign(_cloneDeep(initialAdressebeskyttelse), data[idx])
-		const initialValues = { adressebeskyttelse: initAdressebeskyttelse }
-
-		const redigertAdressebeskyttelsePdlf = _get(
-			tmpPersoner,
-			`${ident}.person.adressebeskyttelse`
-		)?.find((a: Person) => a.id === adressebeskyttelse.id)
-		const slettetAdressebeskyttelsePdlf =
-			tmpPersoner?.hasOwnProperty(ident) && !redigertAdressebeskyttelsePdlf
-		if (slettetAdressebeskyttelsePdlf) {
-			return <pre style={{ margin: '0' }}>Opplysning slettet</pre>
-		}
-
-		const adressebeskyttelseValues = redigertAdressebeskyttelsePdlf
-			? redigertAdressebeskyttelsePdlf
-			: adressebeskyttelse
-		const redigertAdressebeskyttelseValues = redigertAdressebeskyttelsePdlf
-			? {
-					adressebeskyttelse: Object.assign(
-						_cloneDeep(initialAdressebeskyttelse),
-						redigertAdressebeskyttelsePdlf
-					),
-			  }
-			: null
-
-		return erPdlVisning ? (
-			<AdressebeskyttelseLes adressebeskyttelse={adressebeskyttelse} idx={idx} />
-		) : (
-			<VisningRedigerbarConnector
-				dataVisning={
-					<AdressebeskyttelseLes adressebeskyttelse={adressebeskyttelseValues} idx={idx} />
-				}
-				initialValues={initialValues}
-				redigertAttributt={redigertAdressebeskyttelseValues}
-				path="adressebeskyttelse"
-				ident={ident}
-				identtype={identtype}
-			/>
-		)
-	}
-
 	return (
 		<>
 			<SubOverskrift label="Adressebeskyttelse" iconKind="adresse" />
@@ -99,7 +114,15 @@ export const Adressebeskyttelse = ({
 				<ErrorBoundary>
 					<DollyFieldArray data={data} header="" nested>
 						{(adressebeskyttelse: AdressebeskyttelseData, idx: number) => (
-							<AdressebeskyttelseVisning adressebeskyttelse={adressebeskyttelse} idx={idx} />
+							<AdressebeskyttelseVisning
+								adressebeskyttelse={adressebeskyttelse}
+								idx={idx}
+								tmpPersoner={tmpPersoner}
+								ident={ident}
+								identtype={identtype}
+								data={data}
+								erPdlVisning={erPdlVisning}
+							/>
 						)}
 					</DollyFieldArray>
 				</ErrorBoundary>

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/visning/partials/Boadresse.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/visning/partials/Boadresse.tsx
@@ -22,10 +22,20 @@ type BoadresseTypes = {
 
 type BoadresseVisningTypes = {
 	boadresseData: any
+	data: Array<any>
+	idx: number
+	tmpPersoner?: Array<BostedData>
+	ident?: string
+	identtype?: string
+	erPdlVisning?: boolean
+}
+
+type AdresseTypes = {
+	boadresseData: any
 	idx: number
 }
 
-export const Adresse = ({ boadresseData, idx }: BoadresseVisningTypes) => {
+export const Adresse = ({ boadresseData, idx }: AdresseTypes) => {
 	if (!boadresseData) {
 		return null
 	}
@@ -36,6 +46,57 @@ export const Adresse = ({ boadresseData, idx }: BoadresseVisningTypes) => {
 			{boadresseData.utenlandskAdresse && <UtenlandskAdresse adresse={boadresseData} idx={idx} />}
 			{boadresseData.ukjentBosted && <UkjentBosted adresse={boadresseData} idx={idx} />}
 		</>
+	)
+}
+
+const BoadresseVisning = ({
+	boadresseData,
+	idx,
+	data,
+	tmpPersoner,
+	ident,
+	identtype,
+	erPdlVisning,
+}: BoadresseVisningTypes) => {
+	const initBoadresse = Object.assign(_cloneDeep(initialBostedsadresse), data[idx])
+	const initialValues = { bostedsadresse: initBoadresse }
+
+	const redigertBoadressePdlf = _get(tmpPersoner, `${ident}.person.bostedsadresse`)?.find(
+		(a: BostedData) => a.id === boadresseData.id
+	)
+	const slettetBoadressePdlf = tmpPersoner?.hasOwnProperty(ident) && !redigertBoadressePdlf
+	if (slettetBoadressePdlf) {
+		return <pre style={{ margin: '0' }}>Opplysning slettet</pre>
+	}
+
+	const boadresseValues = redigertBoadressePdlf ? redigertBoadressePdlf : boadresseData
+	const redigertBoadresseValues = redigertBoadressePdlf
+		? {
+				bostedsadresse: Object.assign(_cloneDeep(initialBostedsadresse), redigertBoadressePdlf),
+		  }
+		: null
+
+	const filtrertData = [...data]
+	filtrertData.splice(idx, 1)
+	const personFoerLeggTil = {
+		pdlforvalter: {
+			person: {
+				bostedsadresse: filtrertData,
+			},
+		},
+	}
+	return erPdlVisning ? (
+		<Adresse boadresseData={boadresseData} idx={idx} />
+	) : (
+		<VisningRedigerbarConnector
+			dataVisning={<Adresse boadresseData={boadresseValues} idx={idx} />}
+			initialValues={initialValues}
+			redigertAttributt={redigertBoadresseValues}
+			path="bostedsadresse"
+			ident={ident}
+			identtype={identtype}
+			personFoerLeggTil={personFoerLeggTil}
+		/>
 	)
 }
 
@@ -50,56 +111,23 @@ export const Boadresse = ({
 		return null
 	}
 
-	const BoadresseVisning = ({ boadresseData, idx }: BoadresseVisningTypes) => {
-		const initBoadresse = Object.assign(_cloneDeep(initialBostedsadresse), data[idx])
-		const initialValues = { bostedsadresse: initBoadresse }
-
-		const redigertBoadressePdlf = _get(tmpPersoner, `${ident}.person.bostedsadresse`)?.find(
-			(a: BostedData) => a.id === boadresseData.id
-		)
-		const slettetBoadressePdlf = tmpPersoner?.hasOwnProperty(ident) && !redigertBoadressePdlf
-		if (slettetBoadressePdlf) {
-			return <pre style={{ margin: '0' }}>Opplysning slettet</pre>
-		}
-
-		const boadresseValues = redigertBoadressePdlf ? redigertBoadressePdlf : boadresseData
-		const redigertBoadresseValues = redigertBoadressePdlf
-			? {
-					bostedsadresse: Object.assign(_cloneDeep(initialBostedsadresse), redigertBoadressePdlf),
-			  }
-			: null
-
-		const filtrertData = [...data]
-		filtrertData.splice(idx, 1)
-		const personFoerLeggTil = {
-			pdlforvalter: {
-				person: {
-					bostedsadresse: filtrertData,
-				},
-			},
-		}
-		return erPdlVisning ? (
-			<Adresse boadresseData={boadresseData} idx={idx} />
-		) : (
-			<VisningRedigerbarConnector
-				dataVisning={<Adresse boadresseData={boadresseValues} idx={idx} />}
-				initialValues={initialValues}
-				redigertAttributt={redigertBoadresseValues}
-				path="bostedsadresse"
-				ident={ident}
-				identtype={identtype}
-				personFoerLeggTil={personFoerLeggTil}
-			/>
-		)
-	}
-
 	return (
 		<>
 			<SubOverskrift label="Boadresse" iconKind="adresse" />
 			<div className="person-visning_content">
 				<ErrorBoundary>
 					<DollyFieldArray data={data} header="" nested>
-						{(adresse: any, idx: number) => <BoadresseVisning boadresseData={adresse} idx={idx} />}
+						{(adresse: any, idx: number) => (
+							<BoadresseVisning
+								boadresseData={adresse}
+								idx={idx}
+								data={data}
+								tmpPersoner={tmpPersoner}
+								identtype={identtype}
+								ident={ident}
+								erPdlVisning={erPdlVisning}
+							/>
+						)}
 					</DollyFieldArray>
 				</ErrorBoundary>
 			</div>

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/visning/partials/Doedsfall.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/visning/partials/Doedsfall.tsx
@@ -20,49 +20,65 @@ type DoedsfallTypes = {
 type DoedsfallVisningTypes = {
 	doedsfall: DoedsfallData
 	idx: number
+	data: Array<DoedsfallData>
+	tmpPersoner: Array<DoedsfallData>
+	ident: string
+	erPdlVisning: boolean
+}
+
+type DoedsfallLesTypes = {
+	doedsfall: DoedsfallData
+	idx: number
+}
+
+const DoedsfallLes = ({ doedsfall, idx }: DoedsfallLesTypes) => {
+	return (
+		<div className="person-visning_content" key={idx}>
+			<TitleValue title="Dødsdato" value={Formatters.formatDate(doedsfall.doedsdato)} />
+		</div>
+	)
+}
+
+const DoedsfallVisning = ({
+	doedsfall,
+	idx,
+	data,
+	tmpPersoner,
+	ident,
+	erPdlVisning,
+}: DoedsfallVisningTypes) => {
+	const initDoedsfall = Object.assign(_cloneDeep(initialDoedsfall), data[idx])
+	const initialValues = { doedsfall: initDoedsfall }
+
+	const redigertDoedsfallPdlf = _get(tmpPersoner, `${ident}.person.doedsfall`)?.find(
+		(a: Person) => a.id === doedsfall.id
+	)
+	const slettetDoedsfallPdlf = tmpPersoner?.hasOwnProperty(ident) && !redigertDoedsfallPdlf
+	if (slettetDoedsfallPdlf) {
+		return <pre style={{ margin: '0' }}>Opplysning slettet</pre>
+	}
+
+	const doedsfallValues = redigertDoedsfallPdlf ? redigertDoedsfallPdlf : doedsfall
+	const redigertDoedsfallValues = redigertDoedsfallPdlf
+		? { doedsfall: Object.assign(_cloneDeep(initialFoedsel), redigertDoedsfallPdlf) }
+		: null
+
+	return erPdlVisning ? (
+		<DoedsfallLes doedsfall={doedsfall} idx={idx} />
+	) : (
+		<VisningRedigerbarConnector
+			dataVisning={<DoedsfallLes doedsfall={doedsfallValues} idx={idx} />}
+			initialValues={initialValues}
+			redigertAttributt={redigertDoedsfallValues}
+			path="doedsfall"
+			ident={ident}
+		/>
+	)
 }
 
 export const Doedsfall = ({ data, tmpPersoner, ident, erPdlVisning = false }: DoedsfallTypes) => {
 	if (!data || data.length === 0) {
 		return null
-	}
-
-	const DoedsfallLes = ({ doedsfall, idx }: DoedsfallVisningTypes) => {
-		return (
-			<div className="person-visning_content" key={idx}>
-				<TitleValue title="Dødsdato" value={Formatters.formatDate(doedsfall.doedsdato)} />
-			</div>
-		)
-	}
-
-	const DoedsfallVisning = ({ doedsfall, idx }: DoedsfallVisningTypes) => {
-		const initDoedsfall = Object.assign(_cloneDeep(initialDoedsfall), data[idx])
-		const initialValues = { doedsfall: initDoedsfall }
-
-		const redigertDoedsfallPdlf = _get(tmpPersoner, `${ident}.person.doedsfall`)?.find(
-			(a: Person) => a.id === doedsfall.id
-		)
-		const slettetDoedsfallPdlf = tmpPersoner?.hasOwnProperty(ident) && !redigertDoedsfallPdlf
-		if (slettetDoedsfallPdlf) {
-			return <pre style={{ margin: '0' }}>Opplysning slettet</pre>
-		}
-
-		const doedsfallValues = redigertDoedsfallPdlf ? redigertDoedsfallPdlf : doedsfall
-		const redigertDoedsfallValues = redigertDoedsfallPdlf
-			? { doedsfall: Object.assign(_cloneDeep(initialFoedsel), redigertDoedsfallPdlf) }
-			: null
-
-		return erPdlVisning ? (
-			<DoedsfallLes doedsfall={doedsfall} idx={idx} />
-		) : (
-			<VisningRedigerbarConnector
-				dataVisning={<DoedsfallLes doedsfall={doedsfallValues} idx={idx} />}
-				initialValues={initialValues}
-				redigertAttributt={redigertDoedsfallValues}
-				path="doedsfall"
-				ident={ident}
-			/>
-		)
 	}
 
 	return (
@@ -71,7 +87,16 @@ export const Doedsfall = ({ data, tmpPersoner, ident, erPdlVisning = false }: Do
 			<div className="person-visning_content">
 				<ErrorBoundary>
 					<DollyFieldArray data={data} header="" nested>
-						{(item: DoedsfallData, idx: number) => <DoedsfallVisning doedsfall={item} idx={idx} />}
+						{(item: DoedsfallData, idx: number) => (
+							<DoedsfallVisning
+								doedsfall={item}
+								idx={idx}
+								data={data}
+								tmpPersoner={tmpPersoner}
+								ident={ident}
+								erPdlVisning={erPdlVisning}
+							/>
+						)}
 					</DollyFieldArray>
 				</ErrorBoundary>
 			</div>

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/visning/partials/Foedsel.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/visning/partials/Foedsel.tsx
@@ -23,68 +23,84 @@ type FoedselTypes = {
 	erPdlVisning?: boolean
 }
 
+type FoedselLesTypes = {
+	foedsel: FoedselData
+	idx: number
+}
+
 type FoedselVisningTypes = {
 	foedsel: FoedselData
 	idx: number
+	data: Array<FoedselData>
+	tmpPersoner: Array<FoedselData>
+	ident: string
+	erPdlVisning: boolean
+}
+
+const FoedselLes = ({ foedsel, idx }: FoedselLesTypes) => {
+	return (
+		<div className="person-visning_redigerbar" key={idx}>
+			<TitleValue title="Fødselsdato" value={Formatters.formatDate(foedsel.foedselsdato)} />
+			<TitleValue title="Fødselsår" value={foedsel.foedselsaar} />
+			<TitleValue title="Fødested" value={foedsel.foedested} />
+			<TitleValue title="Fødekommune">
+				{foedsel.foedekommune && (
+					<KodeverkConnector navn="Kommuner" value={foedsel.foedekommune}>
+						{(_v: Kodeverk, verdi: KodeverkValues) => (
+							<span>{verdi ? verdi.label : foedsel.foedekommune}</span>
+						)}
+					</KodeverkConnector>
+				)}
+			</TitleValue>
+			<TitleValue
+				title="Fødeland"
+				value={foedsel.foedeland}
+				kodeverk={AdresseKodeverk.StatsborgerskapLand}
+			/>
+		</div>
+	)
+}
+
+const FoedselVisning = ({
+	foedsel,
+	idx,
+	tmpPersoner,
+	data,
+	erPdlVisning,
+	ident,
+}: FoedselVisningTypes) => {
+	const initFoedsel = Object.assign(_cloneDeep(initialFoedsel), data[idx])
+	const initialValues = { foedsel: initFoedsel }
+
+	const redigertFoedselPdlf = _get(tmpPersoner, `${ident}.person.foedsel`)?.find(
+		(a: Person) => a.id === foedsel.id
+	)
+	const slettetFoedselPdlf = tmpPersoner?.hasOwnProperty(ident) && !redigertFoedselPdlf
+	if (slettetFoedselPdlf) {
+		return <pre style={{ margin: '0' }}>Opplysning slettet</pre>
+	}
+
+	const foedselValues = redigertFoedselPdlf ? redigertFoedselPdlf : foedsel
+	const redigertFoedselValues = redigertFoedselPdlf
+		? { foedsel: Object.assign(_cloneDeep(initialFoedsel), redigertFoedselPdlf) }
+		: null
+
+	return erPdlVisning ? (
+		<FoedselLes foedsel={foedsel} idx={idx} />
+	) : (
+		<VisningRedigerbarConnector
+			dataVisning={<FoedselLes foedsel={foedselValues} idx={idx} />}
+			initialValues={initialValues}
+			redigertAttributt={redigertFoedselValues}
+			path="foedsel"
+			ident={ident}
+		/>
+	)
 }
 
 export const Foedsel = ({ data, tmpPersoner, ident, erPdlVisning = false }: FoedselTypes) => {
 	if (!data || data.length === 0) {
 		return null
-	}
-
-	const FoedselLes = ({ foedsel, idx }: FoedselVisningTypes) => {
-		return (
-			<div className="person-visning_redigerbar" key={idx}>
-				<TitleValue title="Fødselsdato" value={Formatters.formatDate(foedsel.foedselsdato)} />
-				<TitleValue title="Fødselsår" value={foedsel.foedselsaar} />
-				<TitleValue title="Fødested" value={foedsel.foedested} />
-				<TitleValue title="Fødekommune">
-					{foedsel.foedekommune && (
-						<KodeverkConnector navn="Kommuner" value={foedsel.foedekommune}>
-							{(_v: Kodeverk, verdi: KodeverkValues) => (
-								<span>{verdi ? verdi.label : foedsel.foedekommune}</span>
-							)}
-						</KodeverkConnector>
-					)}
-				</TitleValue>
-				<TitleValue
-					title="Fødeland"
-					value={foedsel.foedeland}
-					kodeverk={AdresseKodeverk.StatsborgerskapLand}
-				/>
-			</div>
-		)
-	}
-
-	const FoedselVisning = ({ foedsel, idx }: FoedselVisningTypes) => {
-		const initFoedsel = Object.assign(_cloneDeep(initialFoedsel), data[idx])
-		const initialValues = { foedsel: initFoedsel }
-
-		const redigertFoedselPdlf = _get(tmpPersoner, `${ident}.person.foedsel`)?.find(
-			(a: Person) => a.id === foedsel.id
-		)
-		const slettetFoedselPdlf = tmpPersoner?.hasOwnProperty(ident) && !redigertFoedselPdlf
-		if (slettetFoedselPdlf) {
-			return <pre style={{ margin: '0' }}>Opplysning slettet</pre>
-		}
-
-		const foedselValues = redigertFoedselPdlf ? redigertFoedselPdlf : foedsel
-		const redigertFoedselValues = redigertFoedselPdlf
-			? { foedsel: Object.assign(_cloneDeep(initialFoedsel), redigertFoedselPdlf) }
-			: null
-
-		return erPdlVisning ? (
-			<FoedselLes foedsel={foedsel} idx={idx} />
-		) : (
-			<VisningRedigerbarConnector
-				dataVisning={<FoedselLes foedsel={foedselValues} idx={idx} />}
-				initialValues={initialValues}
-				redigertAttributt={redigertFoedselValues}
-				path="foedsel"
-				ident={ident}
-			/>
-		)
 	}
 
 	return (
@@ -93,7 +109,16 @@ export const Foedsel = ({ data, tmpPersoner, ident, erPdlVisning = false }: Foed
 			<div className="person-visning_content">
 				<ErrorBoundary>
 					<DollyFieldArray data={data} header="" nested>
-						{(item: FoedselData, idx: number) => <FoedselVisning foedsel={item} idx={idx} />}
+						{(item: FoedselData, idx: number) => (
+							<FoedselVisning
+								foedsel={item}
+								idx={idx}
+								data={data}
+								ident={ident}
+								erPdlVisning={erPdlVisning}
+								tmpPersoner={tmpPersoner}
+							/>
+						)}
 					</DollyFieldArray>
 				</ErrorBoundary>
 			</div>

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/visning/partials/Innvandring.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/visning/partials/Innvandring.tsx
@@ -23,10 +23,20 @@ type InnvandringTypes = {
 	erPdlVisning?: boolean
 }
 
+type InnvandringLesTypes = {
+	innvandringData: InnvandringValues
+	idx: number
+}
+
 type InnvandringVisningTypes = {
 	innvandringData: InnvandringValues
 	idx: number
 	sisteDato?: Date
+	data: Array<InnvandringValues>
+	tmpPersoner: Array<PersonData>
+	ident: string
+	erPdlVisning: boolean
+	utflyttingData: Array<UtvandringValues>
 }
 
 export const getSisteDatoInnUtvandring = (
@@ -47,6 +57,74 @@ export const getSisteDatoInnUtvandring = (
 		utflytting?.map((val: UtvandringValues) => new Date(val.utflyttingsdato))
 	)
 	return sisteInnflytting > sisteUtflytting ? sisteInnflytting : sisteUtflytting
+}
+
+const InnvandringLes = ({ innvandringData, idx }: InnvandringLesTypes) => {
+	if (!innvandringData) {
+		return null
+	}
+	return (
+		<div className="person-visning_redigerbar" key={idx}>
+			<TitleValue
+				title="Fraflyttingsland"
+				value={innvandringData.fraflyttingsland}
+				kodeverk={AdresseKodeverk.InnvandretUtvandretLand}
+			/>
+			<TitleValue title="Fraflyttingssted" value={innvandringData.fraflyttingsstedIUtlandet} />
+			<TitleValue
+				title="Innflyttingsdato"
+				value={Formatters.formatDate(innvandringData.innflyttingsdato)}
+			/>
+		</div>
+	)
+}
+
+const InnvandringVisning = ({
+	innvandringData,
+	idx,
+	sisteDato,
+	data,
+	tmpPersoner,
+	ident,
+	erPdlVisning,
+	utflyttingData,
+}: InnvandringVisningTypes) => {
+	const initInnvandring = Object.assign(_cloneDeep(initialInnvandring), data[idx])
+	const initialValues = { innflytting: initInnvandring }
+
+	const redigertInnvandringPdlf = _get(tmpPersoner, `${ident}.person.innflytting`)?.find(
+		(a: InnvandringValues) => a.id === innvandringData.id
+	)
+	const slettetInnvandringPdlf = tmpPersoner?.hasOwnProperty(ident) && !redigertInnvandringPdlf
+	if (slettetInnvandringPdlf) {
+		return <pre style={{ margin: '0' }}>Opplysning slettet</pre>
+	}
+
+	const innvandringValues = redigertInnvandringPdlf ? redigertInnvandringPdlf : innvandringData
+	const redigertInnvandringValues = redigertInnvandringPdlf
+		? {
+				innflytting: Object.assign(_cloneDeep(initialInnvandring), redigertInnvandringPdlf),
+		  }
+		: null
+	return erPdlVisning ? (
+		<InnvandringLes innvandringData={innvandringData} idx={idx} />
+	) : (
+		<VisningRedigerbarConnector
+			dataVisning={<InnvandringLes innvandringData={innvandringValues} idx={idx} />}
+			initialValues={initialValues}
+			redigertAttributt={redigertInnvandringValues}
+			path="innflytting"
+			ident={ident}
+			disableSlett={new Date(innvandringData.innflyttingsdato) < sisteDato}
+			personFoerLeggTil={{
+				pdldata: {
+					person: {
+						utflytting: utflyttingData,
+					},
+				},
+			}}
+		/>
+	)
 }
 
 export const Innvandring = ({
@@ -70,71 +148,21 @@ export const Innvandring = ({
 		return null
 	}
 
-	const InnvandringLes = ({ innvandringData, idx }: InnvandringVisningTypes) => {
-		if (!innvandringData) {
-			return null
-		}
-		return (
-			<div className="person-visning_redigerbar" key={idx}>
-				<TitleValue
-					title="Fraflyttingsland"
-					value={innvandringData.fraflyttingsland}
-					kodeverk={AdresseKodeverk.InnvandretUtvandretLand}
-				/>
-				<TitleValue title="Fraflyttingssted" value={innvandringData.fraflyttingsstedIUtlandet} />
-				<TitleValue
-					title="Innflyttingsdato"
-					value={Formatters.formatDate(innvandringData.innflyttingsdato)}
-				/>
-			</div>
-		)
-	}
-
-	const InnvandringVisning = ({ innvandringData, idx, sisteDato }: InnvandringVisningTypes) => {
-		const initInnvandring = Object.assign(_cloneDeep(initialInnvandring), data[idx])
-		const initialValues = { innflytting: initInnvandring }
-
-		const redigertInnvandringPdlf = _get(tmpPersoner, `${ident}.person.innflytting`)?.find(
-			(a: InnvandringValues) => a.id === innvandringData.id
-		)
-		const slettetInnvandringPdlf = tmpPersoner?.hasOwnProperty(ident) && !redigertInnvandringPdlf
-		if (slettetInnvandringPdlf) {
-			return <pre style={{ margin: '0' }}>Opplysning slettet</pre>
-		}
-
-		const innvandringValues = redigertInnvandringPdlf ? redigertInnvandringPdlf : innvandringData
-		const redigertInnvandringValues = redigertInnvandringPdlf
-			? {
-					innflytting: Object.assign(_cloneDeep(initialInnvandring), redigertInnvandringPdlf),
-			  }
-			: null
-		return erPdlVisning ? (
-			<InnvandringLes innvandringData={innvandringData} idx={idx} />
-		) : (
-			<VisningRedigerbarConnector
-				dataVisning={<InnvandringLes innvandringData={innvandringValues} idx={idx} />}
-				initialValues={initialValues}
-				redigertAttributt={redigertInnvandringValues}
-				path="innflytting"
-				ident={ident}
-				disableSlett={new Date(innvandringData.innflyttingsdato) < sisteDato}
-				personFoerLeggTil={{
-					pdldata: {
-						person: {
-							utflytting: utflyttingData,
-						},
-					},
-				}}
-			/>
-		)
-	}
-
 	return (
 		<div className="person-visning_content" style={{ marginTop: '-20px' }}>
 			<ErrorBoundary>
 				<DollyFieldArray data={data} header="Innvandret" nested>
 					{(innvandring: InnvandringValues, idx: number) => (
-						<InnvandringVisning innvandringData={innvandring} idx={idx} sisteDato={sisteDato} />
+						<InnvandringVisning
+							innvandringData={innvandring}
+							idx={idx}
+							sisteDato={sisteDato}
+							data={data}
+							utflyttingData={utflyttingData}
+							tmpPersoner={tmpPersoner}
+							ident={ident}
+							erPdlVisning={erPdlVisning}
+						/>
 					)}
 				</DollyFieldArray>
 			</ErrorBoundary>

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/visning/partials/Kontaktadresse.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/visning/partials/Kontaktadresse.tsx
@@ -35,6 +35,11 @@ type KontaktadresseVisningTypes = {
 	erPdlVisning: boolean
 }
 
+type AdresseTypes = {
+	kontaktadresseData: any
+	idx: number
+}
+
 const Adressedatoer = ({ kontaktadresseData }: any) => (
 	<>
 		<TitleValue
@@ -48,7 +53,7 @@ const Adressedatoer = ({ kontaktadresseData }: any) => (
 	</>
 )
 
-export const Adresse = ({ kontaktadresseData, idx }: KontaktadresseVisningTypes) => {
+export const Adresse = ({ kontaktadresseData, idx }: AdresseTypes) => {
 	if (!kontaktadresseData) {
 		return null
 	}

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/visning/partials/Kontaktadresse.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/visning/partials/Kontaktadresse.tsx
@@ -28,6 +28,11 @@ type KontaktadresseTypes = {
 type KontaktadresseVisningTypes = {
 	kontaktadresseData: any
 	idx: number
+	data: any
+	tmpData: any
+	tmpPersoner: Array<KontaktadresseData>
+	ident: number
+	erPdlVisning: boolean
 }
 
 const Adressedatoer = ({ kontaktadresseData }: any) => (
@@ -155,6 +160,54 @@ export const Adresse = ({ kontaktadresseData, idx }: KontaktadresseVisningTypes)
 	)
 }
 
+const KontaktadresseVisning = ({
+	kontaktadresseData,
+	idx,
+	data,
+	tmpData,
+	tmpPersoner,
+	ident,
+	erPdlVisning,
+}: KontaktadresseVisningTypes) => {
+	const initKontaktadresse = Object.assign(
+		_cloneDeep(initialKontaktadresse),
+		data?.[idx] || tmpData?.[idx]
+	)
+	const initialValues = { kontaktadresse: initKontaktadresse }
+
+	const redigertKontaktadressePdlf = _get(tmpPersoner, `${ident}.person.kontaktadresse`)?.find(
+		(a: KontaktadresseData) => a.id === kontaktadresseData.id
+	)
+	const slettetKontaktadressePdlf =
+		tmpPersoner?.hasOwnProperty(ident) && !redigertKontaktadressePdlf
+	if (slettetKontaktadressePdlf) {
+		return <pre style={{ margin: '0' }}>Opplysning slettet</pre>
+	}
+
+	const kontaktadresseValues = redigertKontaktadressePdlf
+		? redigertKontaktadressePdlf
+		: kontaktadresseData
+	const redigertKontaktadresseValues = redigertKontaktadressePdlf
+		? {
+				kontaktadresse: Object.assign(
+					_cloneDeep(initialKontaktadresse),
+					redigertKontaktadressePdlf
+				),
+		  }
+		: null
+	return erPdlVisning ? (
+		<Adresse kontaktadresseData={kontaktadresseData} idx={idx} />
+	) : (
+		<VisningRedigerbarConnector
+			dataVisning={<Adresse kontaktadresseData={kontaktadresseValues} idx={idx} />}
+			initialValues={initialValues}
+			redigertAttributt={redigertKontaktadresseValues}
+			path="kontaktadresse"
+			ident={ident}
+		/>
+	)
+}
+
 export const Kontaktadresse = ({
 	data,
 	tmpPersoner,
@@ -170,46 +223,6 @@ export const Kontaktadresse = ({
 		return null
 	}
 
-	const KontaktadresseVisning = ({ kontaktadresseData, idx }: KontaktadresseVisningTypes) => {
-		const initKontaktadresse = Object.assign(
-			_cloneDeep(initialKontaktadresse),
-			data?.[idx] || tmpData?.[idx]
-		)
-		const initialValues = { kontaktadresse: initKontaktadresse }
-
-		const redigertKontaktadressePdlf = _get(tmpPersoner, `${ident}.person.kontaktadresse`)?.find(
-			(a: KontaktadresseData) => a.id === kontaktadresseData.id
-		)
-		const slettetKontaktadressePdlf =
-			tmpPersoner?.hasOwnProperty(ident) && !redigertKontaktadressePdlf
-		if (slettetKontaktadressePdlf) {
-			return <pre style={{ margin: '0' }}>Opplysning slettet</pre>
-		}
-
-		const kontaktadresseValues = redigertKontaktadressePdlf
-			? redigertKontaktadressePdlf
-			: kontaktadresseData
-		const redigertKontaktadresseValues = redigertKontaktadressePdlf
-			? {
-					kontaktadresse: Object.assign(
-						_cloneDeep(initialKontaktadresse),
-						redigertKontaktadressePdlf
-					),
-			  }
-			: null
-		return erPdlVisning ? (
-			<Adresse kontaktadresseData={kontaktadresseData} idx={idx} />
-		) : (
-			<VisningRedigerbarConnector
-				dataVisning={<Adresse kontaktadresseData={kontaktadresseValues} idx={idx} />}
-				initialValues={initialValues}
-				redigertAttributt={redigertKontaktadresseValues}
-				path="kontaktadresse"
-				ident={ident}
-			/>
-		)
-	}
-
 	return (
 		<>
 			<SubOverskrift label="Kontaktadresse" iconKind="postadresse" />
@@ -217,7 +230,15 @@ export const Kontaktadresse = ({
 				<ErrorBoundary>
 					<DollyFieldArray data={data || tmpData} header="" nested>
 						{(adresse: any, idx: number) => (
-							<KontaktadresseVisning kontaktadresseData={adresse} idx={idx} />
+							<KontaktadresseVisning
+								kontaktadresseData={adresse}
+								idx={idx}
+								data={data}
+								tmpData={tmpData}
+								ident={ident}
+								erPdlVisning={erPdlVisning}
+								tmpPersoner={tmpPersoner}
+							/>
 						)}
 					</DollyFieldArray>
 				</ErrorBoundary>

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/visning/partials/Oppholdsadresse.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/visning/partials/Oppholdsadresse.tsx
@@ -20,12 +20,21 @@ type OppholdsadresseTypes = {
 	erPdlVisning?: boolean
 }
 
-type OppholdsadresseVisningTypes = {
+type AdresseTypes = {
 	oppholdsadresseData: any
 	idx: number
 }
 
-export const Adresse = ({ oppholdsadresseData, idx }: OppholdsadresseVisningTypes) => {
+type OppholdsadresseVisningTypes = {
+	oppholdsadresseData: any
+	idx: number
+	data: Array<any>
+	tmpPersoner: Array<OppholdsadresseData>
+	ident: string
+	erPdlVisning: boolean
+}
+
+export const Adresse = ({ oppholdsadresseData, idx }: AdresseTypes) => {
 	if (!oppholdsadresseData) {
 		return null
 	}
@@ -51,6 +60,50 @@ export const Adresse = ({ oppholdsadresseData, idx }: OppholdsadresseVisningType
 	)
 }
 
+const OppholdsadresseVisning = ({
+	oppholdsadresseData,
+	idx,
+	data,
+	tmpPersoner,
+	ident,
+	erPdlVisning,
+}: OppholdsadresseVisningTypes) => {
+	const initOppholdsadresse = Object.assign(_cloneDeep(initialOppholdsadresse), data[idx])
+	const initialValues = { oppholdsadresse: initOppholdsadresse }
+
+	const redigertOppholdsadressePdlf = _get(tmpPersoner, `${ident}.person.oppholdsadresse`)?.find(
+		(a: OppholdsadresseData) => a.id === oppholdsadresseData.id
+	)
+	const slettetOppholdsadressePdlf =
+		tmpPersoner?.hasOwnProperty(ident) && !redigertOppholdsadressePdlf
+	if (slettetOppholdsadressePdlf) {
+		return <pre style={{ margin: '0' }}>Opplysning slettet</pre>
+	}
+
+	const oppholdsadresseValues = redigertOppholdsadressePdlf
+		? redigertOppholdsadressePdlf
+		: oppholdsadresseData
+	const redigertOppholdsadresseValues = redigertOppholdsadressePdlf
+		? {
+				oppholdsadresse: Object.assign(
+					_cloneDeep(initialOppholdsadresse),
+					redigertOppholdsadressePdlf
+				),
+		  }
+		: null
+	return erPdlVisning ? (
+		<Adresse oppholdsadresseData={oppholdsadresseData} idx={idx} />
+	) : (
+		<VisningRedigerbarConnector
+			dataVisning={<Adresse oppholdsadresseData={oppholdsadresseValues} idx={idx} />}
+			initialValues={initialValues}
+			redigertAttributt={redigertOppholdsadresseValues}
+			path="oppholdsadresse"
+			ident={ident}
+		/>
+	)
+}
+
 export const Oppholdsadresse = ({
 	data,
 	tmpPersoner,
@@ -61,43 +114,6 @@ export const Oppholdsadresse = ({
 		return null
 	}
 
-	const OppholdsadresseVisning = ({ oppholdsadresseData, idx }: OppholdsadresseVisningTypes) => {
-		const initOppholdsadresse = Object.assign(_cloneDeep(initialOppholdsadresse), data[idx])
-		const initialValues = { oppholdsadresse: initOppholdsadresse }
-
-		const redigertOppholdsadressePdlf = _get(tmpPersoner, `${ident}.person.oppholdsadresse`)?.find(
-			(a: OppholdsadresseData) => a.id === oppholdsadresseData.id
-		)
-		const slettetOppholdsadressePdlf =
-			tmpPersoner?.hasOwnProperty(ident) && !redigertOppholdsadressePdlf
-		if (slettetOppholdsadressePdlf) {
-			return <pre style={{ margin: '0' }}>Opplysning slettet</pre>
-		}
-
-		const oppholdsadresseValues = redigertOppholdsadressePdlf
-			? redigertOppholdsadressePdlf
-			: oppholdsadresseData
-		const redigertOppholdsadresseValues = redigertOppholdsadressePdlf
-			? {
-					oppholdsadresse: Object.assign(
-						_cloneDeep(initialOppholdsadresse),
-						redigertOppholdsadressePdlf
-					),
-			  }
-			: null
-		return erPdlVisning ? (
-			<Adresse oppholdsadresseData={oppholdsadresseData} idx={idx} />
-		) : (
-			<VisningRedigerbarConnector
-				dataVisning={<Adresse oppholdsadresseData={oppholdsadresseValues} idx={idx} />}
-				initialValues={initialValues}
-				redigertAttributt={redigertOppholdsadresseValues}
-				path="oppholdsadresse"
-				ident={ident}
-			/>
-		)
-	}
-
 	return (
 		<>
 			<SubOverskrift label="Oppholdsadresse" iconKind="adresse" />
@@ -105,7 +121,14 @@ export const Oppholdsadresse = ({
 				<ErrorBoundary>
 					<DollyFieldArray data={data} header="" nested>
 						{(adresse: any, idx: number) => (
-							<OppholdsadresseVisning oppholdsadresseData={adresse} idx={idx} />
+							<OppholdsadresseVisning
+								oppholdsadresseData={adresse}
+								idx={idx}
+								data={data}
+								tmpPersoner={tmpPersoner}
+								ident={ident}
+								erPdlVisning={erPdlVisning}
+							/>
 						)}
 					</DollyFieldArray>
 				</ErrorBoundary>

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/visning/partials/Persondetaljer.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/visning/partials/Persondetaljer.tsx
@@ -28,6 +28,9 @@ type PersondetaljerTypes = {
 type PersonTypes = {
 	person: PersonData
 	skjerming?: Skjerming
+	redigertPerson: any
+	tpsMessaging: any
+	tpsMessagingLoading?: boolean
 }
 
 const getCurrentPersonstatus = (data: any) => {
@@ -41,6 +44,34 @@ const getCurrentPersonstatus = (data: any) => {
 		return statuser.length > 0 ? statuser[0] : null
 	}
 	return null
+}
+
+const PersondetaljerLes = ({
+	person,
+	skjerming,
+	redigertPerson,
+	tpsMessaging,
+	tpsMessagingLoading,
+}: PersonTypes) => {
+	const personNavn = person?.navn?.[0]
+	const personKjoenn = person?.kjoenn?.[0]
+	const personstatus = getCurrentPersonstatus(redigertPerson || person)
+
+	return (
+		<div className="person-visning_redigerbar">
+			<TitleValue title="Ident" value={person?.ident} />
+			<TitleValue title="Fornavn" value={personNavn?.fornavn} />
+			<TitleValue title="Mellomnavn" value={personNavn?.mellomnavn} />
+			<TitleValue title="Etternavn" value={personNavn?.etternavn} />
+			<TitleValue title="Kjønn" value={personKjoenn?.kjoenn} />
+			<TitleValue
+				title="Personstatus"
+				value={Formatters.showLabel('personstatus', personstatus?.status)}
+			/>
+			<SkjermingVisning data={skjerming} />
+			<TpsMPersonInfo data={tpsMessaging} loading={tpsMessagingLoading} />
+		</div>
+	)
 }
 
 export const Persondetaljer = ({
@@ -57,74 +88,32 @@ export const Persondetaljer = ({
 	}
 	const redigertPerson = _get(tmpPersoner?.pdlforvalter, `${data?.ident}.person`)
 
-	const PersondetaljerLes = ({ person, skjerming }: PersonTypes) => {
-		const personNavn = person?.navn?.[0]
-		const personKjoenn = person?.kjoenn?.[0]
-		const personstatus = getCurrentPersonstatus(redigertPerson || person)
-
-		return (
-			<div className="person-visning_redigerbar">
-				<TitleValue title="Ident" value={person?.ident} />
-				<TitleValue title="Fornavn" value={personNavn?.fornavn} />
-				<TitleValue title="Mellomnavn" value={personNavn?.mellomnavn} />
-				<TitleValue title="Etternavn" value={personNavn?.etternavn} />
-				<TitleValue title="Kjønn" value={personKjoenn?.kjoenn} />
-				<TitleValue
-					title="Personstatus"
-					value={Formatters.showLabel('personstatus', personstatus?.status)}
-				/>
-				<SkjermingVisning data={skjerming} />
-				<TpsMPersonInfo data={tpsMessaging} loading={tpsMessagingLoading} />
-			</div>
-		)
+	const initPerson = {
+		navn: [data?.navn?.[0] || initialNavn],
+		kjoenn: [data?.kjoenn?.[0] || initialKjoenn],
+		folkeregisterpersonstatus: [data?.folkeregisterPersonstatus?.[0] || initialPersonstatus],
+		skjermingsregister: skjermingData,
 	}
 
-	const PersondetaljerVisning = ({ person }: PersonTypes) => {
-		const initPerson = {
-			navn: [data?.navn?.[0] || initialNavn],
-			kjoenn: [data?.kjoenn?.[0] || initialKjoenn],
-			folkeregisterpersonstatus: [data?.folkeregisterPersonstatus?.[0] || initialPersonstatus],
-			skjermingsregister: skjermingData,
-		}
+	const redigertPersonPdlf = _get(tmpPersoner?.pdlforvalter, `${ident}.person`)
+	const redigertSkjerming = _get(tmpPersoner?.skjermingsregister, `${ident}`)
 
-		const redigertPersonPdlf = _get(tmpPersoner?.pdlforvalter, `${ident}.person`)
-		const redigertSkjerming = _get(tmpPersoner?.skjermingsregister, `${ident}`)
+	const personValues = redigertPersonPdlf ? redigertPersonPdlf : data
+	const redigertPdlfPersonValues = redigertPersonPdlf
+		? {
+				navn: [redigertPersonPdlf?.navn ? redigertPersonPdlf?.navn?.[0] : initialNavn],
+				kjoenn: [redigertPersonPdlf?.kjoenn ? redigertPersonPdlf?.kjoenn?.[0] : initialKjoenn],
+				folkeregisterpersonstatus: [
+					redigertPersonPdlf?.folkeregisterPersonstatus
+						? redigertPersonPdlf?.folkeregisterPersonstatus?.[0]
+						: initialPersonstatus,
+				],
+		  }
+		: null
 
-		const personValues = redigertPersonPdlf ? redigertPersonPdlf : person
-		const redigertPdlfPersonValues = redigertPersonPdlf
-			? {
-					navn: [redigertPersonPdlf?.navn ? redigertPersonPdlf?.navn?.[0] : initialNavn],
-					kjoenn: [redigertPersonPdlf?.kjoenn ? redigertPersonPdlf?.kjoenn?.[0] : initialKjoenn],
-					folkeregisterpersonstatus: [
-						redigertPersonPdlf?.folkeregisterPersonstatus
-							? redigertPersonPdlf?.folkeregisterPersonstatus?.[0]
-							: initialPersonstatus,
-					],
-			  }
-			: null
-
-		const redigertPersonValues = {
-			pdlf: redigertPdlfPersonValues,
-			skjermingsregister: redigertSkjerming ? redigertSkjerming : null,
-		}
-
-		return erPdlVisning ? (
-			<PersondetaljerLes person={person} skjerming={skjermingData} />
-		) : (
-			<VisningRedigerbarPersondetaljerConnector
-				dataVisning={
-					<PersondetaljerLes
-						person={personValues}
-						skjerming={redigertSkjerming ? redigertSkjerming : skjermingData}
-					/>
-				}
-				initialValues={initPerson}
-				redigertAttributt={redigertPersonValues}
-				path="person"
-				ident={ident}
-				tpsMessagingData={tpsMessaging}
-			/>
-		)
+	const redigertPersonValues = {
+		pdlf: redigertPdlfPersonValues,
+		skjermingsregister: redigertSkjerming ? redigertSkjerming : null,
 	}
 
 	return (
@@ -132,7 +121,32 @@ export const Persondetaljer = ({
 			<div>
 				<SubOverskrift label="Persondetaljer" iconKind="personinformasjon" />
 				<div className="person-visning_content">
-					<PersondetaljerVisning person={data} />
+					{erPdlVisning ? (
+						<PersondetaljerLes
+							person={data}
+							skjerming={skjermingData}
+							redigertPerson={redigertPerson}
+							tpsMessaging={tpsMessaging}
+							tpsMessagingLoading={tpsMessagingLoading}
+						/>
+					) : (
+						<VisningRedigerbarPersondetaljerConnector
+							dataVisning={
+								<PersondetaljerLes
+									person={personValues}
+									skjerming={redigertSkjerming ? redigertSkjerming : skjermingData}
+									redigertPerson={redigertPerson}
+									tpsMessaging={tpsMessaging}
+									tpsMessagingLoading={tpsMessagingLoading}
+								/>
+							}
+							initialValues={initPerson}
+							redigertAttributt={redigertPersonValues}
+							path="person"
+							ident={ident}
+							tpsMessagingData={tpsMessaging}
+						/>
+					)}
 				</div>
 			</div>
 		</ErrorBoundary>

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/visning/partials/Statsborgerskap.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/visning/partials/Statsborgerskap.tsx
@@ -17,9 +17,85 @@ type StatsborgerskapTypes = {
 	erPdlVisning?: boolean
 }
 
+type StatsborgerskapLesTypes = {
+	statsborgerskapData: StatsborgerskapData
+	idx: number
+}
+
 type StatsborgerskapVisningTypes = {
 	statsborgerskapData: StatsborgerskapData
 	idx: number
+	data: Array<StatsborgerskapData>
+	tmpPersoner: Array<PersonData>
+	ident: string
+	erPdlVisning: boolean
+}
+
+const StatsborgerskapLes = ({ statsborgerskapData, idx }: StatsborgerskapLesTypes) => {
+	if (statsborgerskapData) {
+		return (
+			<div className="person-visning_redigerbar" key={idx}>
+				<TitleValue
+					title="Statsborgerskap"
+					kodeverk={AdresseKodeverk.StatsborgerskapLand}
+					value={statsborgerskapData.landkode}
+				/>
+				<TitleValue
+					title="Statsborgerskap registrert"
+					value={Formatters.formatDate(statsborgerskapData.gyldigFraOgMed)}
+				/>
+				<TitleValue
+					title="Statsborgerskap til"
+					value={Formatters.formatDate(statsborgerskapData.gyldigTilOgMed)}
+				/>
+			</div>
+		)
+	}
+	return null
+}
+
+const StatsborgerskapVisning = ({
+	statsborgerskapData,
+	idx,
+	data,
+	tmpPersoner,
+	ident,
+	erPdlVisning,
+}: StatsborgerskapVisningTypes) => {
+	const initStatsborgerskap = Object.assign(_cloneDeep(initialStatsborgerskap), data[idx])
+	const initialValues = { statsborgerskap: initStatsborgerskap }
+
+	const redigertStatsborgerskapPdlf = _get(tmpPersoner, `${ident}.person.statsborgerskap`)?.find(
+		(a: StatsborgerskapData) => a.id === statsborgerskapData.id
+	)
+	const slettetStatsborgerskapPdlf =
+		tmpPersoner?.hasOwnProperty(ident) && !redigertStatsborgerskapPdlf
+	if (slettetStatsborgerskapPdlf) {
+		return <pre style={{ margin: '0' }}>Opplysning slettet</pre>
+	}
+
+	const statsborgerskapValues = redigertStatsborgerskapPdlf
+		? redigertStatsborgerskapPdlf
+		: statsborgerskapData
+	const redigertStatsborgerskapValues = redigertStatsborgerskapPdlf
+		? {
+				statsborgerskap: Object.assign(
+					_cloneDeep(initialStatsborgerskap),
+					redigertStatsborgerskapPdlf
+				),
+		  }
+		: null
+	return erPdlVisning ? (
+		<StatsborgerskapLes statsborgerskapData={statsborgerskapData} idx={idx} />
+	) : (
+		<VisningRedigerbarConnector
+			dataVisning={<StatsborgerskapLes statsborgerskapData={statsborgerskapValues} idx={idx} />}
+			initialValues={initialValues}
+			redigertAttributt={redigertStatsborgerskapValues}
+			path="statsborgerskap"
+			ident={ident}
+		/>
+	)
 }
 
 export const Statsborgerskap = ({
@@ -32,72 +108,19 @@ export const Statsborgerskap = ({
 		return null
 	}
 
-	const StatsborgerskapLes = ({ statsborgerskapData, idx }: StatsborgerskapVisningTypes) => {
-		if (statsborgerskapData) {
-			return (
-				<div className="person-visning_redigerbar" key={idx}>
-					<TitleValue
-						title="Statsborgerskap"
-						kodeverk={AdresseKodeverk.StatsborgerskapLand}
-						value={statsborgerskapData.landkode}
-					/>
-					<TitleValue
-						title="Statsborgerskap registrert"
-						value={Formatters.formatDate(statsborgerskapData.gyldigFraOgMed)}
-					/>
-					<TitleValue
-						title="Statsborgerskap til"
-						value={Formatters.formatDate(statsborgerskapData.gyldigTilOgMed)}
-					/>
-				</div>
-			)
-		}
-		return null
-	}
-
-	const StatsborgerskapVisning = ({ statsborgerskapData, idx }: StatsborgerskapVisningTypes) => {
-		const initStatsborgerskap = Object.assign(_cloneDeep(initialStatsborgerskap), data[idx])
-		const initialValues = { statsborgerskap: initStatsborgerskap }
-
-		const redigertStatsborgerskapPdlf = _get(tmpPersoner, `${ident}.person.statsborgerskap`)?.find(
-			(a: StatsborgerskapData) => a.id === statsborgerskapData.id
-		)
-		const slettetStatsborgerskapPdlf =
-			tmpPersoner?.hasOwnProperty(ident) && !redigertStatsborgerskapPdlf
-		if (slettetStatsborgerskapPdlf) {
-			return <pre style={{ margin: '0' }}>Opplysning slettet</pre>
-		}
-
-		const statsborgerskapValues = redigertStatsborgerskapPdlf
-			? redigertStatsborgerskapPdlf
-			: statsborgerskapData
-		const redigertStatsborgerskapValues = redigertStatsborgerskapPdlf
-			? {
-					statsborgerskap: Object.assign(
-						_cloneDeep(initialStatsborgerskap),
-						redigertStatsborgerskapPdlf
-					),
-			  }
-			: null
-		return erPdlVisning ? (
-			<StatsborgerskapLes statsborgerskapData={statsborgerskapData} idx={idx} />
-		) : (
-			<VisningRedigerbarConnector
-				dataVisning={<StatsborgerskapLes statsborgerskapData={statsborgerskapValues} idx={idx} />}
-				initialValues={initialValues}
-				redigertAttributt={redigertStatsborgerskapValues}
-				path="statsborgerskap"
-				ident={ident}
-			/>
-		)
-	}
-
 	return (
 		<div className="person-visning_content" style={{ marginTop: '-15px' }}>
 			<ErrorBoundary>
 				<DollyFieldArray data={data} header="Statsborgerskap" nested>
 					{(borgerskap: StatsborgerskapData, idx: number) => (
-						<StatsborgerskapVisning statsborgerskapData={borgerskap} idx={idx} />
+						<StatsborgerskapVisning
+							statsborgerskapData={borgerskap}
+							idx={idx}
+							data={data}
+							tmpPersoner={tmpPersoner}
+							ident={ident}
+							erPdlVisning={erPdlVisning}
+						/>
 					)}
 				</DollyFieldArray>
 			</ErrorBoundary>

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/visning/partials/Vergemaal.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/visning/partials/Vergemaal.tsx
@@ -5,19 +5,180 @@ import { ErrorBoundary } from '~/components/ui/appError/ErrorBoundary'
 import { TitleValue } from '~/components/ui/titleValue/TitleValue'
 import Formatters from '~/utils/DataFormatter'
 import { RelatertPerson } from '~/components/fagsystem/pdlf/visning/partials/RelatertPerson'
-import { Relasjon, VergemaalValues } from '~/components/fagsystem/pdlf/PdlTypes'
+import { PersonData, Relasjon, VergemaalValues } from '~/components/fagsystem/pdlf/PdlTypes'
 import { VergemaalKodeverk } from '~/config/kodeverk'
 import _cloneDeep from 'lodash/cloneDeep'
 import { initialPdlPerson, initialVergemaal } from '~/components/fagsystem/pdlf/form/initialValues'
 import _get from 'lodash/get'
 import VisningRedigerbarConnector from '~/components/fagsystem/pdlf/visning/visningRedigerbar/VisningRedigerbarConnector'
 
+type Vergemaal = {
+	vergemaalEmbete?: string
+	embete?: string
+	mandatType?: string
+	vergeEllerFullmektig?: {
+		omfang?: string
+		motpartsPersonident?: string
+	}
+	sakType?: string
+	type?: string
+	gyldigFraOgMed: string
+	gyldigTilOgMed: string
+	vergeIdent?: string
+	id: number
+}
+
 type VergemaalTypes = {
-	data: Array<VergemaalValues>
-	tmpPersoner?: Array<VergemaalValues>
+	data: Array<Vergemaal>
+	tmpPersoner?: Array<PersonData>
 	ident?: string
 	erPdlVisning?: boolean
 	relasjoner: Array<Relasjon>
+}
+
+type VergemaalLesTypes = {
+	vergemaalData: Vergemaal
+	relasjoner: Array<Relasjon>
+	redigertRelatertePersoner?: Array<Relasjon>
+	idx: number
+}
+
+type VergemaalVisningTypes = {
+	vergemaalData: Vergemaal
+	relasjoner: Array<Relasjon>
+	idx: number
+	data: Array<Vergemaal>
+	tmpPersoner: Array<PersonData>
+	ident: string
+	erPdlVisning?: boolean
+}
+
+const VergemaalLes = ({
+	vergemaalData,
+	relasjoner,
+	redigertRelatertePersoner = null,
+	idx,
+}: VergemaalLesTypes) => {
+	if (!vergemaalData) {
+		return null
+	}
+
+	const retatertPersonIdent = vergemaalData.vergeIdent
+	const relasjon = relasjoner?.find((item) => item.relatertPerson?.ident === retatertPersonIdent)
+	const relasjonRedigert = redigertRelatertePersoner?.find(
+		(item) => item.relatertPerson?.ident === retatertPersonIdent
+	)
+
+	const harFullmektig = vergemaalData.sakType === 'FRE'
+
+	return (
+		<>
+			<div className="person-visning_redigerbar" key={idx}>
+				<TitleValue
+					title="Fylkesmannsembete"
+					kodeverk={VergemaalKodeverk.Fylkesmannsembeter}
+					value={vergemaalData.vergemaalEmbete || vergemaalData.embete}
+				/>
+				<TitleValue
+					title="Sakstype"
+					kodeverk={VergemaalKodeverk.Sakstype}
+					value={vergemaalData.sakType || vergemaalData.type}
+				/>
+				<TitleValue
+					title="Mandattype"
+					kodeverk={VergemaalKodeverk.Mandattype}
+					value={vergemaalData.mandatType || vergemaalData.vergeEllerFullmektig?.omfang}
+				/>
+				<TitleValue
+					title="Gyldig f.o.m."
+					value={Formatters.formatDate(vergemaalData.gyldigFraOgMed)}
+				/>
+				<TitleValue
+					title="Gyldig t.o.m."
+					value={Formatters.formatDate(vergemaalData.gyldigTilOgMed)}
+				/>
+				{!relasjon && !relasjonRedigert && (
+					<TitleValue
+						title={harFullmektig ? 'Fullmektig' : 'Verge'}
+						value={
+							vergemaalData.vergeIdent || vergemaalData.vergeEllerFullmektig?.motpartsPersonident
+						}
+					/>
+				)}
+			</div>
+			{(relasjonRedigert || relasjon) && (
+				<RelatertPerson
+					data={relasjonRedigert?.relatertPerson || relasjon?.relatertPerson}
+					tittel={harFullmektig ? 'Fullmektig' : 'Verge'}
+				/>
+			)}
+		</>
+	)
+}
+
+const VergemaalVisning = ({
+	vergemaalData,
+	idx,
+	data,
+	tmpPersoner,
+	ident,
+	relasjoner,
+	erPdlVisning,
+}: VergemaalVisningTypes) => {
+	const initVergemaal = Object.assign(_cloneDeep(initialVergemaal), data[idx])
+	let initialValues = { vergemaal: initVergemaal }
+	initialValues.vergemaal.nyVergeIdent = initialPdlPerson
+
+	const redigertVergemaalPdlf = _get(tmpPersoner, `${ident}.person.vergemaal`)?.find(
+		(a: VergemaalValues) => a.id === vergemaalData.id
+	)
+	const redigertRelatertePersoner = _get(tmpPersoner, `${ident}.relasjoner`)
+
+	const slettetVergemaalPdlf = tmpPersoner?.hasOwnProperty(ident) && !redigertVergemaalPdlf
+	if (slettetVergemaalPdlf) {
+		return <pre style={{ margin: '0' }}>Opplysning slettet</pre>
+	}
+
+	const vergemaalValues = redigertVergemaalPdlf ? redigertVergemaalPdlf : vergemaalData
+	let redigertVergemaalValues = redigertVergemaalPdlf
+		? {
+				vergemaal: Object.assign(_cloneDeep(initialVergemaal), redigertVergemaalPdlf),
+		  }
+		: null
+	if (redigertVergemaalValues) {
+		redigertVergemaalValues.vergemaal.nyVergeIdent = initialPdlPerson
+	}
+
+	const eksisterendeNyPerson = redigertRelatertePersoner
+		? getEksisterendeNyPerson(redigertRelatertePersoner)
+		: getEksisterendeNyPerson(relasjoner)
+
+	return erPdlVisning ? (
+		<VergemaalLes vergemaalData={vergemaalData} relasjoner={relasjoner} idx={idx} />
+	) : (
+		<VisningRedigerbarConnector
+			dataVisning={
+				<VergemaalLes
+					vergemaalData={vergemaalValues}
+					redigertRelatertePersoner={redigertRelatertePersoner}
+					relasjoner={relasjoner}
+					idx={idx}
+				/>
+			}
+			initialValues={initialValues}
+			eksisterendeNyPerson={eksisterendeNyPerson}
+			redigertAttributt={redigertVergemaalValues}
+			path="vergemaal"
+			ident={ident}
+		/>
+	)
+}
+
+const getEksisterendeNyPerson = (relasjoner: Array<Relasjon>) => {
+	return {
+		value: relasjoner?.[0]?.relatertPerson?.ident,
+		label: `${relasjoner?.[0]?.relatertPerson?.ident} - ${relasjoner?.[0]?.relatertPerson?.navn?.[0]?.fornavn} ${relasjoner?.[0]?.relatertPerson?.navn?.[0]?.etternavn}`,
+	}
 }
 
 export const Vergemaal = ({
@@ -31,119 +192,6 @@ export const Vergemaal = ({
 		return null
 	}
 
-	const VergemaalLes = ({ vergemaalData, redigertRelatertePersoner = null, idx }) => {
-		if (!vergemaalData) {
-			return null
-		}
-
-		const retatertPersonIdent = vergemaalData.vergeIdent
-		const relasjon = relasjoner?.find((item) => item.relatertPerson?.ident === retatertPersonIdent)
-		const relasjonRedigert = redigertRelatertePersoner?.find(
-			(item) => item.relatertPerson?.ident === retatertPersonIdent
-		)
-
-		const harFullmektig = vergemaalData.sakType === 'FRE'
-
-		return (
-			<>
-				<div className="person-visning_redigerbar" key={idx}>
-					<TitleValue
-						title="Fylkesmannsembete"
-						kodeverk={VergemaalKodeverk.Fylkesmannsembeter}
-						value={vergemaalData.vergemaalEmbete || vergemaalData.embete}
-					/>
-					<TitleValue
-						title="Sakstype"
-						kodeverk={VergemaalKodeverk.Sakstype}
-						value={vergemaalData.sakType || vergemaalData.type}
-					/>
-					<TitleValue
-						title="Mandattype"
-						kodeverk={VergemaalKodeverk.Mandattype}
-						value={vergemaalData.mandatType || vergemaalData.vergeEllerFullmektig?.omfang}
-					/>
-					<TitleValue
-						title="Gyldig f.o.m."
-						value={Formatters.formatDate(vergemaalData.gyldigFraOgMed)}
-					/>
-					<TitleValue
-						title="Gyldig t.o.m."
-						value={Formatters.formatDate(vergemaalData.gyldigTilOgMed)}
-					/>
-					{!relasjon && !relasjonRedigert && (
-						<TitleValue
-							title={harFullmektig ? 'Fullmektig' : 'Verge'}
-							value={
-								vergemaalData.vergeIdent || vergemaalData.vergeEllerFullmektig?.motpartsPersonident
-							}
-						/>
-					)}
-				</div>
-				{(relasjonRedigert || relasjon) && (
-					<RelatertPerson
-						data={relasjonRedigert?.relatertPerson || relasjon?.relatertPerson}
-						tittel={harFullmektig ? 'Fullmektig' : 'Verge'}
-					/>
-				)}
-			</>
-		)
-	}
-
-	const VergemaalVisning = ({ vergemaalData, idx }) => {
-		const initVergemaal = Object.assign(_cloneDeep(initialVergemaal), data[idx])
-		let initialValues = { vergemaal: initVergemaal }
-		initialValues.vergemaal.nyVergeIdent = initialPdlPerson
-
-		const redigertVergemaalPdlf = _get(tmpPersoner, `${ident}.person.vergemaal`)?.find(
-			(a: VergemaalValues) => a.id === vergemaalData.id
-		)
-		const redigertRelatertePersoner = _get(tmpPersoner, `${ident}.relasjoner`)
-
-		const slettetVergemaalPdlf = tmpPersoner?.hasOwnProperty(ident) && !redigertVergemaalPdlf
-		if (slettetVergemaalPdlf) {
-			return <pre style={{ margin: '0' }}>Opplysning slettet</pre>
-		}
-
-		const vergemaalValues = redigertVergemaalPdlf ? redigertVergemaalPdlf : vergemaalData
-		let redigertVergemaalValues = redigertVergemaalPdlf
-			? {
-					vergemaal: Object.assign(_cloneDeep(initialVergemaal), redigertVergemaalPdlf),
-			  }
-			: null
-		if (redigertVergemaalValues) {
-			redigertVergemaalValues.vergemaal.nyVergeIdent = initialPdlPerson
-		}
-
-		const eksisterendeNyPerson = redigertRelatertePersoner
-			? {
-					value: redigertRelatertePersoner[0]?.relatertPerson?.ident,
-					label: `${redigertRelatertePersoner[0]?.relatertPerson?.ident} - ${redigertRelatertePersoner?.[0]?.relatertPerson?.navn?.[0]?.fornavn} ${redigertRelatertePersoner?.[0]?.relatertPerson?.navn?.[0]?.etternavn}`,
-			  }
-			: {
-					value: relasjoner?.[0]?.relatertPerson?.ident,
-					label: `${relasjoner?.[0]?.relatertPerson?.ident} - ${relasjoner?.[0]?.relatertPerson?.navn?.[0]?.fornavn} ${relasjoner?.[0]?.relatertPerson?.navn?.[0]?.etternavn}`,
-			  }
-
-		return erPdlVisning ? (
-			<VergemaalLes vergemaalData={vergemaalData} idx={idx} />
-		) : (
-			<VisningRedigerbarConnector
-				dataVisning={
-					<VergemaalLes
-						vergemaalData={vergemaalValues}
-						redigertRelatertePersoner={redigertRelatertePersoner}
-						idx={idx}
-					/>
-				}
-				initialValues={initialValues}
-				eksisterendeNyPerson={eksisterendeNyPerson}
-				redigertAttributt={redigertVergemaalValues}
-				path="vergemaal"
-				ident={ident}
-			/>
-		)
-	}
-
 	return (
 		<div>
 			<SubOverskrift label="Vergemål" iconKind="vergemaal" />
@@ -151,7 +199,15 @@ export const Vergemaal = ({
 				<ErrorBoundary>
 					<DollyFieldArray data={data} nested>
 						{(vergemaal: VergemaalValues, idx: number) => (
-							<VergemaalVisning vergemaalData={vergemaal} idx={idx} />
+							<VergemaalVisning
+								vergemaalData={vergemaal}
+								idx={idx}
+								data={data}
+								tmpPersoner={tmpPersoner}
+								ident={ident}
+								erPdlVisning={erPdlVisning}
+								relasjoner={relasjoner}
+							/>
 						)}
 					</DollyFieldArray>
 				</ErrorBoundary>

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/sigrunstub/form/Form.js
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/sigrunstub/form/Form.js
@@ -21,7 +21,7 @@ export const SigrunstubForm = ({ formikBag }) => (
 )
 
 const mapTjeneste = (tjeneste) => {
-	var mapped = tjeneste.toUpperCase()
+	let mapped = tjeneste.toUpperCase()
 	return mapped.replace(' ', '_')
 }
 

--- a/apps/dolly-frontend/src/main/js/src/ducks/fagsystem/index.js
+++ b/apps/dolly-frontend/src/main/js/src/ducks/fagsystem/index.js
@@ -318,7 +318,7 @@ const hentPersonStatus = (ident, bestillingStatus) => {
 	if (!bestillingStatus) {
 		return totalStatus
 	}
-	bestillingStatus?.status.forEach((fagsystem) => {
+	bestillingStatus?.status?.forEach((fagsystem) => {
 		_get(fagsystem, 'statuser', []).forEach((status) => {
 			if (status.detaljert) {
 				_get(status, 'detaljert', []).forEach((miljoe) => {

--- a/apps/dolly-frontend/src/main/js/src/utils/hooks/useOrganisasjoner.tsx
+++ b/apps/dolly-frontend/src/main/js/src/utils/hooks/useOrganisasjoner.tsx
@@ -4,7 +4,6 @@ import { Organisasjon, OrganisasjonFasteData } from '~/service/services/organisa
 import { Bestillingsinformasjon } from '~/components/bestilling/sammendrag/miljoeStatus/MiljoeStatus'
 import { Arbeidsforhold } from '~/components/fagsystem/inntektsmelding/InntektsmeldingTypes'
 import { useDollyEnvironments } from '~/utils/hooks/useEnvironments'
-import _isArray from 'lodash/isArray'
 
 type MiljoDataListe = {
 	miljo: string


### PR DESCRIPTION
Sonarcloud liker ikke lenger når du definerer komponenter inni andre komponenter fordi: _"React will see a new component type on every render and destroy the entire subtree's DOM and nodes."_ . Har dermed oppdatert Pdlf visning partials som har brukt dette. Har ikke gjort noe mer enn å flytte komponentene ut og oppdatert props.

Var flere filer med samme problem igjen, men syns PR-en er stor nok.