### PR TITLE
cleanup/oversikt-frontend-inbound

### DIFF
--- a/apps/adresse-service/config.yml
+++ b/apps/adresse-service/config.yml
@@ -39,8 +39,6 @@ spec:
   accessPolicy:
     inbound:
       rules:
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
         - application: team-dolly-lokal-app
           cluster: dev-gcp
         - application: testnav-organisasjon-forvalter

--- a/apps/amelding-service/config.yml
+++ b/apps/amelding-service/config.yml
@@ -13,8 +13,6 @@ spec:
       rules:
         - application: team-dolly-lokal-app
           cluster: dev-gcp
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
         - application: dolly-backend-dev
           cluster: dev-gcp
         - application: dolly-backend

--- a/apps/arbeidsforhold-export-api/config.yml
+++ b/apps/arbeidsforhold-export-api/config.yml
@@ -14,8 +14,6 @@ spec:
       rules:
         - application: team-dolly-lokal-app
           cluster: dev-gcp
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
   tokenx:
     enabled: true
   azure:

--- a/apps/arbeidsforhold-service/config.yml
+++ b/apps/arbeidsforhold-service/config.yml
@@ -24,8 +24,6 @@ spec:
           cluster: dev-gcp
         - application: dolly-backend-dev
           cluster: dev-gcp
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
         - application: testnav-synt-sykemelding-api
           cluster: dev-gcp
     outbound:

--- a/apps/batch-bestilling-service/config.yml
+++ b/apps/batch-bestilling-service/config.yml
@@ -18,8 +18,6 @@ spec:
       rules:
         - application: team-dolly-lokal-app
           cluster: dev-gcp
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
     outbound:
       rules:
         - application: dolly-backend

--- a/apps/bruker-service/config.yml
+++ b/apps/bruker-service/config.yml
@@ -17,8 +17,6 @@ spec:
           cluster: dev-gcp
         - application: dolly-idporten
           cluster: dev-gcp
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
     outbound:
       rules:
         - application: testnav-person-organisasjon-tilgang-service

--- a/apps/dolly-backend/config.test.yml
+++ b/apps/dolly-backend/config.test.yml
@@ -16,8 +16,6 @@ spec:
   accessPolicy:
     inbound:
       rules:
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
         - application: dolly-frontend-dev
           cluster: dev-gcp
         - application: dolly-idporten

--- a/apps/dolly-backend/config.yml
+++ b/apps/dolly-backend/config.yml
@@ -21,8 +21,6 @@ spec:
           cluster: dev-gcp
         - application: testnav-dollystatus
           cluster: dev-gcp
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
         - application: testnav-batch-bestilling-service
           cluster: dev-gcp
         - application: etterlatte-testdata

--- a/apps/endringsmelding-service/config.yml
+++ b/apps/endringsmelding-service/config.yml
@@ -21,8 +21,6 @@ spec:
       rules:
         - application: team-dolly-lokal-app
           cluster: dev-gcp
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
         - application: testnav-endringsmelding-frontend
           cluster: dev-gcp
     outbound:

--- a/apps/ereg-batch-status-service/config.yml
+++ b/apps/ereg-batch-status-service/config.yml
@@ -14,8 +14,6 @@ spec:
       rules:
         - application: team-dolly-lokal-app
           cluster: dev-gcp
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
         - application: organisasjon-bestilling-service
           cluster: dev-gcp
   tokenx:

--- a/apps/generer-arbeidsforhold-populasjon-service/config.yml
+++ b/apps/generer-arbeidsforhold-populasjon-service/config.yml
@@ -22,8 +22,6 @@ spec:
       rules:
         - application: team-dolly-lokal-app
           cluster: dev-gcp
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
     outbound:
       rules:
         - application: oppsummeringsdokument-service

--- a/apps/generer-navn-service/config.yml
+++ b/apps/generer-navn-service/config.yml
@@ -21,8 +21,6 @@ spec:
           cluster: dev-gcp
         - application: testnav-pdl-forvalter-dev
           cluster: dev-gcp
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
         - application: dolly-backend
           cluster: dev-gcp
         - application: dolly-backend-dev

--- a/apps/generer-organisasjon-populasjon-service/config.yml
+++ b/apps/generer-organisasjon-populasjon-service/config.yml
@@ -20,8 +20,6 @@ spec:
       rules:
         - application: team-dolly-lokal-app
           cluster: dev-gcp
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
         - application: mn-synt-arbeidsforhold-service
           cluster: dev-fss
         - application: testnav-generer-arbeidsforhold-populasjon-service

--- a/apps/generer-synt-amelding-service/config.yml
+++ b/apps/generer-synt-amelding-service/config.yml
@@ -22,8 +22,6 @@ spec:
           cluster: dev-gcp
         - application: dolly-frontend-dev
           cluster: dev-gcp
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
         - application: app-1
           namespace: plattformsikkerhet
           cluster: dev-gcp

--- a/apps/geografiske-kodeverk-service/config.yml
+++ b/apps/geografiske-kodeverk-service/config.yml
@@ -19,8 +19,6 @@ spec:
           cluster: dev-gcp
         - application: testnav-pdl-forvalter-dev
           cluster: dev-gcp
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
   tokenx:
     enabled: true
   azure:

--- a/apps/helsepersonell-service/config.yml
+++ b/apps/helsepersonell-service/config.yml
@@ -27,8 +27,6 @@ spec:
           cluster: dev-gcp
         - application: dolly-idporten
           cluster: dev-gcp
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
         - application: testnav-synt-sykemelding-api
           cluster: dev-gcp
   liveness:

--- a/apps/hodejegeren/config.yml
+++ b/apps/hodejegeren/config.yml
@@ -41,8 +41,6 @@ spec:
           cluster: dev-fss
         - application: mn-synt-arbeidsforhold-service
           cluster: dev-fss
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
     outbound:
       rules:
         - application: tps-forvalteren-proxy

--- a/apps/import-person-service/config.yml
+++ b/apps/import-person-service/config.yml
@@ -21,8 +21,6 @@ spec:
       rules:
         - application: team-dolly-lokal-app
           cluster: dev-gcp
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
         - application: testnav-pdl-forvalter
           cluster: dev-gcp
     outbound:

--- a/apps/inntektsmelding-generator-service/config.yml
+++ b/apps/inntektsmelding-generator-service/config.yml
@@ -20,8 +20,6 @@ spec:
       rules:
         - application: team-dolly-lokal-app
           cluster: dev-gcp
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
         - application: testnav-inntektsmelding-service
           cluster: dev-gcp
   liveness:

--- a/apps/inntektsmelding-service/config.yml
+++ b/apps/inntektsmelding-service/config.yml
@@ -20,8 +20,6 @@ spec:
       rules:
         - application: team-dolly-lokal-app
           cluster: dev-gcp
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
         - application: dolly-backend
           cluster: dev-gcp
         - application: dolly-backend-dev

--- a/apps/jenkins-batch-status-service/config.yml
+++ b/apps/jenkins-batch-status-service/config.yml
@@ -14,8 +14,6 @@ spec:
       rules:
         - application: team-dolly-lokal-app
           cluster: dev-gcp
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
         - application: testnav-organisasjon-mottak-service
           cluster: dev-gcp
     outbound:

--- a/apps/joark-dokument-service/config.yml
+++ b/apps/joark-dokument-service/config.yml
@@ -15,8 +15,6 @@ spec:
       rules:
         - application: team-dolly-lokal-app
           cluster: dev-gcp
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
         - application: dolly-frontend
           cluster: dev-gcp
         - application: dolly-idporten

--- a/apps/miljoer-service/config.yml
+++ b/apps/miljoer-service/config.yml
@@ -16,8 +16,6 @@ spec:
       rules:
         - application: team-dolly-lokal-app
           cluster: dev-gcp
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
         - application: dolly-backend
           cluster: dev-gcp
         - application: dolly-backend-dev

--- a/apps/mn-synt-arbeidsforhold-service/config.yml
+++ b/apps/mn-synt-arbeidsforhold-service/config.yml
@@ -14,8 +14,6 @@ spec:
       rules:
         - application: team-dolly-lokal-app
           cluster: dev-gcp
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
     outbound:
       rules:
         - application: testnorge-hodejegeren

--- a/apps/oppsummeringsdokument-service/config.yml
+++ b/apps/oppsummeringsdokument-service/config.yml
@@ -15,8 +15,6 @@ spec:
       rules:
         - application: team-dolly-lokal-app
           cluster: dev-gcp
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
         - application: mn-synt-arbeidsforhold-service
           cluster: dev-fss
         - application: testnav-generer-arbeidsforhold-populasjon-service

--- a/apps/organisasjon-bestilling-service/config.yml
+++ b/apps/organisasjon-bestilling-service/config.yml
@@ -20,8 +20,6 @@ spec:
       rules:
         - application: team-dolly-lokal-app
           cluster: dev-gcp
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
         - application: testnav-organisasjon-forvalter
           cluster: dev-gcp
         - application: jenkins-batch-status-service

--- a/apps/organisasjon-faste-data-service/config.yml
+++ b/apps/organisasjon-faste-data-service/config.yml
@@ -24,8 +24,6 @@ spec:
       rules:
         - application: team-dolly-lokal-app
           cluster: dev-gcp
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
         - application: testnorge-statisk-data-forvalter
           cluster: dev-fss
         - application: dolly-frontend-dev

--- a/apps/organisasjon-forvalter/config.yml
+++ b/apps/organisasjon-forvalter/config.yml
@@ -22,8 +22,6 @@ spec:
   accessPolicy:
     inbound:
       rules:
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
         - application: dolly-backend
           cluster: dev-gcp
         - application: dolly-backend-dev

--- a/apps/organisasjon-mottak-service/config.yml
+++ b/apps/organisasjon-mottak-service/config.yml
@@ -20,8 +20,6 @@ spec:
       rules:
         - application: team-dolly-lokal-app
           cluster: dev-gcp
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
     outbound:
       rules:
         - application: organisasjon-bestilling-service

--- a/apps/organisasjon-service/config.yml
+++ b/apps/organisasjon-service/config.yml
@@ -28,8 +28,6 @@ spec:
           cluster: dev-gcp
         - application: testnav-organisasjon-forvalter
           cluster: dev-gcp
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
         - application: dolly-backend
           cluster: dev-gcp
         - application: dolly-backend-dev

--- a/apps/organisasjon-tilgang-service/config.yml
+++ b/apps/organisasjon-tilgang-service/config.yml
@@ -23,8 +23,6 @@ spec:
           cluster: dev-gcp
         - application: team-dolly-lokal-app
           cluster: dev-gcp
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
         - application: dolly-frontend
           cluster: dev-gcp
         - application: dolly-frontend-dev

--- a/apps/orgnummer-service/config.yml
+++ b/apps/orgnummer-service/config.yml
@@ -25,8 +25,6 @@ spec:
           cluster: dev-gcp
         - application: testnav-organisasjon-forvalter
           cluster: dev-gcp
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
     outbound:
       rules:
         - application: testnav-miljoer-service

--- a/apps/oversikt-frontend/config.yml
+++ b/apps/oversikt-frontend/config.yml
@@ -26,10 +26,10 @@ spec:
   accessPolicy:
     outbound:
       rules:
-        - application: testnorge-profil-api-dev
         - application: testnav-app-tilgang-analyse-service
-        - application: testnav-person-organisasjon-tilgang-service-dev
         - application: testnav-bruker-service-dev
+        - application: testnav-person-organisasjon-tilgang-service-dev
+        - application: testnorge-profil-api-dev
   liveness:
     path: /internal/isAlive
     initialDelay: 4

--- a/apps/pdl-forvalter/config.test.yml
+++ b/apps/pdl-forvalter/config.test.yml
@@ -47,8 +47,6 @@ spec:
   accessPolicy:
     inbound:
       rules:
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
         - application: team-dolly-lokal-app
           cluster: dev-gcp
         - application: dolly-backend-dev

--- a/apps/pdl-forvalter/config.yml
+++ b/apps/pdl-forvalter/config.yml
@@ -46,8 +46,6 @@ spec:
   accessPolicy:
     inbound:
       rules:
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
         - application: dolly-backend
           cluster: dev-gcp
         - application: dolly-frontend

--- a/apps/person-export-api/config.yml
+++ b/apps/person-export-api/config.yml
@@ -45,8 +45,6 @@ spec:
       rules:
         - application: team-dolly-lokal-app
           cluster: dev-gcp
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
     outbound:
       external:
         - host: tps-forvalteren-proxy.dev-fss-pub.nais.io

--- a/apps/person-faste-data-service/config.yml
+++ b/apps/person-faste-data-service/config.yml
@@ -20,8 +20,6 @@ spec:
       rules:
         - application: team-dolly-lokal-app
           cluster: dev-gcp
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
         - application: testnorge-statisk-data-forvalter
           cluster: dev-fss
         - application: dolly-frontend-dev

--- a/apps/person-search-service/config.yml
+++ b/apps/person-search-service/config.yml
@@ -21,8 +21,6 @@ spec:
       rules:
         - application: team-dolly-lokal-app
           cluster: dev-gcp
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
         - application: dolly-frontend-dev
           cluster: dev-gcp
         - application: dolly-frontend

--- a/apps/person-service/config.yml
+++ b/apps/person-service/config.yml
@@ -27,8 +27,6 @@ spec:
           cluster: dev-fss
         - application: testnav-faste-data-frontend
           cluster: dev-gcp
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
         - application: dolly-backend
           cluster: dev-fss
         - application: dolly-backend-dev

--- a/apps/profil-api/config.yml
+++ b/apps/profil-api/config.yml
@@ -43,8 +43,6 @@ spec:
           cluster: dev-gcp
         - application: testnav-applikasjonsanalyse-frontend
           cluster: dev-gcp
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
     outbound:
       rules:
         - application: testnav-person-organisasjon-tilgang-service

--- a/apps/sykemelding-api/config.yml
+++ b/apps/sykemelding-api/config.yml
@@ -59,8 +59,6 @@ spec:
           cluster: dev-gcp
         - application: dolly-backend-dev
           cluster: dev-gcp
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
         - application: testnav-synt-sykemelding-api
           cluster: dev-gcp
         - application: app-1

--- a/apps/synt-sykemelding-api/config.yml
+++ b/apps/synt-sykemelding-api/config.yml
@@ -48,8 +48,6 @@ spec:
       rules:
         - application: team-dolly-lokal-app
           cluster: dev-gcp
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
         - application: dolly-backend
           cluster: dev-gcp
         - application: dolly-backend-dev

--- a/apps/synt-vedtakshistorikk-service/config.yml
+++ b/apps/synt-vedtakshistorikk-service/config.yml
@@ -38,7 +38,6 @@ spec:
     inbound:
       rules:
         - application: team-dolly-lokal-app
-        - application: testnav-oversikt-frontend
     outbound:
       rules:
         - application: synthdata-arena-vedtakshistorikk

--- a/apps/testnav-ident-pool/config.yml
+++ b/apps/testnav-ident-pool/config.yml
@@ -56,8 +56,6 @@ spec:
           cluster: dev-gcp
         - application: team-dolly-lokal-app
           cluster: dev-gcp
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
         - application: app-1
           namespace: plattformsikkerhet
           cluster: dev-gcp

--- a/apps/testnorge-statisk-data-forvalter/config.yml
+++ b/apps/testnorge-statisk-data-forvalter/config.yml
@@ -49,8 +49,6 @@ spec:
       rules:
         - application: testnav-statisk-data-forvalter-proxy
           cluster: dev-fss
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
     outbound:
       rules:
         - application: testnorge-hodejegeren

--- a/apps/testnorge-tp/config.yml
+++ b/apps/testnorge-tp/config.yml
@@ -39,8 +39,6 @@ spec:
     inbound:
       rules:
         - application: testnorge-statisk-data-forvalter
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
         - application: team-dolly-lokal-app
           cluster: dev-gcp
     outbound:

--- a/apps/tilbakemelding-api/config.yml
+++ b/apps/tilbakemelding-api/config.yml
@@ -19,8 +19,6 @@ spec:
           cluster: dev-gcp
         - application: dolly-idporten
           cluster: dev-gcp
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
         - application: team-dolly-lokal-app
           cluster: dev-gcp
         - application: app-1

--- a/apps/tps-messaging-service/config.yml
+++ b/apps/tps-messaging-service/config.yml
@@ -46,8 +46,6 @@ spec:
       rules:
         - application: testnav-endringsmelding-service
           cluster: dev-gcp
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
         - application: team-dolly-lokal-app
           cluster: dev-gcp
         - application: testnav-organisasjon-forvalter

--- a/apps/udi-stub/config.yml
+++ b/apps/udi-stub/config.yml
@@ -25,8 +25,6 @@ spec:
           cluster: dev-gcp
         - application: dolly-idporten
           cluster: dev-gcp
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
         - application: testnav-udistub-proxy
           cluster: dev-fss
   liveness:

--- a/apps/varslinger-service/config.test.yml
+++ b/apps/varslinger-service/config.test.yml
@@ -16,8 +16,6 @@ spec:
           cluster: dev-gcp
         - application: dolly-frontend-dev-unstable
           cluster: dev-gcp
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
         - application: team-dolly-lokal-app
           cluster: dev-gcp
         - application: app-1

--- a/apps/varslinger-service/config.yml
+++ b/apps/varslinger-service/config.yml
@@ -18,8 +18,6 @@ spec:
           cluster: dev-gcp
         - application: dolly-idporten
           cluster: dev-gcp
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
         - application: team-dolly-lokal-app
           cluster: dev-gcp
         - application: app-1

--- a/proxies/aareg-proxy/config.yml
+++ b/proxies/aareg-proxy/config.yml
@@ -44,8 +44,6 @@ spec:
           cluster: dev-gcp
         - application: dolly-frontend-dev
           cluster: dev-gcp
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
         - application: testnav-arbeidsforhold-service
           cluster: dev-gcp
         - application: testnorge-statisk-data-forvalter

--- a/proxies/arbeidsplassencv-proxy/config.yml
+++ b/proxies/arbeidsplassencv-proxy/config.yml
@@ -31,8 +31,6 @@ spec:
           cluster: dev-gcp
         - application: dolly-backend-dev
           cluster: dev-gcp
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
         - application: app-1
           namespace: plattformsikkerhet
           cluster: dev-gcp

--- a/proxies/arena-forvalteren-proxy/config.yml
+++ b/proxies/arena-forvalteren-proxy/config.yml
@@ -31,8 +31,6 @@ spec:
           cluster: dev-gcp
         - application: dolly-backend-dev
           cluster: dev-gcp
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
         - application: app-1
           namespace: plattformsikkerhet
           cluster: dev-gcp

--- a/proxies/batch-adeo-proxy/config.yml
+++ b/proxies/batch-adeo-proxy/config.yml
@@ -27,8 +27,6 @@ spec:
           cluster: dev-gcp
         - application: organisasjon-bestilling-service
           cluster: dev-fss
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
         - application: organisasjon-mottak-service
           cluster: dev-fss
         - application: testnav-organisasjon-mottak-service

--- a/proxies/brregstub-proxy/config.yml
+++ b/proxies/brregstub-proxy/config.yml
@@ -31,8 +31,6 @@ spec:
           cluster: dev-gcp
         - application: dolly-backend-dev
           cluster: dev-gcp
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
         - application: app-1
           namespace: plattformsikkerhet
           cluster: dev-gcp

--- a/proxies/dokarkiv-proxy/config.yml
+++ b/proxies/dokarkiv-proxy/config.yml
@@ -37,8 +37,6 @@ spec:
       rules:
         - application: team-dolly-lokal-app
           cluster: dev-gcp
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
         - application: testnav-inntektsmelding-service
           cluster: dev-gcp
         - application: dolly-backend

--- a/proxies/ereg-proxy/config.yml
+++ b/proxies/ereg-proxy/config.yml
@@ -21,8 +21,6 @@ spec:
       rules:
         - application: team-dolly-lokal-app
           cluster: dev-gcp
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
         - application: testnav-organisasjon-service
           cluster: dev-gcp
   liveness:

--- a/proxies/histark-proxy/config.yml
+++ b/proxies/histark-proxy/config.yml
@@ -32,8 +32,6 @@ spec:
           cluster: dev-gcp
         - application: dolly-backend-dev
           cluster: dev-gcp
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
         - application: app-1
           namespace: plattformsikkerhet
           cluster: dev-gcp

--- a/proxies/hodejegeren-proxy/config.yml
+++ b/proxies/hodejegeren-proxy/config.yml
@@ -27,8 +27,6 @@ spec:
           cluster: dev-gcp
         - application: dolly-frontend-dev
           cluster: dev-gcp
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
         - application: testnav-generer-arbeidsforhold-populasjon-service
           cluster: dev-gcp
         - application: app-1

--- a/proxies/inntektstub-proxy/config.yml
+++ b/proxies/inntektstub-proxy/config.yml
@@ -31,8 +31,6 @@ spec:
           cluster: dev-gcp
         - application: dolly-backend-dev
           cluster: dev-gcp
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
         - application: testnav-synt-vedtakshistorikk-service
           cluster: dev-gcp
         - application: app-1

--- a/proxies/inst-proxy/config.yml
+++ b/proxies/inst-proxy/config.yml
@@ -31,8 +31,6 @@ spec:
           cluster: dev-gcp
         - application: team-dolly-lokal-app
           cluster: dev-gcp
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
         - application: app-1
           namespace: plattformsikkerhet
           cluster: dev-gcp

--- a/proxies/kodeverk-proxy/config.yml
+++ b/proxies/kodeverk-proxy/config.yml
@@ -31,8 +31,6 @@ spec:
           cluster: dev-gcp
         - application: dolly-backend-dev
           cluster: dev-gcp
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
         - application: testnav-person-export-api
           cluster: dev-gcp
         - application: app-1

--- a/proxies/kontoregister-person-proxy/config.yml
+++ b/proxies/kontoregister-person-proxy/config.yml
@@ -40,8 +40,6 @@ spec:
           cluster: dev-gcp
         - application: dolly-frontend-dev
           cluster: dev-gcp
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
         - application: dolly-backend
           cluster: dev-gcp
         - application: dolly-backend-dev

--- a/proxies/krrstub-proxy/config.yml
+++ b/proxies/krrstub-proxy/config.yml
@@ -40,8 +40,6 @@ spec:
           cluster: dev-gcp
         - application: dolly-frontend-dev
           cluster: dev-gcp
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
         - application: dolly-backend
           cluster: dev-gcp
         - application: dolly-backend-dev

--- a/proxies/medl-proxy/config.yml
+++ b/proxies/medl-proxy/config.yml
@@ -40,8 +40,6 @@ spec:
           cluster: dev-gcp
         - application: dolly-frontend-dev
           cluster: dev-gcp
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
         - application: dolly-backend
           cluster: dev-gcp
         - application: dolly-backend-dev

--- a/proxies/norg2-proxy/config.yml
+++ b/proxies/norg2-proxy/config.yml
@@ -31,8 +31,6 @@ spec:
           cluster: dev-gcp
         - application: dolly-backend-dev
           cluster: dev-gcp
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
         - application: app-1
           namespace: plattformsikkerhet
           cluster: dev-gcp

--- a/proxies/pdl-proxy/config.yml
+++ b/proxies/pdl-proxy/config.yml
@@ -34,8 +34,6 @@ spec:
       rules:
         - application: team-dolly-lokal-app
           cluster: dev-gcp
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
         - application: testnav-adresse-service
           cluster: dev-gcp
         - application: testnav-pdl-forvalter

--- a/proxies/pensjon-testdata-facade-proxy/config.yml
+++ b/proxies/pensjon-testdata-facade-proxy/config.yml
@@ -40,8 +40,6 @@ spec:
           cluster: dev-gcp
         - application: dolly-frontend-dev
           cluster: dev-gcp
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
         - application: dolly-backend
           cluster: dev-gcp
         - application: dolly-backend-dev

--- a/proxies/saf-proxy/config.yml
+++ b/proxies/saf-proxy/config.yml
@@ -34,8 +34,6 @@ spec:
       rules:
         - application: team-dolly-lokal-app
           cluster: dev-gcp
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
         - application: dolly-frontend-dev
           cluster: dev-gcp
         - application: dolly-frontend

--- a/proxies/sigrunstub-proxy/config.yml
+++ b/proxies/sigrunstub-proxy/config.yml
@@ -31,8 +31,6 @@ spec:
           cluster: dev-gcp
         - application: dolly-frontend-dev
           cluster: dev-gcp
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
         - application: app-1
           namespace: plattformsikkerhet
           cluster: dev-gcp

--- a/proxies/skjermingsregister-proxy/config.yml
+++ b/proxies/skjermingsregister-proxy/config.yml
@@ -29,8 +29,6 @@ spec:
           cluster: dev-gcp
         - application: dolly-backend-dev
           cluster: dev-gcp
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
         - application: app-1
           namespace: plattformsikkerhet
           cluster: dev-gcp

--- a/proxies/statisk-data-forvalter-proxy/config.yml
+++ b/proxies/statisk-data-forvalter-proxy/config.yml
@@ -25,8 +25,6 @@ spec:
           cluster: dev-gcp
         - application: dolly-frontend-dev
           cluster: dev-gcp
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
         - application: app-1
           namespace: plattformsikkerhet
           cluster: dev-gcp

--- a/proxies/tps-forvalteren-proxy/config.test.yml
+++ b/proxies/tps-forvalteren-proxy/config.test.yml
@@ -22,8 +22,6 @@ spec:
   accessPolicy:
     inbound:
       rules:
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
         - application: team-dolly-lokal-app
           cluster: dev-gcp
         - application: testnav-endringsmelding-service

--- a/proxies/tps-forvalteren-proxy/config.yml
+++ b/proxies/tps-forvalteren-proxy/config.yml
@@ -22,8 +22,6 @@ spec:
   accessPolicy:
     inbound:
       rules:
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
         - application: team-dolly-lokal-app
           cluster: dev-gcp
         - application: testnav-endringsmelding-service

--- a/proxies/udistub-proxy/config.yml
+++ b/proxies/udistub-proxy/config.yml
@@ -29,8 +29,6 @@ spec:
           cluster: dev-gcp
         - application: dolly-backend-dev
           cluster: dev-gcp
-        - application: testnav-oversikt-frontend
-          cluster: dev-gcp
         - application: app-1
           namespace: plattformsikkerhet
           cluster: dev-gcp


### PR DESCRIPTION
Ref. https://console.nav.cloud.nais.io/team/dolly.

Kan ikke se at oversikt-frontend konsumerer andre enn disse fire under jfr. sine egne outbound rules, så fjerner inbound rules på testnav-oversikt-frontend alle andre steder:

- testnav-app-tilgang-analyse-service
- testnav-bruker-service-dev
- testnav-person-organisasjon-tilgang-service-dev
- testnorge-profil-api-dev