### PR TITLE
feature/image_isalive_isready

### DIFF
--- a/libs/reactive-core/src/main/java/no/nav/testnav/libs/reactivecore/router/InternalHandler.java
+++ b/libs/reactive-core/src/main/java/no/nav/testnav/libs/reactivecore/router/InternalHandler.java
@@ -1,5 +1,7 @@
 package no.nav.testnav.libs.reactivecore.router;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.server.ServerRequest;
@@ -7,11 +9,33 @@ import org.springframework.web.reactive.function.server.ServerResponse;
 import reactor.core.publisher.Mono;
 
 @Component
+@SuppressWarnings("java:S1172")
+@RequiredArgsConstructor
 public class InternalHandler {
-    public Mono<ServerResponse> isAlive(ServerRequest request) {
-        return ServerResponse.ok().body(BodyInserters.fromValue("OK"));
+
+    private final Environment env;
+    private String html;
+
+    public Mono<ServerResponse> isAlive(ServerRequest ignored) {
+        return ServerResponse.ok().body(BodyInserters.fromValue(body()));
     }
-    public Mono<ServerResponse> isReady(ServerRequest request) {
-        return ServerResponse.ok().body(BodyInserters.fromValue("OK"));
+    public Mono<ServerResponse> isReady(ServerRequest ignored) {
+        return ServerResponse.ok().body(BodyInserters.fromValue(body()));
     }
+
+    private synchronized String body() {
+        if (html == null) {
+            html = "OK";
+            var naisAppImage = env.getProperty("NAIS_APP_IMAGE");
+            if (naisAppImage != null) {
+                var i = naisAppImage.lastIndexOf("-");
+                if (i > 0) {
+                    var hash = naisAppImage.substring(i + 1);
+                    html = "OK - image is <a href=https://github.com/navikt/testnorge/commit/%s>%s</a>".formatted(hash, naisAppImage);
+                }
+            }
+        }
+        return html;
+    }
+
 }

--- a/libs/reactive-core/src/test/java/no/nav/testnav/libs/reactivecore/router/InternalHandlerTest.java
+++ b/libs/reactive-core/src/test/java/no/nav/testnav/libs/reactivecore/router/InternalHandlerTest.java
@@ -1,0 +1,109 @@
+package no.nav.testnav.libs.reactivecore.router;
+
+import io.micrometer.common.lang.NonNullApi;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.core.env.Environment;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.codec.HttpMessageWriter;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.web.reactive.function.server.HandlerStrategies;
+import org.springframework.web.reactive.function.server.ServerResponse;
+import org.springframework.web.reactive.result.view.ViewResolver;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@NonNullApi
+class InternalHandlerTest {
+
+    private static final ServerResponse.Context CONTEXT = new ServerResponse.Context() {
+        @Override
+        public List<HttpMessageWriter<?>> messageWriters() {
+            return HandlerStrategies.withDefaults().messageWriters();
+        }
+
+        @Override
+        public List<ViewResolver> viewResolvers() {
+            return Collections.emptyList();
+        }
+    };
+
+    @Test
+    @DisplayName("Test response body with null NAIS_APP_IMAGE")
+    void testNullNaisAppImage() {
+
+        var env = Mockito.mock(Environment.class);
+        when(env.getProperty("NAIS_APP_IMAGE")).thenReturn(null);
+
+        var controller = new InternalHandler(env);
+        assertThat(controller.isAlive(null))
+                .isNotNull()
+                .satisfies(mono -> assertThat(mono.block())
+                        .isNotNull()
+                        .satisfies(response -> {
+                            assertThat(response.statusCode()).isEqualTo(HttpStatus.OK);
+                            var exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/internal/isAlive"));
+                            response.writeTo(exchange, CONTEXT).block();
+                            assertThat(exchange.getResponse().getBodyAsString().block())
+                                    .isNotNull()
+                                    .satisfies(html -> assertThat(html).isEqualTo("OK"));
+                        }));
+
+        assertThat(controller.isReady(null))
+                .isNotNull()
+                .satisfies(mono -> assertThat(mono.block())
+                        .isNotNull()
+                        .satisfies(response -> {
+                            assertThat(response.statusCode()).isEqualTo(HttpStatus.OK);
+                            var exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/internal/isReady"));
+                            response.writeTo(exchange, CONTEXT).block();
+                            assertThat(exchange.getResponse().getBodyAsString().block())
+                                    .isNotNull()
+                                    .satisfies(html -> assertThat(html).isEqualTo("OK"));
+                        }));
+
+    }
+
+    @Test
+    @DisplayName("Test response body with expected NAIS_APP_IMAGE")
+    void testNonNullNaisAppImage() {
+
+        var env = Mockito.mock(Environment.class);
+        when(env.getProperty("NAIS_APP_IMAGE")).thenReturn("europe-north1-docker.pkg.dev/nais-management-233d/dolly/testnorge-dolly-backend:2023.05.04-13.27-36aa348");
+
+        var controller = new InternalHandler(env);
+        assertThat(controller.isAlive(null))
+                .isNotNull()
+                .satisfies(mono -> assertThat(mono.block())
+                        .isNotNull()
+                        .satisfies(response -> {
+                            assertThat(response.statusCode()).isEqualTo(HttpStatus.OK);
+                            var exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/internal/isAlive"));
+                            response.writeTo(exchange, CONTEXT).block();
+                            assertThat(exchange.getResponse().getBodyAsString().block())
+                                    .isNotNull()
+                                    .satisfies(html -> assertThat(html).isEqualTo("OK - image is <a href=https://github.com/navikt/testnorge/commit/36aa348>europe-north1-docker.pkg.dev/nais-management-233d/dolly/testnorge-dolly-backend:2023.05.04-13.27-36aa348</a>"));
+                        }));
+
+        assertThat(controller.isReady(null))
+                .isNotNull()
+                .satisfies(mono -> assertThat(mono.block())
+                        .isNotNull()
+                        .satisfies(response -> {
+                            assertThat(response.statusCode()).isEqualTo(HttpStatus.OK);
+                            var exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/internal/isAlive"));
+                            response.writeTo(exchange, CONTEXT).block();
+                            assertThat(exchange.getResponse().getBodyAsString().block())
+                                    .isNotNull()
+                                    .satisfies(html -> assertThat(html).isEqualTo("OK - image is <a href=https://github.com/navikt/testnorge/commit/36aa348>europe-north1-docker.pkg.dev/nais-management-233d/dolly/testnorge-dolly-backend:2023.05.04-13.27-36aa348</a>"));
+                        }));
+
+    }
+
+}

--- a/libs/servlet-core/build.gradle
+++ b/libs/servlet-core/build.gradle
@@ -32,6 +32,10 @@ repositories {
 
 java.sourceCompatibility = JavaVersion.VERSION_17
 
+test {
+    useJUnitPlatform()
+}
+
 dependencies {
 
     implementation 'io.swagger.core.v3:swagger-annotations-jakarta:2.2.8'

--- a/libs/servlet-core/src/main/java/no/nav/testnav/libs/servletcore/provider/InternalController.java
+++ b/libs/servlet-core/src/main/java/no/nav/testnav/libs/servletcore/provider/InternalController.java
@@ -1,28 +1,46 @@
 package no.nav.testnav.libs.servletcore.provider;
 
 import io.swagger.v3.oas.annotations.Operation;
-import org.springframework.context.annotation.Profile;
-import org.springframework.http.HttpStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.env.Environment;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Profile({"prod","dev"})
 @RestController
 @RequestMapping("/internal")
+@RequiredArgsConstructor
 public class InternalController {
+
+    private final Environment env;
+    private String html;
 
     @GetMapping("/isAlive")
     @Operation(hidden = true)
-    public ResponseEntity<HttpStatus> isAlive() {
-        return ResponseEntity.ok().build();
+    public ResponseEntity<String> isAlive() {
+        return ResponseEntity.ok(body());
     }
 
     @GetMapping("/isReady")
     @Operation(hidden = true)
-    public ResponseEntity<HttpStatus> isReady() {
-        return ResponseEntity.ok().build();
+    public ResponseEntity<String> isReady() {
+        return ResponseEntity.ok(body());
+    }
+
+    private synchronized String body() {
+        if (html == null) {
+            html = "OK";
+            var naisAppImage = env.getProperty("NAIS_APP_IMAGE");
+            if (naisAppImage != null) {
+                var i = naisAppImage.lastIndexOf("-");
+                if (i > 0) {
+                    var hash = naisAppImage.substring(i + 1);
+                    html = "OK - image is <a href=https://github.com/navikt/testnorge/commit/%s>%s</a>".formatted(hash, naisAppImage);
+                }
+            }
+        }
+        return html;
     }
 
 }

--- a/libs/servlet-core/src/test/java/no/nav/testnav/libs/servletcore/provider/InternalControllerTest.java
+++ b/libs/servlet-core/src/test/java/no/nav/testnav/libs/servletcore/provider/InternalControllerTest.java
@@ -1,0 +1,58 @@
+package no.nav.testnav.libs.servletcore.provider;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.core.env.Environment;
+import org.springframework.http.HttpStatus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+class InternalControllerTest {
+
+    @Test
+    @DisplayName("Test response body with null NAIS_APP_IMAGE")
+    void testNullNaisAppImage() {
+
+        var env = Mockito.mock(Environment.class);
+        when(env.getProperty("NAIS_APP_IMAGE")).thenReturn(null);
+
+        var controller = new InternalController(env);
+        assertThat(controller.isAlive())
+                .isNotNull()
+                .satisfies(response -> {
+                    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+                    assertThat(response.getBody()).isEqualTo("OK");
+                });
+        assertThat(controller.isReady())
+                .isNotNull()
+                .satisfies(response -> {
+                    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+                    assertThat(response.getBody()).isEqualTo("OK");
+                });
+
+    }
+
+    @Test
+    @DisplayName("Test response body with expected NAIS_APP_IMAGE")
+    void testNonNullNaisAppImage() {
+
+        var env = Mockito.mock(Environment.class);
+        when(env.getProperty("NAIS_APP_IMAGE")).thenReturn("europe-north1-docker.pkg.dev/nais-management-233d/dolly/testnorge-dolly-backend:2023.05.04-13.27-36aa348");
+
+        var controller = new InternalController(env);
+        assertThat(controller.isAlive())
+                .satisfies(response -> {
+                    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+                    assertThat(response.getBody()).isEqualTo("OK - image is <a href=https://github.com/navikt/testnorge/commit/36aa348>europe-north1-docker.pkg.dev/nais-management-233d/dolly/testnorge-dolly-backend:2023.05.04-13.27-36aa348</a>");
+                });
+        assertThat(controller.isReady())
+                .satisfies(response -> {
+                    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+                    assertThat(response.getBody()).isEqualTo("OK - image is <a href=https://github.com/navikt/testnorge/commit/36aa348>europe-north1-docker.pkg.dev/nais-management-233d/dolly/testnorge-dolly-backend:2023.05.04-13.27-36aa348</a>");
+                });
+
+    }
+
+}


### PR DESCRIPTION
I stedet for å vise "OK" på /internal/is[Alive|Ready] så vises nå også navnet på Docker image, hvis satt i env NAIS_APP_IMAGE i pod, med link til siste commit.