### PR TITLE
change/dolly-frontend-cypress

### DIFF
--- a/.github/workflows/app.dolly-frontend.yml
+++ b/.github/workflows/app.dolly-frontend.yml
@@ -5,10 +5,21 @@ on:
     paths:
       - apps/dolly-frontend/**
       - .github/workflows/app.dolly-frontend.yml
+      - .github/workflows/common.cypress.yml # TODO: For testing only.
+      - .github/workflows/common.workflow.frontend.yml # TODO: For testing only.
   workflow_dispatch:
 
 jobs:
+
+  cypress:
+    uses: ./.github/workflows/common.cypress.yml
+    with:
+      working-directory: "apps/dolly-frontend"
+    secrets:
+      READER_TOKEN: ${{ secrets.READER_TOKEN }}
+
   workflow:
+    needs: cypress
     uses: ./.github/workflows/common.workflow.frontend.yml
     with:
       working-directory: "apps/dolly-frontend"
@@ -16,7 +27,6 @@ jobs:
       deploy-tag-test: "#deploy-test-frontend"
       deploy-tag-idporten: "#deploy-idporten-frontend"
       deploy-tag-unstable: "#deploy-unstable-frontend"
-      cypress-enabled: true
     secrets:
       NAIS_DOLLY_DEPLOY_API_KEY: ${{ secrets.NAIS_DOLLY_DEPLOY_API_KEY }}
       NAIS_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}

--- a/.github/workflows/common.cypress.yml
+++ b/.github/workflows/common.cypress.yml
@@ -9,25 +9,25 @@ on:
       READER_TOKEN:
         required: true
 
-  jobs:
-    scan:
-      runs-on: ubuntu-latest
-      steps:
-        - name: "Checkout"
-          uses: actions/checkout@v3
-        - name: "Setup"
-          uses: actions/setup-node@v3
-          with:
-            node-version: 18.x
-            registry-url: https://npm.pkg.github.com/
-            scope: "@navikt"
-        - name: "Run"
-          env:
-            NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
-          uses: cypress-io/github-action@v5
-          with:
-            config: video=false
-            working-directory: ${{ inputs.working-directory }}/src/main/js
-            browser: chrome
-            build: npm run build
-            start: npm run preview
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v3
+      - name: "Setup"
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+          registry-url: https://npm.pkg.github.com/
+          scope: "@navikt"
+      - name: "Run"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
+        uses: cypress-io/github-action@v5
+        with:
+          config: video=false
+          working-directory: ${{ inputs.working-directory }}/src/main/js
+          browser: chrome
+          build: npm run build
+          start: npm run preview

--- a/.github/workflows/common.cypress.yml
+++ b/.github/workflows/common.cypress.yml
@@ -1,0 +1,33 @@
+on:
+  workflow_call:
+    inputs:
+      working-directory:
+        type: string
+        description: "The working directory for the job, e.g. apps/dolly-frontend (without leading/trailing slash)."
+        required: true
+    secrets:
+      READER_TOKEN:
+        required: true
+
+  jobs:
+    scan:
+      runs-on: ubuntu-latest
+      steps:
+        - name: "Checkout"
+          uses: actions/checkout@v3
+        - name: "Setup"
+          uses: actions/setup-node@v3
+          with:
+            node-version: 18.x
+            registry-url: https://npm.pkg.github.com/
+            scope: "@navikt"
+        - name: "Run"
+          env:
+            NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
+          uses: cypress-io/github-action@v5
+          with:
+            config: video=false
+            working-directory: ${{ inputs.working-directory }}/src/main/js
+            browser: chrome
+            build: npm run build
+            start: npm run preview

--- a/.github/workflows/common.workflow.frontend.yml
+++ b/.github/workflows/common.workflow.frontend.yml
@@ -21,11 +21,6 @@ on:
         type: string
         description: "The commit message tag that will trigger a deployment to the 'unstable' environment on a commit to a non-master branch, e.g. #deploy-unstable-frontend."
         required: false
-      cypress-enabled:
-        type: boolean
-        description: "If true, run Cypress tests."
-        required: false
-        default: false
 
     secrets:
       NAIS_DOLLY_DEPLOY_API_KEY:
@@ -49,34 +44,8 @@ jobs:
       NAV_TOKEN: ${{ secrets.NAV_TOKEN }}
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
-  cypress:
-    if: inputs.cypress-enabled
-    runs-on: ubuntu-latest
-    steps:
-      - name: "Checkout"
-        uses: actions/checkout@v3
-      - name: "Setup"
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18.x
-          registry-url: https://npm.pkg.github.com/
-          scope: "@navikt"
-      - name: "Run"
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
-        uses: cypress-io/github-action@v5
-        with:
-          config: video=false
-          working-directory: ${{ inputs.working-directory }}/src/main/js
-          browser: chrome
-          build: npm run build
-          start: npm run preview
-
   build:
-    needs: cypress
-    if: |
-      github.actor != 'dependabot[bot]' &&
-      (always() && !inputs.cypress-enabled)
+    if: github.actor != 'dependabot[bot]'
     permissions:
       contents: "read"
       id-token: "write"


### PR DESCRIPTION
Siden dolly-frontend (som eneste frontend-app) bruker cypress, så kjøres denne som en egen job før ordinær frontend workflow.