### PR TITLE
Refactor httpClientRequests to add responseTimeout

### DIFF
--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/aareg/AaregClient.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/aareg/AaregClient.java
@@ -80,7 +80,7 @@ public class AaregClient implements ClientRegister {
 
                             return sendArbeidsforhold(bestilling, dollyPerson, miljoerTrygg.get(), isOpprettEndre);
                         } else {
-                            return ameldingService.sendAmelding(bestilling, dollyPerson, miljoerTrygg.get(), progress);
+                            return ameldingService.sendAmelding(bestilling, dollyPerson, miljoerTrygg.get());
                         }
                     })
                     .map(status -> futurePersist(progress, status));

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/aareg/command/AmeldingPutCommand.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/aareg/command/AmeldingPutCommand.java
@@ -9,10 +9,13 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
+import reactor.netty.http.client.HttpClientRequest;
 import reactor.util.retry.Retry;
 
 import java.time.Duration;
 import java.util.concurrent.Callable;
+
+import static no.nav.dolly.util.RequestTimeout.REQUEST_DURATION;
 
 @RequiredArgsConstructor
 public class AmeldingPutCommand implements Callable<Mono<ResponseEntity<String>>> {
@@ -31,6 +34,10 @@ public class AmeldingPutCommand implements Callable<Mono<ResponseEntity<String>>
         return webClient.put()
                 .uri(uriBuilder -> uriBuilder.path(AMELDING_URL)
                         .build())
+                .httpRequest(httpRequest -> {
+                    HttpClientRequest reactorRequest = httpRequest.getNativeRequest();
+                    reactorRequest.responseTimeout(Duration.ofSeconds(REQUEST_DURATION));
+                })
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                 .header(UserConstant.USER_HEADER_JWT, TokenXUtil.getUserJwt())
                 .header(MILJOE, miljo)

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/pdldata/command/PdlDataOppdateringCommand.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/pdldata/command/PdlDataOppdateringCommand.java
@@ -13,12 +13,14 @@ import org.springframework.http.MediaType;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Flux;
+import reactor.netty.http.client.HttpClientRequest;
 import reactor.util.retry.Retry;
 
 import java.net.http.HttpTimeoutException;
 import java.time.Duration;
 import java.util.concurrent.Callable;
 
+import static no.nav.dolly.util.RequestTimeout.REQUEST_DURATION;
 import static no.nav.dolly.util.TokenXUtil.getUserJwt;
 
 @Slf4j
@@ -37,6 +39,10 @@ public class PdlDataOppdateringCommand implements Callable<Flux<PdlResponse>> {
         return webClient
                 .put()
                 .uri(PDL_FORVALTER_PERSONER_URL, ident)
+                .httpRequest(httpRequest -> {
+                    HttpClientRequest reactorRequest = httpRequest.getNativeRequest();
+                    reactorRequest.responseTimeout(Duration.ofSeconds(REQUEST_DURATION));
+                })
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                 .header(UserConstant.USER_HEADER_JWT, getUserJwt())
                 .contentType(MediaType.APPLICATION_JSON)

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/pdldata/command/PdlDataOpprettingCommand.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/pdldata/command/PdlDataOpprettingCommand.java
@@ -13,12 +13,14 @@ import org.springframework.http.MediaType;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Flux;
+import reactor.netty.http.client.HttpClientRequest;
 import reactor.util.retry.Retry;
 
 import java.net.http.HttpTimeoutException;
 import java.time.Duration;
 import java.util.concurrent.Callable;
 
+import static no.nav.dolly.util.RequestTimeout.REQUEST_DURATION;
 import static no.nav.dolly.util.TokenXUtil.getUserJwt;
 
 @Slf4j
@@ -36,6 +38,10 @@ public class PdlDataOpprettingCommand implements Callable<Flux<PdlResponse>> {
         return webClient
                 .post()
                 .uri(PDL_FORVALTER_PERSONER_URL)
+                .httpRequest(httpRequest -> {
+                    HttpClientRequest reactorRequest = httpRequest.getNativeRequest();
+                    reactorRequest.responseTimeout(Duration.ofSeconds(REQUEST_DURATION));
+                })
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                 .header(UserConstant.USER_HEADER_JWT, getUserJwt())
                 .contentType(MediaType.APPLICATION_JSON)

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/pdldata/command/PdlDataOrdreCommand.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/pdldata/command/PdlDataOrdreCommand.java
@@ -10,12 +10,14 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Flux;
+import reactor.netty.http.client.HttpClientRequest;
 import reactor.util.retry.Retry;
 
 import java.net.http.HttpTimeoutException;
 import java.time.Duration;
 import java.util.concurrent.Callable;
 
+import static no.nav.dolly.util.RequestTimeout.REQUEST_DURATION;
 import static no.nav.dolly.util.TokenXUtil.getUserJwt;
 
 @RequiredArgsConstructor
@@ -36,6 +38,10 @@ public class PdlDataOrdreCommand implements Callable<Flux<PdlResponse>> {
                 .uri(uriBuilder -> uriBuilder.path(PDL_FORVALTER_ORDRE_URL)
                         .queryParam(EXCLUDE_EKSTERNE_PERSONER, ekskluderEksternePersoner)
                         .build(ident))
+                .httpRequest(httpRequest -> {
+                    HttpClientRequest reactorRequest = httpRequest.getNativeRequest();
+                    reactorRequest.responseTimeout(Duration.ofSeconds(REQUEST_DURATION));
+                })
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                 .header(UserConstant.USER_HEADER_JWT, getUserJwt())
                 .contentType(MediaType.APPLICATION_JSON)

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/pensjonforvalter/PensjonforvalterConsumer.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/pensjonforvalter/PensjonforvalterConsumer.java
@@ -41,7 +41,6 @@ import static no.nav.dolly.util.JacksonExchangeStrategyUtil.getJacksonStrategy;
 @Service
 public class PensjonforvalterConsumer implements ConsumerStatus {
 
-    public static final int REQUEST_DURATION = 30000;
     private final TokenExchange tokenService;
     private final WebClient webClient;
     private final ServerProperties serverProperties;

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/pensjonforvalter/command/LagreAlderspensjonCommand.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/pensjonforvalter/command/LagreAlderspensjonCommand.java
@@ -15,11 +15,11 @@ import reactor.util.retry.Retry;
 import java.time.Duration;
 import java.util.concurrent.Callable;
 
-import static no.nav.dolly.bestilling.pensjonforvalter.PensjonforvalterConsumer.REQUEST_DURATION;
 import static no.nav.dolly.domain.CommonKeysAndUtils.CONSUMER;
 import static no.nav.dolly.domain.CommonKeysAndUtils.HEADER_NAV_CALL_ID;
 import static no.nav.dolly.domain.CommonKeysAndUtils.HEADER_NAV_CONSUMER_ID;
 import static no.nav.dolly.util.CallIdUtil.generateCallId;
+import static no.nav.dolly.util.RequestTimeout.REQUEST_DURATION;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
 @Slf4j

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/pensjonforvalter/command/LagrePoppInntektCommand.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/pensjonforvalter/command/LagrePoppInntektCommand.java
@@ -14,11 +14,11 @@ import reactor.util.retry.Retry;
 import java.time.Duration;
 import java.util.concurrent.Callable;
 
-import static no.nav.dolly.bestilling.pensjonforvalter.PensjonforvalterConsumer.REQUEST_DURATION;
 import static no.nav.dolly.domain.CommonKeysAndUtils.CONSUMER;
 import static no.nav.dolly.domain.CommonKeysAndUtils.HEADER_NAV_CALL_ID;
 import static no.nav.dolly.domain.CommonKeysAndUtils.HEADER_NAV_CONSUMER_ID;
 import static no.nav.dolly.util.CallIdUtil.generateCallId;
+import static no.nav.dolly.util.RequestTimeout.REQUEST_DURATION;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
 @Slf4j

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/pensjonforvalter/command/LagreTpForholdCommand.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/pensjonforvalter/command/LagreTpForholdCommand.java
@@ -15,11 +15,11 @@ import reactor.util.retry.Retry;
 import java.time.Duration;
 import java.util.concurrent.Callable;
 
-import static no.nav.dolly.bestilling.pensjonforvalter.PensjonforvalterConsumer.REQUEST_DURATION;
 import static no.nav.dolly.domain.CommonKeysAndUtils.CONSUMER;
 import static no.nav.dolly.domain.CommonKeysAndUtils.HEADER_NAV_CALL_ID;
 import static no.nav.dolly.domain.CommonKeysAndUtils.HEADER_NAV_CONSUMER_ID;
 import static no.nav.dolly.util.CallIdUtil.generateCallId;
+import static no.nav.dolly.util.RequestTimeout.REQUEST_DURATION;
 import static no.nav.dolly.util.TokenXUtil.getUserJwt;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/pensjonforvalter/command/LagreTpYtelseCommand.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/pensjonforvalter/command/LagreTpYtelseCommand.java
@@ -15,11 +15,11 @@ import reactor.util.retry.Retry;
 import java.time.Duration;
 import java.util.concurrent.Callable;
 
-import static no.nav.dolly.bestilling.pensjonforvalter.PensjonforvalterConsumer.REQUEST_DURATION;
 import static no.nav.dolly.domain.CommonKeysAndUtils.CONSUMER;
 import static no.nav.dolly.domain.CommonKeysAndUtils.HEADER_NAV_CALL_ID;
 import static no.nav.dolly.domain.CommonKeysAndUtils.HEADER_NAV_CONSUMER_ID;
 import static no.nav.dolly.util.CallIdUtil.generateCallId;
+import static no.nav.dolly.util.RequestTimeout.REQUEST_DURATION;
 import static no.nav.dolly.util.TokenXUtil.getUserJwt;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/pensjonforvalter/command/LagreUforetrygdCommand.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/pensjonforvalter/command/LagreUforetrygdCommand.java
@@ -14,11 +14,11 @@ import reactor.util.retry.Retry;
 import java.time.Duration;
 import java.util.concurrent.Callable;
 
-import static no.nav.dolly.bestilling.pensjonforvalter.PensjonforvalterConsumer.REQUEST_DURATION;
 import static no.nav.dolly.domain.CommonKeysAndUtils.CONSUMER;
 import static no.nav.dolly.domain.CommonKeysAndUtils.HEADER_NAV_CALL_ID;
 import static no.nav.dolly.domain.CommonKeysAndUtils.HEADER_NAV_CONSUMER_ID;
 import static no.nav.dolly.util.CallIdUtil.generateCallId;
+import static no.nav.dolly.util.RequestTimeout.REQUEST_DURATION;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
 @Slf4j

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/tpsmessagingservice/command/EgenansattPostCommand.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/tpsmessagingservice/command/EgenansattPostCommand.java
@@ -9,6 +9,7 @@ import org.springframework.http.MediaType;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.netty.http.client.HttpClientRequest;
 import reactor.util.retry.Retry;
 
 import java.time.Duration;
@@ -18,6 +19,7 @@ import java.util.Optional;
 import java.util.concurrent.Callable;
 
 import static java.util.Objects.nonNull;
+import static no.nav.dolly.util.RequestTimeout.REQUEST_DURATION;
 
 @RequiredArgsConstructor
 @Slf4j
@@ -44,6 +46,10 @@ public class EgenansattPostCommand implements Callable<Flux<TpsMeldingResponseDT
                         .queryParamIfPresent(MILJOER_PARAM, nonNull(miljoer) ? Optional.of(miljoer) : Optional.empty())
                         .queryParam(EGENANSATT_FRA_PARAM, datoFra)
                         .build(ident))
+                .httpRequest(httpRequest -> {
+                    HttpClientRequest reactorRequest = httpRequest.getNativeRequest();
+                    reactorRequest.responseTimeout(Duration.ofSeconds(REQUEST_DURATION));
+                })
                 .contentType(MediaType.APPLICATION_JSON)
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                 .retrieve()

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/tpsmessagingservice/command/TpsMessagingPostCommand.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/tpsmessagingservice/command/TpsMessagingPostCommand.java
@@ -9,6 +9,7 @@ import org.springframework.http.MediaType;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.netty.http.client.HttpClientRequest;
 import reactor.util.retry.Retry;
 
 import java.time.Duration;
@@ -17,6 +18,7 @@ import java.util.Optional;
 import java.util.concurrent.Callable;
 
 import static java.util.Objects.nonNull;
+import static no.nav.dolly.util.RequestTimeout.REQUEST_DURATION;
 
 @RequiredArgsConstructor
 @Slf4j
@@ -41,6 +43,10 @@ public class TpsMessagingPostCommand implements Callable<Flux<TpsMeldingResponse
                         .path(urlPath)
                         .queryParamIfPresent(MILJOER_PARAM, nonNull(miljoer) ? Optional.of(miljoer) : Optional.empty())
                         .build(ident))
+                .httpRequest(httpRequest -> {
+                    HttpClientRequest reactorRequest = httpRequest.getNativeRequest();
+                    reactorRequest.responseTimeout(Duration.ofSeconds(REQUEST_DURATION));
+                })
                 .contentType(MediaType.APPLICATION_JSON)
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                 .bodyValue(body)

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/util/RequestTimeout.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/util/RequestTimeout.java
@@ -1,0 +1,9 @@
+package no.nav.dolly.util;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class RequestTimeout {
+
+    public static final int REQUEST_DURATION = 30000;
+}


### PR DESCRIPTION
#deploy-test-dolly-backend #deploy-dolly-backend

Implemented a standard timeout defined as REQUEST_DURATION constant used across multiple classes' httpClientRequests. This refactoring ensures the application aborts requests to prevent hang-ups due to slow or unresponsive servers.