### PR TITLE
Rettet feil ved bostedsadresse #deploy-pdl-forvalter-dev #deploy-pdl-…

### DIFF
--- a/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/service/BostedAdresseService.java
+++ b/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/service/BostedAdresseService.java
@@ -118,11 +118,16 @@ public class BostedAdresseService extends AdresseService<BostedadresseDTO, Perso
                 bostedadresse.setVegadresse(new VegadresseDTO());
             }
 
-        } else if (bostedadresse.countAdresser() == 0 &&
-                person.getOppholdsadresse().isEmpty() &&
+        } else if (bostedadresse.countAdresser() == 0) {
+
+            if (person.getOppholdsadresse().isEmpty() &&
                 person.getKontaktadresse().isEmpty()) {
 
-            bostedadresse.setUtenlandskAdresse(new UtenlandskAdresseDTO());
+                bostedadresse.setUtenlandskAdresse(new UtenlandskAdresseDTO());
+            } else {
+                person.setBostedsadresse(null);
+                return;
+            }
 
         } else {
 


### PR DESCRIPTION
Rettet feil ved bostedsadresse:
når person er DNR
og oppholdsadresse er valgt
så skal bostedsadresse (utland) ikke genereres.

Feilen besto i en ufullstendig bostedsadresse, den ble ikke slettet når oppholdsadresse ble valgt.