### PR TITLE
Refactor BestillingServiceTest to handle valid environments

### DIFF
--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/tpsmessagingservice/MiljoerConsumer.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/tpsmessagingservice/MiljoerConsumer.java
@@ -16,13 +16,13 @@ import java.util.List;
 
 @Slf4j
 @Service
-public class TpsMiljoerConsumer implements ConsumerStatus {
+public class MiljoerConsumer implements ConsumerStatus {
 
     private final WebClient webClient;
     private final TokenExchange tokenService;
     private final ServerProperties serverProperties;
 
-    public TpsMiljoerConsumer(
+    public MiljoerConsumer(
             TokenExchange tokenService,
             Consumers consumers,
             WebClient.Builder webClientBuilder
@@ -39,8 +39,8 @@ public class TpsMiljoerConsumer implements ConsumerStatus {
         return tokenService.exchange(serverProperties);
     }
 
-    @Timed(name = "providers", tags = {"operation", "get_tps_miljoer"})
-    public Mono<List<String>> getTpsMiljoer() {
+    @Timed(name = "providers", tags = {"operation", "get_miljoer"})
+    public Mono<List<String>> getMiljoer() {
 
         return tokenService.exchange(serverProperties)
                 .flatMap(token -> new MiljoerGetCommand(webClient, token.getTokenValue()).call());

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/tpsmessagingservice/TpsMessagingClient.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/tpsmessagingservice/TpsMessagingClient.java
@@ -51,7 +51,7 @@ public class TpsMessagingClient implements ClientRegister {
     private final MapperFacade mapperFacade;
     private final PersonServiceConsumer personServiceConsumer;
     private final TransactionHelperService transactionHelperService;
-    private final TpsMiljoerConsumer tpsMiljoerConsumer;
+    private final MiljoerConsumer miljoerConsumer;
 
     private static String getResultat(TpsMeldingResponseDTO respons) {
 
@@ -76,7 +76,7 @@ public class TpsMessagingClient implements ClientRegister {
     @SuppressWarnings("S1144")
     public Flux<ClientFuture> gjenopprett(RsDollyUtvidetBestilling bestilling, DollyPerson dollyPerson, BestillingProgress progress, boolean isOpprettEndre) {
 
-        return Flux.from(tpsMiljoerConsumer.getTpsMiljoer()
+        return Flux.from(miljoerConsumer.getMiljoer()
                         .flatMap(miljoer -> {
 
                             if (!dollyPerson.isOrdre() && isTpsMessage(bestilling)) {

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/tpsmessagingservice/command/MiljoerGetCommand.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/tpsmessagingservice/command/MiljoerGetCommand.java
@@ -35,6 +35,7 @@ public class MiljoerGetCommand implements Callable<Mono<List<String>>> {
                 .map(Arrays::asList)
                 .doOnError(WebClientFilter::logErrorMessage)
                 .retryWhen(Retry.backoff(3, Duration.ofSeconds(5))
-                        .filter(WebClientFilter::is5xxException));
+                        .filter(WebClientFilter::is5xxException))
+                .cache(Duration.ofHours(8));
     }
 }

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/provider/api/BestillingController.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/provider/api/BestillingController.java
@@ -29,7 +29,6 @@ import reactor.core.publisher.Mono;
 
 import java.util.List;
 
-import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Objects.nonNull;
 import static no.nav.dolly.config.CachingConfig.CACHE_BESTILLING;
@@ -120,7 +119,7 @@ public class BestillingController {
     @Operation(description = "Gjenopprett en bestilling med bestillingsId, for en liste med miljoer")
     @Transactional
     public RsBestillingStatus gjenopprettBestilling(@PathVariable("bestillingId") Long bestillingId, @RequestParam(value = "miljoer", required = false) String miljoer) {
-        Bestilling bestilling = bestillingService.createBestillingForGjenopprettFraBestilling(bestillingId, nonNull(miljoer) ? asList(miljoer.split(",")) : emptyList());
+        Bestilling bestilling = bestillingService.createBestillingForGjenopprettFraBestilling(bestillingId, miljoer);
         gjenopprettBestillingService.executeAsync(bestilling);
         return mapperFacade.map(bestilling, RsBestillingStatus.class);
     }

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/service/BestillingService.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/service/BestillingService.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import no.nav.dolly.bestilling.tpsmessagingservice.MiljoerConsumer;
 import no.nav.dolly.domain.jpa.Bestilling;
 import no.nav.dolly.domain.jpa.BestillingKontroll;
 import no.nav.dolly.domain.jpa.BestillingProgress;
@@ -51,7 +52,6 @@ import static java.lang.String.format;
 import static java.lang.String.join;
 import static java.time.LocalDateTime.now;
 import static java.util.Collections.emptySet;
-import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 import static java.util.stream.Collectors.toSet;
 import static no.nav.dolly.util.CurrentAuthentication.getUserId;
@@ -77,6 +77,7 @@ public class BestillingService {
     private final BrukerService brukerService;
     private final GetUserInfo getUserInfo;
     private final BestillingElasticRepository elasticRepository;
+    private final MiljoerConsumer miljoerConsumer;
 
     public Bestilling fetchBestillingById(Long bestillingId) {
         return bestillingRepository.findById(bestillingId)
@@ -108,19 +109,6 @@ public class BestillingService {
         }
     }
 
-    public Set<Bestilling> fetchBestillingerByGruppeId(Long gruppeId, Integer page, Integer pageSize) {
-        Optional<Testgruppe> testgruppe = testgruppeRepository.findById(gruppeId);
-        if (page == null || pageSize == null) {
-            return testgruppe
-                    .map(Testgruppe::getBestillinger).orElse(emptySet());
-        }
-        return testgruppe
-                .map(value -> value.getBestillinger().stream()
-                        .skip(page.longValue() * pageSize).limit(pageSize)
-                        .collect(toSet()))
-                .orElse(emptySet());
-    }
-
     public Set<Bestilling> fetchBestillingerByGruppeIdOgIkkeFerdig(Long gruppeId) {
         Optional<Testgruppe> testgruppe = testgruppeRepository.findById(gruppeId);
         return testgruppe
@@ -134,6 +122,7 @@ public class BestillingService {
         Optional<Testgruppe> testgruppe = testgruppeRepository.findById(gruppeId);
         return testgruppe.map(value -> value.getBestillinger().stream()
                 .map(Bestilling::getMiljoer)
+                .filter(StringUtils::isNotBlank)
                 .flatMap(miljoer -> Arrays.stream(miljoer.split(",")))
                 .filter(StringUtils::isNotBlank)
                 .collect(toSet())).orElse(emptySet());
@@ -214,7 +203,7 @@ public class BestillingService {
                 .antallIdenter(1)
                 .navSyntetiskIdent(request.getNavSyntetiskIdent())
                 .sistOppdatert(now())
-                .miljoer(join(",", request.getEnvironments()))
+                .miljoer(filterAvailable(request.getEnvironments()))
                 .bestKriterier(getBestKriterier(request))
                 .bruker(bruker)
                 .build();
@@ -223,6 +212,19 @@ public class BestillingService {
             bestillingMalService.saveBestillingMal(bestilling, request.getMalBestillingNavn(), bruker);
         }
         return saveBestillingToDB(bestilling);
+    }
+
+    private String filterAvailable(Collection<String> environments) {
+
+        var miljoer = miljoerConsumer.getMiljoer().block();
+        return nonNull(environments) ? environments.stream()
+                .filter(miljoer::contains)
+                .collect(Collectors.joining(",")) : null;
+    }
+
+    private String filterAvailable(String miljoer) {
+
+        return isNotBlank(miljoer) ? filterAvailable(Arrays.asList(miljoer.split(","))) : null;
     }
 
     @Transactional
@@ -235,7 +237,7 @@ public class BestillingService {
                 .antallIdenter(antall)
                 .navSyntetiskIdent(navSyntetiskIdent)
                 .sistOppdatert(now())
-                .miljoer(join(",", request.getEnvironments()))
+                .miljoer(filterAvailable(request.getEnvironments()))
                 .bestKriterier(getBestKriterier(request))
                 .opprettFraIdenter(nonNull(opprettFraIdenter) ? join(",", opprettFraIdenter) : null)
                 .bruker(bruker)
@@ -250,7 +252,7 @@ public class BestillingService {
 
     @Transactional
     // Egen transaksjon på denne da bestillingId hentes opp igjen fra database i samme kallet
-    public Bestilling createBestillingForGjenopprettFraBestilling(Long bestillingId, List<String> miljoer) {
+    public Bestilling createBestillingForGjenopprettFraBestilling(Long bestillingId, String miljoer) {
         Bestilling bestilling = fetchBestillingById(bestillingId);
         if (!bestilling.isFerdig()) {
             throw new DollyFunctionalException(format("Du kan ikke starte gjenopprett før bestilling %d er ferdigstilt.", bestillingId));
@@ -264,7 +266,7 @@ public class BestillingService {
                         .antallIdenter(bestilling.getAntallIdenter())
                         .opprettFraIdenter(bestilling.getOpprettFraIdenter())
                         .sistOppdatert(now())
-                        .miljoer(isNull(miljoer) || miljoer.isEmpty() ? bestilling.getMiljoer() : join(",", miljoer))
+                        .miljoer(filterAvailable(isNotBlank(miljoer) ? miljoer : bestilling.getMiljoer()))
                         .opprettetFraId(bestillingId)
                         .bestKriterier("{}")
                         .bruker(fetchOrCreateBruker())
@@ -283,7 +285,7 @@ public class BestillingService {
                         .antallIdenter(1)
                         .bestKriterier("{}")
                         .sistOppdatert(now())
-                        .miljoer(isNull(miljoer) || miljoer.isEmpty() ? "" : join(",", miljoer))
+                        .miljoer(filterAvailable(miljoer))
                         .gjenopprettetFraIdent(ident)
                         .bruker(fetchOrCreateBruker())
                         .build());
@@ -305,7 +307,7 @@ public class BestillingService {
                         .antallIdenter(testgruppe.get().getTestidenter().size())
                         .bestKriterier("{}")
                         .sistOppdatert(now())
-                        .miljoer(miljoer)
+                        .miljoer(filterAvailable(miljoer))
                         .opprettetFraGruppeId(gruppeId)
                         .bruker(fetchOrCreateBruker())
                         .build());
@@ -319,7 +321,7 @@ public class BestillingService {
         Bestilling bestilling = Bestilling.builder()
                 .gruppe(gruppe)
                 .kildeMiljoe("PDL")
-                .miljoer(join(",", request.getEnvironments()))
+                .miljoer(filterAvailable(request.getEnvironments()))
                 .sistOppdatert(now())
                 .bruker(bruker)
                 .antallIdenter(request.getIdenter().size())
@@ -344,7 +346,7 @@ public class BestillingService {
         return saveBestillingToDB(
                 Bestilling.builder()
                         .gruppe(gruppe)
-                        .miljoer(join(",", request.getEnvironments()))
+                        .miljoer(filterAvailable(request.getEnvironments()))
                         .sistOppdatert(now())
                         .bruker(fetchOrCreateBruker())
                         .antallIdenter(size)


### PR DESCRIPTION
The code has been modified to import 'MiljoerConsumer' and the necessary changes have been made to the 'BestillingServiceTest.java' test cases to handle valid environments only. Also, redundant variables 'BRUKERNAVN' and 'EPOST' were removed. A method has been added to filter available environments and ensure that only valid environments are included while processing. Classes 'TpsMessagingClient.java' and 'BestillingController.java' were also adjusted accordingly to use the new method.