### PR TITLE
change/sonar-jacoco-cleanup

### DIFF
--- a/apps/adresse-service/build.gradle
+++ b/apps/adresse-service/build.gradle
@@ -19,7 +19,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/apps/adresse-service/build.gradle
+++ b/apps/adresse-service/build.gradle
@@ -11,12 +11,6 @@ test {
     jvmArgs '--add-opens', 'java.base/java.lang=ALL-UNNAMED'
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/apps/amelding-service/build.gradle
+++ b/apps/amelding-service/build.gradle
@@ -10,12 +10,6 @@ test {
     useJUnitPlatform()
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/apps/amelding-service/build.gradle
+++ b/apps/amelding-service/build.gradle
@@ -18,7 +18,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/apps/app-tilgang-analyse-service/build.gradle
+++ b/apps/app-tilgang-analyse-service/build.gradle
@@ -10,12 +10,6 @@ test {
     useJUnitPlatform()
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/apps/app-tilgang-analyse-service/build.gradle
+++ b/apps/app-tilgang-analyse-service/build.gradle
@@ -18,7 +18,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/apps/arbeidsforhold-service/build.gradle
+++ b/apps/arbeidsforhold-service/build.gradle
@@ -10,12 +10,6 @@ test {
     useJUnitPlatform()
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/apps/arbeidsforhold-service/build.gradle
+++ b/apps/arbeidsforhold-service/build.gradle
@@ -18,7 +18,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/apps/batch-bestilling-service/build.gradle
+++ b/apps/batch-bestilling-service/build.gradle
@@ -10,12 +10,6 @@ test {
     useJUnitPlatform()
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/apps/batch-bestilling-service/build.gradle
+++ b/apps/batch-bestilling-service/build.gradle
@@ -18,7 +18,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/apps/brreg-stub/build.gradle
+++ b/apps/brreg-stub/build.gradle
@@ -20,7 +20,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/apps/brreg-stub/build.gradle
+++ b/apps/brreg-stub/build.gradle
@@ -12,12 +12,6 @@ test {
     useJUnitPlatform()
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/apps/bruker-service/build.gradle
+++ b/apps/bruker-service/build.gradle
@@ -19,12 +19,6 @@ def iTest = tasks.register("iTest", Test) {
     shouldRunAfter test
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/apps/bruker-service/build.gradle
+++ b/apps/bruker-service/build.gradle
@@ -27,7 +27,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/apps/budpro-service/build.gradle
+++ b/apps/budpro-service/build.gradle
@@ -98,7 +98,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/apps/budpro-service/build.gradle
+++ b/apps/budpro-service/build.gradle
@@ -90,12 +90,6 @@ test {
     jvmArgs '--add-opens', 'java.base/java.lang=ALL-UNNAMED'
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/apps/dolly-backend/build.gradle
+++ b/apps/dolly-backend/build.gradle
@@ -19,7 +19,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/apps/dolly-backend/build.gradle
+++ b/apps/dolly-backend/build.gradle
@@ -11,12 +11,6 @@ test {
     jvmArgs '--add-opens', 'java.base/java.lang=ALL-UNNAMED'
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/apps/dolly-frontend/build.gradle
+++ b/apps/dolly-frontend/build.gradle
@@ -10,12 +10,6 @@ test {
     useJUnitPlatform()
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/apps/dolly-frontend/build.gradle
+++ b/apps/dolly-frontend/build.gradle
@@ -18,7 +18,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/apps/dollystatus/build.gradle
+++ b/apps/dollystatus/build.gradle
@@ -12,7 +12,6 @@ test {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/apps/endringsmelding-frontend/build.gradle
+++ b/apps/endringsmelding-frontend/build.gradle
@@ -10,12 +10,6 @@ test {
     useJUnitPlatform()
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/apps/endringsmelding-frontend/build.gradle
+++ b/apps/endringsmelding-frontend/build.gradle
@@ -18,7 +18,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/apps/endringsmelding-service/build.gradle
+++ b/apps/endringsmelding-service/build.gradle
@@ -12,7 +12,6 @@ test {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/apps/ereg-batch-status-service/build.gradle
+++ b/apps/ereg-batch-status-service/build.gradle
@@ -10,12 +10,6 @@ test {
     useJUnitPlatform()
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/apps/ereg-batch-status-service/build.gradle
+++ b/apps/ereg-batch-status-service/build.gradle
@@ -18,7 +18,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/apps/faste-data-frontend/build.gradle
+++ b/apps/faste-data-frontend/build.gradle
@@ -10,12 +10,6 @@ test {
     useJUnitPlatform()
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/apps/faste-data-frontend/build.gradle
+++ b/apps/faste-data-frontend/build.gradle
@@ -18,7 +18,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/apps/generer-arbeidsforhold-populasjon-service/build.gradle
+++ b/apps/generer-arbeidsforhold-populasjon-service/build.gradle
@@ -10,12 +10,6 @@ test {
     useJUnitPlatform()
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/apps/generer-arbeidsforhold-populasjon-service/build.gradle
+++ b/apps/generer-arbeidsforhold-populasjon-service/build.gradle
@@ -18,7 +18,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/apps/generer-navn-service/build.gradle
+++ b/apps/generer-navn-service/build.gradle
@@ -10,12 +10,6 @@ test {
     useJUnitPlatform()
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/apps/generer-navn-service/build.gradle
+++ b/apps/generer-navn-service/build.gradle
@@ -18,7 +18,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/apps/generer-organisasjon-populasjon-service/build.gradle
+++ b/apps/generer-organisasjon-populasjon-service/build.gradle
@@ -10,12 +10,6 @@ test {
     useJUnitPlatform()
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/apps/generer-organisasjon-populasjon-service/build.gradle
+++ b/apps/generer-organisasjon-populasjon-service/build.gradle
@@ -18,7 +18,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/apps/generer-synt-amelding-service/build.gradle
+++ b/apps/generer-synt-amelding-service/build.gradle
@@ -12,7 +12,6 @@ test {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/apps/geografiske-kodeverk-service/build.gradle
+++ b/apps/geografiske-kodeverk-service/build.gradle
@@ -10,12 +10,6 @@ test {
     useJUnitPlatform()
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/apps/geografiske-kodeverk-service/build.gradle
+++ b/apps/geografiske-kodeverk-service/build.gradle
@@ -18,7 +18,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/apps/helsepersonell-service/build.gradle
+++ b/apps/helsepersonell-service/build.gradle
@@ -10,12 +10,6 @@ test {
     useJUnitPlatform()
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/apps/helsepersonell-service/build.gradle
+++ b/apps/helsepersonell-service/build.gradle
@@ -18,7 +18,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/apps/inntektsmelding-generator-service/build.gradle
+++ b/apps/inntektsmelding-generator-service/build.gradle
@@ -10,12 +10,6 @@ test {
     useJUnitPlatform()
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/apps/inntektsmelding-generator-service/build.gradle
+++ b/apps/inntektsmelding-generator-service/build.gradle
@@ -18,7 +18,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/apps/inntektsmelding-service/build.gradle
+++ b/apps/inntektsmelding-service/build.gradle
@@ -10,12 +10,6 @@ test {
     useJUnitPlatform()
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/apps/inntektsmelding-service/build.gradle
+++ b/apps/inntektsmelding-service/build.gradle
@@ -18,7 +18,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/apps/jenkins-batch-status-service/build.gradle
+++ b/apps/jenkins-batch-status-service/build.gradle
@@ -10,12 +10,6 @@ test {
     useJUnitPlatform()
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/apps/jenkins-batch-status-service/build.gradle
+++ b/apps/jenkins-batch-status-service/build.gradle
@@ -18,7 +18,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/apps/joark-dokument-service/build.gradle
+++ b/apps/joark-dokument-service/build.gradle
@@ -10,12 +10,6 @@ test {
     useJUnitPlatform()
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/apps/joark-dokument-service/build.gradle
+++ b/apps/joark-dokument-service/build.gradle
@@ -18,7 +18,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/apps/miljoer-service/build.gradle
+++ b/apps/miljoer-service/build.gradle
@@ -10,12 +10,6 @@ test {
     useJUnitPlatform()
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/apps/miljoer-service/build.gradle
+++ b/apps/miljoer-service/build.gradle
@@ -18,7 +18,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/apps/oppsummeringsdokument-service/build.gradle
+++ b/apps/oppsummeringsdokument-service/build.gradle
@@ -10,12 +10,6 @@ test {
     useJUnitPlatform()
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/apps/oppsummeringsdokument-service/build.gradle
+++ b/apps/oppsummeringsdokument-service/build.gradle
@@ -18,7 +18,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/apps/organisasjon-bestilling-service/build.gradle
+++ b/apps/organisasjon-bestilling-service/build.gradle
@@ -10,12 +10,6 @@ test {
     useJUnitPlatform()
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/apps/organisasjon-bestilling-service/build.gradle
+++ b/apps/organisasjon-bestilling-service/build.gradle
@@ -18,7 +18,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/apps/organisasjon-faste-data-service/build.gradle
+++ b/apps/organisasjon-faste-data-service/build.gradle
@@ -10,12 +10,6 @@ test {
     useJUnitPlatform()
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/apps/organisasjon-faste-data-service/build.gradle
+++ b/apps/organisasjon-faste-data-service/build.gradle
@@ -18,7 +18,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/apps/organisasjon-forvalter/build.gradle
+++ b/apps/organisasjon-forvalter/build.gradle
@@ -19,7 +19,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/apps/organisasjon-forvalter/build.gradle
+++ b/apps/organisasjon-forvalter/build.gradle
@@ -11,12 +11,6 @@ test {
     jvmArgs '--add-opens', 'java.base/java.lang=ALL-UNNAMED'
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/apps/organisasjon-mottak-service/build.gradle
+++ b/apps/organisasjon-mottak-service/build.gradle
@@ -10,12 +10,6 @@ test {
     useJUnitPlatform()
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/apps/organisasjon-mottak-service/build.gradle
+++ b/apps/organisasjon-mottak-service/build.gradle
@@ -18,7 +18,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/apps/organisasjon-service/build.gradle
+++ b/apps/organisasjon-service/build.gradle
@@ -10,12 +10,6 @@ test {
     useJUnitPlatform()
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/apps/organisasjon-service/build.gradle
+++ b/apps/organisasjon-service/build.gradle
@@ -18,7 +18,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/apps/organisasjon-tilgang-frontend/build.gradle
+++ b/apps/organisasjon-tilgang-frontend/build.gradle
@@ -10,12 +10,6 @@ test {
     useJUnitPlatform()
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/apps/organisasjon-tilgang-frontend/build.gradle
+++ b/apps/organisasjon-tilgang-frontend/build.gradle
@@ -18,7 +18,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/apps/organisasjon-tilgang-service/build.gradle
+++ b/apps/organisasjon-tilgang-service/build.gradle
@@ -10,12 +10,6 @@ test {
     useJUnitPlatform()
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/apps/organisasjon-tilgang-service/build.gradle
+++ b/apps/organisasjon-tilgang-service/build.gradle
@@ -18,7 +18,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/apps/orgnummer-service/build.gradle
+++ b/apps/orgnummer-service/build.gradle
@@ -10,12 +10,6 @@ test {
     useJUnitPlatform()
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/apps/orgnummer-service/build.gradle
+++ b/apps/orgnummer-service/build.gradle
@@ -18,7 +18,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/apps/oversikt-frontend/build.gradle
+++ b/apps/oversikt-frontend/build.gradle
@@ -10,12 +10,6 @@ test {
     useJUnitPlatform()
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/apps/oversikt-frontend/build.gradle
+++ b/apps/oversikt-frontend/build.gradle
@@ -18,7 +18,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/apps/pdl-forvalter/build.gradle
+++ b/apps/pdl-forvalter/build.gradle
@@ -19,7 +19,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/apps/pdl-forvalter/build.gradle
+++ b/apps/pdl-forvalter/build.gradle
@@ -11,12 +11,6 @@ test {
     jvmArgs '--add-opens', 'java.base/java.lang=ALL-UNNAMED'
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/apps/person-faste-data-service/build.gradle
+++ b/apps/person-faste-data-service/build.gradle
@@ -10,12 +10,6 @@ test {
     useJUnitPlatform()
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/apps/person-faste-data-service/build.gradle
+++ b/apps/person-faste-data-service/build.gradle
@@ -18,7 +18,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/apps/person-organisasjon-tilgang-service/build.gradle
+++ b/apps/person-organisasjon-tilgang-service/build.gradle
@@ -29,7 +29,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/apps/person-organisasjon-tilgang-service/build.gradle
+++ b/apps/person-organisasjon-tilgang-service/build.gradle
@@ -21,12 +21,6 @@ def iTest = tasks.register("iTest", Test) {
     shouldRunAfter test
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/apps/person-search-service/build.gradle
+++ b/apps/person-search-service/build.gradle
@@ -19,7 +19,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/apps/person-search-service/build.gradle
+++ b/apps/person-search-service/build.gradle
@@ -11,12 +11,6 @@ test {
     jvmArgs '--add-opens', 'java.base/java.lang=ALL-UNNAMED'
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/apps/person-service/build.gradle
+++ b/apps/person-service/build.gradle
@@ -10,12 +10,6 @@ test {
     useJUnitPlatform()
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/apps/person-service/build.gradle
+++ b/apps/person-service/build.gradle
@@ -18,7 +18,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/apps/profil-api/build.gradle
+++ b/apps/profil-api/build.gradle
@@ -10,12 +10,6 @@ test {
     useJUnitPlatform()
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/apps/profil-api/build.gradle
+++ b/apps/profil-api/build.gradle
@@ -18,7 +18,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/apps/sykemelding-api/build.gradle
+++ b/apps/sykemelding-api/build.gradle
@@ -10,12 +10,6 @@ test {
     useJUnitPlatform()
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/apps/sykemelding-api/build.gradle
+++ b/apps/sykemelding-api/build.gradle
@@ -18,7 +18,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/apps/synt-sykemelding-api/build.gradle
+++ b/apps/synt-sykemelding-api/build.gradle
@@ -10,12 +10,6 @@ test {
     useJUnitPlatform()
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/apps/synt-sykemelding-api/build.gradle
+++ b/apps/synt-sykemelding-api/build.gradle
@@ -18,7 +18,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/apps/synt-vedtakshistorikk-service/build.gradle
+++ b/apps/synt-vedtakshistorikk-service/build.gradle
@@ -10,12 +10,6 @@ test {
     useJUnitPlatform()
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/apps/synt-vedtakshistorikk-service/build.gradle
+++ b/apps/synt-vedtakshistorikk-service/build.gradle
@@ -18,7 +18,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/apps/tenor-search-service/build.gradle
+++ b/apps/tenor-search-service/build.gradle
@@ -10,12 +10,6 @@ test {
     useJUnitPlatform()
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/apps/tenor-search-service/build.gradle
+++ b/apps/tenor-search-service/build.gradle
@@ -18,7 +18,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/apps/testnav-ident-pool/build.gradle
+++ b/apps/testnav-ident-pool/build.gradle
@@ -19,7 +19,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/apps/testnav-ident-pool/build.gradle
+++ b/apps/testnav-ident-pool/build.gradle
@@ -11,12 +11,6 @@ test {
     jvmArgs '--add-opens', 'java.base/java.lang=ALL-UNNAMED'
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/apps/testnorge-statisk-data-forvalter/build.gradle
+++ b/apps/testnorge-statisk-data-forvalter/build.gradle
@@ -10,12 +10,6 @@ test {
     useJUnitPlatform()
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/apps/testnorge-statisk-data-forvalter/build.gradle
+++ b/apps/testnorge-statisk-data-forvalter/build.gradle
@@ -18,7 +18,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/apps/tilbakemelding-api/build.gradle
+++ b/apps/tilbakemelding-api/build.gradle
@@ -10,12 +10,6 @@ test {
     useJUnitPlatform()
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/apps/tilbakemelding-api/build.gradle
+++ b/apps/tilbakemelding-api/build.gradle
@@ -18,7 +18,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/apps/tps-messaging-service/build.gradle
+++ b/apps/tps-messaging-service/build.gradle
@@ -16,12 +16,6 @@ rewrite {
     activeRecipe("org.openrewrite.java.spring.boot3.UpgradeSpringBoot_3_2")
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/apps/tps-messaging-service/build.gradle
+++ b/apps/tps-messaging-service/build.gradle
@@ -24,7 +24,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/apps/udi-stub/build.gradle
+++ b/apps/udi-stub/build.gradle
@@ -13,12 +13,6 @@ test {
     jvmArgs '--add-opens', 'java.base/java.lang=ALL-UNNAMED'
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 rewrite {
     activeRecipe("org.openrewrite.java.spring.boot3.UpgradeSpringBoot_3_2")
 }

--- a/apps/udi-stub/build.gradle
+++ b/apps/udi-stub/build.gradle
@@ -25,7 +25,6 @@ rewrite {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/apps/varslinger-service/build.gradle
+++ b/apps/varslinger-service/build.gradle
@@ -10,12 +10,6 @@ test {
     useJUnitPlatform()
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/apps/varslinger-service/build.gradle
+++ b/apps/varslinger-service/build.gradle
@@ -18,7 +18,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/examples/reactive-rest-example/build.gradle
+++ b/examples/reactive-rest-example/build.gradle
@@ -10,12 +10,6 @@ test {
     useJUnitPlatform()
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/examples/reactive-rest-example/build.gradle
+++ b/examples/reactive-rest-example/build.gradle
@@ -18,7 +18,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/libs/commands/build.gradle
+++ b/libs/commands/build.gradle
@@ -5,12 +5,6 @@ plugins {
     id "jacoco"
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/libs/commands/build.gradle
+++ b/libs/commands/build.gradle
@@ -13,7 +13,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/libs/csv-converter/build.gradle
+++ b/libs/csv-converter/build.gradle
@@ -5,12 +5,6 @@ plugins {
     id "jacoco"
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/libs/csv-converter/build.gradle
+++ b/libs/csv-converter/build.gradle
@@ -13,7 +13,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/libs/data-transfer-objects/build.gradle
+++ b/libs/data-transfer-objects/build.gradle
@@ -14,7 +14,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/libs/data-transfer-objects/build.gradle
+++ b/libs/data-transfer-objects/build.gradle
@@ -6,12 +6,6 @@ plugins {
     id "jacoco"
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/libs/data-transfer-search-objects/build.gradle
+++ b/libs/data-transfer-search-objects/build.gradle
@@ -14,7 +14,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/libs/data-transfer-search-objects/build.gradle
+++ b/libs/data-transfer-search-objects/build.gradle
@@ -6,12 +6,6 @@ plugins {
     id "jacoco"
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/libs/database/build.gradle
+++ b/libs/database/build.gradle
@@ -5,12 +5,6 @@ plugins {
     id "jacoco"
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/libs/database/build.gradle
+++ b/libs/database/build.gradle
@@ -13,7 +13,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/libs/domain/build.gradle
+++ b/libs/domain/build.gradle
@@ -5,12 +5,6 @@ plugins {
     id "jacoco"
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/libs/domain/build.gradle
+++ b/libs/domain/build.gradle
@@ -13,7 +13,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/libs/integration-test/build.gradle
+++ b/libs/integration-test/build.gradle
@@ -17,7 +17,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/libs/integration-test/build.gradle
+++ b/libs/integration-test/build.gradle
@@ -9,12 +9,6 @@ test {
     useJUnitPlatform()
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/libs/kafka-config/build.gradle
+++ b/libs/kafka-config/build.gradle
@@ -5,12 +5,6 @@ plugins {
     id "jacoco"
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/libs/kafka-config/build.gradle
+++ b/libs/kafka-config/build.gradle
@@ -13,7 +13,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/libs/kafka-producers/build.gradle
+++ b/libs/kafka-producers/build.gradle
@@ -5,12 +5,6 @@ plugins {
     id "jacoco"
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/libs/kafka-producers/build.gradle
+++ b/libs/kafka-producers/build.gradle
@@ -13,7 +13,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/libs/reactive-core/build.gradle
+++ b/libs/reactive-core/build.gradle
@@ -10,12 +10,6 @@ test {
     useJUnitPlatform()
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/libs/reactive-core/build.gradle
+++ b/libs/reactive-core/build.gradle
@@ -18,7 +18,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/libs/reactive-frontend/build.gradle
+++ b/libs/reactive-frontend/build.gradle
@@ -14,7 +14,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/libs/reactive-frontend/build.gradle
+++ b/libs/reactive-frontend/build.gradle
@@ -6,12 +6,6 @@ plugins {
     id "jacoco"
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/libs/reactive-proxy/build.gradle
+++ b/libs/reactive-proxy/build.gradle
@@ -14,7 +14,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/libs/reactive-proxy/build.gradle
+++ b/libs/reactive-proxy/build.gradle
@@ -6,12 +6,6 @@ plugins {
     id "jacoco"
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/libs/reactive-security/build.gradle
+++ b/libs/reactive-security/build.gradle
@@ -10,12 +10,6 @@ test {
     useJUnitPlatform()
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/libs/reactive-security/build.gradle
+++ b/libs/reactive-security/build.gradle
@@ -18,7 +18,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/libs/reactive-session-security/build.gradle
+++ b/libs/reactive-session-security/build.gradle
@@ -5,12 +5,6 @@ plugins {
     id "jacoco"
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/libs/reactive-session-security/build.gradle
+++ b/libs/reactive-session-security/build.gradle
@@ -13,7 +13,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/libs/security-core/build.gradle
+++ b/libs/security-core/build.gradle
@@ -5,12 +5,6 @@ plugins {
     id "jacoco"
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/libs/security-core/build.gradle
+++ b/libs/security-core/build.gradle
@@ -13,7 +13,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/libs/security-token-service/build.gradle
+++ b/libs/security-token-service/build.gradle
@@ -5,12 +5,6 @@ plugins {
     id "jacoco"
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/libs/security-token-service/build.gradle
+++ b/libs/security-token-service/build.gradle
@@ -13,7 +13,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/libs/servlet-core/build.gradle
+++ b/libs/servlet-core/build.gradle
@@ -17,7 +17,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/libs/servlet-core/build.gradle
+++ b/libs/servlet-core/build.gradle
@@ -9,12 +9,6 @@ test {
     useJUnitPlatform()
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/libs/servlet-insecure-security/build.gradle
+++ b/libs/servlet-insecure-security/build.gradle
@@ -5,12 +5,6 @@ plugins {
     id "jacoco"
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/libs/servlet-insecure-security/build.gradle
+++ b/libs/servlet-insecure-security/build.gradle
@@ -13,7 +13,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/libs/servlet-security/build.gradle
+++ b/libs/servlet-security/build.gradle
@@ -5,12 +5,6 @@ plugins {
     id "jacoco"
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/libs/servlet-security/build.gradle
+++ b/libs/servlet-security/build.gradle
@@ -13,7 +13,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/libs/slack/build.gradle
+++ b/libs/slack/build.gradle
@@ -5,12 +5,6 @@ plugins {
     id "jacoco"
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/libs/slack/build.gradle
+++ b/libs/slack/build.gradle
@@ -13,7 +13,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/libs/testing/build.gradle
+++ b/libs/testing/build.gradle
@@ -5,12 +5,6 @@ plugins {
     id "jacoco"
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/libs/testing/build.gradle
+++ b/libs/testing/build.gradle
@@ -13,7 +13,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/proxies/aareg-proxy/build.gradle
+++ b/proxies/aareg-proxy/build.gradle
@@ -10,12 +10,6 @@ test {
     useJUnitPlatform()
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/proxies/aareg-proxy/build.gradle
+++ b/proxies/aareg-proxy/build.gradle
@@ -18,7 +18,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/proxies/aareg-synt-services-proxy/build.gradle
+++ b/proxies/aareg-synt-services-proxy/build.gradle
@@ -10,12 +10,6 @@ test {
     useJUnitPlatform()
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/proxies/aareg-synt-services-proxy/build.gradle
+++ b/proxies/aareg-synt-services-proxy/build.gradle
@@ -18,7 +18,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/proxies/arbeidsplassencv-proxy/build.gradle
+++ b/proxies/arbeidsplassencv-proxy/build.gradle
@@ -10,12 +10,6 @@ test {
     useJUnitPlatform()
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/proxies/arbeidsplassencv-proxy/build.gradle
+++ b/proxies/arbeidsplassencv-proxy/build.gradle
@@ -18,7 +18,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/proxies/arena-forvalteren-proxy/build.gradle
+++ b/proxies/arena-forvalteren-proxy/build.gradle
@@ -10,12 +10,6 @@ test {
     useJUnitPlatform()
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/proxies/arena-forvalteren-proxy/build.gradle
+++ b/proxies/arena-forvalteren-proxy/build.gradle
@@ -18,7 +18,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/proxies/batch-adeo-proxy/build.gradle
+++ b/proxies/batch-adeo-proxy/build.gradle
@@ -10,12 +10,6 @@ test {
     useJUnitPlatform()
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/proxies/batch-adeo-proxy/build.gradle
+++ b/proxies/batch-adeo-proxy/build.gradle
@@ -18,7 +18,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/proxies/brregstub-proxy/build.gradle
+++ b/proxies/brregstub-proxy/build.gradle
@@ -10,12 +10,6 @@ test {
     useJUnitPlatform()
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/proxies/brregstub-proxy/build.gradle
+++ b/proxies/brregstub-proxy/build.gradle
@@ -18,7 +18,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/proxies/dokarkiv-proxy/build.gradle
+++ b/proxies/dokarkiv-proxy/build.gradle
@@ -12,7 +12,6 @@ test {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/proxies/ereg-proxy/build.gradle
+++ b/proxies/ereg-proxy/build.gradle
@@ -10,12 +10,6 @@ test {
     useJUnitPlatform()
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/proxies/ereg-proxy/build.gradle
+++ b/proxies/ereg-proxy/build.gradle
@@ -18,7 +18,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/proxies/histark-proxy/build.gradle
+++ b/proxies/histark-proxy/build.gradle
@@ -10,12 +10,6 @@ test {
     useJUnitPlatform()
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/proxies/histark-proxy/build.gradle
+++ b/proxies/histark-proxy/build.gradle
@@ -18,7 +18,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/proxies/inntektstub-proxy/build.gradle
+++ b/proxies/inntektstub-proxy/build.gradle
@@ -10,12 +10,6 @@ test {
     useJUnitPlatform()
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/proxies/inntektstub-proxy/build.gradle
+++ b/proxies/inntektstub-proxy/build.gradle
@@ -18,7 +18,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/proxies/inst-proxy/build.gradle
+++ b/proxies/inst-proxy/build.gradle
@@ -10,12 +10,6 @@ test {
     useJUnitPlatform()
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/proxies/inst-proxy/build.gradle
+++ b/proxies/inst-proxy/build.gradle
@@ -18,7 +18,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/proxies/kontoregister-person-proxy/build.gradle
+++ b/proxies/kontoregister-person-proxy/build.gradle
@@ -10,12 +10,6 @@ test {
     useJUnitPlatform()
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/proxies/kontoregister-person-proxy/build.gradle
+++ b/proxies/kontoregister-person-proxy/build.gradle
@@ -18,7 +18,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/proxies/krrstub-proxy/build.gradle
+++ b/proxies/krrstub-proxy/build.gradle
@@ -10,12 +10,6 @@ test {
     useJUnitPlatform()
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/proxies/krrstub-proxy/build.gradle
+++ b/proxies/krrstub-proxy/build.gradle
@@ -18,7 +18,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/proxies/medl-proxy/build.gradle
+++ b/proxies/medl-proxy/build.gradle
@@ -10,12 +10,6 @@ test {
     useJUnitPlatform()
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.sourceEncoding", "UTF-8"

--- a/proxies/medl-proxy/build.gradle
+++ b/proxies/medl-proxy/build.gradle
@@ -22,7 +22,6 @@ sonarqube {
         property "sonar.projectKey", "testnav-medl-proxy"
         property "sonar.projectName", "testnav-medl-proxy"
         property "sonar.organization", "navikt"
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/proxies/norg2-proxy/build.gradle
+++ b/proxies/norg2-proxy/build.gradle
@@ -12,7 +12,6 @@ test {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/proxies/pdl-proxy/build.gradle
+++ b/proxies/pdl-proxy/build.gradle
@@ -10,12 +10,6 @@ test {
     useJUnitPlatform()
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/proxies/pdl-proxy/build.gradle
+++ b/proxies/pdl-proxy/build.gradle
@@ -18,7 +18,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/proxies/pensjon-testdata-facade-proxy/build.gradle
+++ b/proxies/pensjon-testdata-facade-proxy/build.gradle
@@ -10,12 +10,6 @@ test {
     useJUnitPlatform()
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/proxies/pensjon-testdata-facade-proxy/build.gradle
+++ b/proxies/pensjon-testdata-facade-proxy/build.gradle
@@ -18,7 +18,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/proxies/saf-proxy/build.gradle
+++ b/proxies/saf-proxy/build.gradle
@@ -10,12 +10,6 @@ test {
     useJUnitPlatform()
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/proxies/saf-proxy/build.gradle
+++ b/proxies/saf-proxy/build.gradle
@@ -18,7 +18,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/proxies/sigrunstub-proxy/build.gradle
+++ b/proxies/sigrunstub-proxy/build.gradle
@@ -10,12 +10,6 @@ test {
     useJUnitPlatform()
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/proxies/sigrunstub-proxy/build.gradle
+++ b/proxies/sigrunstub-proxy/build.gradle
@@ -18,7 +18,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/proxies/skjermingsregister-proxy/build.gradle
+++ b/proxies/skjermingsregister-proxy/build.gradle
@@ -10,12 +10,6 @@ test {
     useJUnitPlatform()
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/proxies/skjermingsregister-proxy/build.gradle
+++ b/proxies/skjermingsregister-proxy/build.gradle
@@ -18,7 +18,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/proxies/synthdata-meldekort-proxy/build.gradle
+++ b/proxies/synthdata-meldekort-proxy/build.gradle
@@ -10,12 +10,6 @@ test {
     useJUnitPlatform()
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/proxies/synthdata-meldekort-proxy/build.gradle
+++ b/proxies/synthdata-meldekort-proxy/build.gradle
@@ -18,7 +18,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/proxies/tps-forvalteren-proxy/build.gradle
+++ b/proxies/tps-forvalteren-proxy/build.gradle
@@ -10,12 +10,6 @@ test {
     useJUnitPlatform()
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/proxies/tps-forvalteren-proxy/build.gradle
+++ b/proxies/tps-forvalteren-proxy/build.gradle
@@ -18,7 +18,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"

--- a/proxies/udistub-proxy/build.gradle
+++ b/proxies/udistub-proxy/build.gradle
@@ -10,12 +10,6 @@ test {
     useJUnitPlatform()
 }
 
-jacocoTestReport {
-    reports {
-        xml.required = true
-    }
-}
-
 sonarqube {
     properties {
         property "sonar.dynamicAnalysis", "reuseReports"

--- a/proxies/udistub-proxy/build.gradle
+++ b/proxies/udistub-proxy/build.gradle
@@ -18,7 +18,6 @@ jacocoTestReport {
 
 sonarqube {
     properties {
-        property "sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory}/reports/jacoco/test/jacocoTestReport.xml"
         property "sonar.dynamicAnalysis", "reuseReports"
         property "sonar.host.url", "https://sonarcloud.io"
         property "sonar.java.coveragePlugin", "jacoco"


### PR DESCRIPTION
Endringer for Sonar:

**Feil:**
Finner ikke output fra JaCoCo, ref.:

`No coverage report can be found with sonar.coverage.jacoco.xmlReportPaths='property(org.gradle.api.file.Directory,fixed(class org.gradle.api.internal.file.DefaultFilePropertyFactory$FixedDirectory,**your-source-path-here**))/reports/jacoco/test/jacocoTestReport.xml'. Using default locations: target/site/jacoco/jacoco.xml,target/site/jacoco-it/jacoco.xml,build/reports/jacoco/test/jacocoTestReport.xml
`

**Løsning:**
Nye Sonar finner tilsynelatende default output fra JaCoCo automagisk.

**Endring:**
Cleanup, dvs. fjerner eksplisitt config for JaCoCo output og Sonar input.

**Dokumentasjon:**
https://docs.sonarsource.com/sonarcloud/advanced-setup/ci-based-analysis/sonarscanner-for-gradle/#additional-defaults-when-jacoco-plugin-is-applied

**Disclaimer:**
Ikke manuelt testet på alle 90+ builds, men følger opp som del av annet arbeid på workflows.