### PR TITLE
Bugfix/synth meldekort proxy

### DIFF
--- a/proxies/pensjon-testdata-facade-proxy/config.yml
+++ b/proxies/pensjon-testdata-facade-proxy/config.yml
@@ -49,6 +49,9 @@ spec:
           cluster: dev-gcp
         - application: testnav-synt-vedtakshistorikk-service
           cluster: dev-gcp
+    outbound:
+      external:
+        - host: popp-testdata.dev.intern.nav.no
   liveness:
     path: /internal/isAlive
     initialDelay: 4

--- a/proxies/pensjon-testdata-facade-proxy/src/main/resources/application.yml
+++ b/proxies/pensjon-testdata-facade-proxy/src/main/resources/application.yml
@@ -26,5 +26,5 @@ consumers:
   popp-testdata:
     name: popp-testdata
     namespace: pensjonopptjening
-    url: http://popp-testdata.pensjontestdata.svc.nais.local
+    url: https://popp-testdata.dev.intern.nav.no
     cluster: dev-gcp

--- a/proxies/synthdata-meldekort-proxy/config.yml
+++ b/proxies/synthdata-meldekort-proxy/config.yml
@@ -50,6 +50,8 @@ spec:
     outbound:
       rules:
         - application: synthdata-arena-meldekort
+      external:
+        - host: synthdata-arena-meldekort.dev.intern.nav.no
   liveness:
     path: /internal/isAlive
     initialDelay: 4

--- a/proxies/synthdata-meldekort-proxy/src/main/resources/application.yml
+++ b/proxies/synthdata-meldekort-proxy/src/main/resources/application.yml
@@ -17,7 +17,7 @@ spring:
 
 consumers:
   synt-meldekort:
-    url: http://synthdata-arena-meldekort.dolly.svc.cluster.local
+    url: https://synthdata-arena-meldekort.dev.intern.nav.no
     cluster: dev-gcp
     namespace: dolly
     name: synthdata-arena-meldekort


### PR DESCRIPTION
Proxyen klarer ikke å nå meldekort gjennom service discovery, fungerer igjen når den går mot ingress. 
Kanskje service discovery ikke fungerer mot syntpakkene av en eller annen grunn?