### PR TITLE
chore(arbeidsplassencv-proxy): update fakedings url

### DIFF
--- a/proxies/arbeidsplassencv-proxy/src/main/java/no/nav/testnav/proxies/arbeidsplassencvproxy/consumer/FakedingsConsumer.java
+++ b/proxies/arbeidsplassencv-proxy/src/main/java/no/nav/testnav/proxies/arbeidsplassencvproxy/consumer/FakedingsConsumer.java
@@ -12,7 +12,7 @@ import reactor.core.publisher.Mono;
 @Service
 public class FakedingsConsumer {
 
-    private static final String FAKE_TOKENDINGS_URL = "https://fakedings.dev-gcp.nais.io";
+    private static final String FAKE_TOKENDINGS_URL = "https://fakedings.intern.dev.nav.no";
     private final WebClient webClient;
 
     public FakedingsConsumer(ObjectMapper objectMapper) {

--- a/proxies/arbeidsplassencv-proxy/src/main/resources/application.yml
+++ b/proxies/arbeidsplassencv-proxy/src/main/resources/application.yml
@@ -31,5 +31,5 @@ consumer:
   fakedings-token-provider:
     name: fakedings
     namespace: plattformsikkerhet
-    url: https://fakedings.dev-gcp.nais.io
+    url: https://fakedings.intern.dev.nav.no
     cluster: dev-fss


### PR DESCRIPTION
The old url is deprecated and will be removed soon.