### PR TITLE
bugfix/builder_init_warnings

### DIFF
--- a/apps/brreg-stub/src/main/java/no/nav/brregstub/api/common/RsOrganisasjon.java
+++ b/apps/brreg-stub/src/main/java/no/nav/brregstub/api/common/RsOrganisasjon.java
@@ -21,7 +21,9 @@ public class RsOrganisasjon {
 
     @NotNull
     private Integer orgnr;
+    @Builder.Default
     private Integer hovedstatus = 0;
+    @Builder.Default
     private List<Integer> understatuser = new LinkedList<>();
     @NotNull
     private LocalDate registreringsdato;

--- a/libs/domain/src/main/java/no/nav/testnav/libs/domain/dto/aordningen/arbeidsforhold/Gyldighetsperiode.java
+++ b/libs/domain/src/main/java/no/nav/testnav/libs/domain/dto/aordningen/arbeidsforhold/Gyldighetsperiode.java
@@ -4,14 +4,14 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.EqualsAndHashCode;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
 public class Gyldighetsperiode extends Periode {
 
     protected Gyldighetsperiode(GyldighetsperiodeBuilder<?, ?> b) {
         super(b);
     }
 
-    public static GyldighetsperiodeBuilder<?, ?> builder() {
+    public static GyldighetsperiodeBuilder<Gyldighetsperiode, GyldighetsperiodeBuilderImpl> builder() {
         return new GyldighetsperiodeBuilderImpl();
     }
 
@@ -31,13 +31,14 @@ public class Gyldighetsperiode extends Periode {
 
     public abstract static class GyldighetsperiodeBuilder<C extends Gyldighetsperiode, B extends GyldighetsperiodeBuilder<C, B>> extends PeriodeBuilder<C, B> {
 
-        public GyldighetsperiodeBuilder() {
+        protected GyldighetsperiodeBuilder() {
         }
 
         protected abstract B self();
 
         public abstract C build();
 
+        @Override
         public String toString() {
             return "Gyldighetsperiode.GyldighetsperiodeBuilder(super=" + super.toString() + ")";
         }

--- a/libs/domain/src/main/java/no/nav/testnav/libs/domain/dto/aordningen/arbeidsforhold/OpplysningspliktigArbeidsgiver.java
+++ b/libs/domain/src/main/java/no/nav/testnav/libs/domain/dto/aordningen/arbeidsforhold/OpplysningspliktigArbeidsgiver.java
@@ -3,23 +3,17 @@ package no.nav.testnav.libs.domain.dto.aordningen.arbeidsforhold;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 @ApiModel(
         description = "Informasjon om opplysningspliktig eller arbeidsgiver (organisasjon eller person)",
-        subTypes = { Organisasjon.class, Person.class }
+        subTypes = {Organisasjon.class, Person.class}
 )
-@Getter
-@Setter
-@NoArgsConstructor
-public abstract class OpplysningspliktigArbeidsgiver {
+public interface OpplysningspliktigArbeidsgiver {
 
     @ApiModelProperty(
             notes = "Type: Organisasjon eller Person",
             allowableValues = "Organisasjon,Person"
     )
-    public abstract String getType();
+    String getType();
 }

--- a/libs/domain/src/main/java/no/nav/testnav/libs/domain/dto/aordningen/arbeidsforhold/Organisasjon.java
+++ b/libs/domain/src/main/java/no/nav/testnav/libs/domain/dto/aordningen/arbeidsforhold/Organisasjon.java
@@ -23,7 +23,7 @@ import lombok.Setter;
 @AllArgsConstructor
 @Builder
 @EqualsAndHashCode
-public class Organisasjon extends OpplysningspliktigArbeidsgiver {
+public class Organisasjon implements OpplysningspliktigArbeidsgiver {
 
     @ApiModelProperty(
             notes = "Organisasjonsnummer fra Enhetsregisteret",

--- a/libs/domain/src/main/java/no/nav/testnav/libs/domain/dto/aordningen/arbeidsforhold/Person.java
+++ b/libs/domain/src/main/java/no/nav/testnav/libs/domain/dto/aordningen/arbeidsforhold/Person.java
@@ -23,7 +23,7 @@ import lombok.Setter;
 @AllArgsConstructor
 @Builder
 @EqualsAndHashCode
-public class Person extends OpplysningspliktigArbeidsgiver {
+public class Person implements OpplysningspliktigArbeidsgiver {
 
     @ApiModelProperty(
             notes = "Gjeldende offentlig ident",

--- a/libs/domain/src/main/java/no/nav/testnav/libs/domain/dto/eregmapper/v1/EregDTO.java
+++ b/libs/domain/src/main/java/no/nav/testnav/libs/domain/dto/eregmapper/v1/EregDTO.java
@@ -23,6 +23,7 @@ public class EregDTO {
     private NavnDTO navn;
     @JsonProperty(required = true)
     private String enhetstype;
+    @Builder.Default
     @JsonProperty
     private String endringsType = "N";
     @JsonProperty

--- a/libs/domain/src/main/java/no/nav/testnav/libs/domain/dto/eregmapper/v1/KnytningDTO.java
+++ b/libs/domain/src/main/java/no/nav/testnav/libs/domain/dto/eregmapper/v1/KnytningDTO.java
@@ -13,16 +13,21 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(force = true)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class KnytningDTO {
+    @Builder.Default
     @JsonProperty
     private String type = "BEDRNSSY";
+    @Builder.Default
     @JsonProperty
     private String ansvarsandel = "";
+    @Builder.Default
     @JsonProperty
     private String fratreden = "";
     @JsonProperty(required = true)
     private String orgnr;
+    @Builder.Default
     @JsonProperty
     private String valgtAv = "";
+    @Builder.Default
     @JsonProperty
     private String korrektOrgNr = "";
 }


### PR DESCRIPTION
Fjerner noen advarsler knyttet til manglende annotering av defaults for Lombok @Builder, samt bruk av generert hashCode.