### PR TITLE
Add error message inclusion across applications

### DIFF
--- a/apps/adresse-service/src/main/resources/application.yaml
+++ b/apps/adresse-service/src/main/resources/application.yaml
@@ -51,3 +51,5 @@ server:
   servlet:
     encoding:
       charset: UTF-8
+  error:
+    include-message: always

--- a/apps/amelding-service/src/main/resources/application.yml
+++ b/apps/amelding-service/src/main/resources/application.yml
@@ -44,3 +44,5 @@ server:
   servlet:
     encoding:
       charset: UTF-8
+  error:
+    include-message: always

--- a/apps/app-tilgang-analyse-service/src/main/resources/application.yml
+++ b/apps/app-tilgang-analyse-service/src/main/resources/application.yml
@@ -49,3 +49,5 @@ server:
   servlet:
     encoding:
       charset: UTF-8
+  error:
+    include-message: always

--- a/apps/arbeidsforhold-service/src/main/resources/application.yml
+++ b/apps/arbeidsforhold-service/src/main/resources/application.yml
@@ -47,3 +47,5 @@ server:
   servlet:
     encoding:
       charset: UTF-8
+  error:
+    include-message: always

--- a/apps/batch-bestilling-service/src/main/resources/application.yml
+++ b/apps/batch-bestilling-service/src/main/resources/application.yml
@@ -45,6 +45,8 @@ server:
   servlet:
     encoding:
       charset: UTF-8
+  error:
+    include-message: always
 
 consumers:
   dolly-backend:

--- a/apps/brreg-stub/src/main/resources/application.yaml
+++ b/apps/brreg-stub/src/main/resources/application.yaml
@@ -30,3 +30,5 @@ server:
   servlet:
     encoding:
       charset: UTF-8
+  error:
+    include-message: always

--- a/apps/bruker-service/src/main/resources/application.yml
+++ b/apps/bruker-service/src/main/resources/application.yml
@@ -45,3 +45,5 @@ server:
   servlet:
     encoding:
       charset: UTF-8
+  error:
+    include-message: always

--- a/apps/budpro-service/src/main/resources/application.yml
+++ b/apps/budpro-service/src/main/resources/application.yml
@@ -37,3 +37,10 @@ consumers:
 app:
   security:
     allow-api: true
+
+server:
+  servlet:
+    encoding:
+      charset: UTF-8
+  error:
+    include-message: always

--- a/apps/dolly-backend/src/main/resources/application.yaml
+++ b/apps/dolly-backend/src/main/resources/application.yaml
@@ -17,6 +17,8 @@ server:
       encoding:
         charset: UTF-8
     max-http-header-size: 70KB
+  error:
+    include-message: always
 
 spring:
   cloud:
@@ -82,11 +84,6 @@ open:
   search:
     total-fields: 1500
     index: bestilling
-
-tps:
-  person:
-    service:
-      wait: 30_000
 
 consumers:
   testnav-organisasjon-forvalter:

--- a/apps/dolly-frontend/src/main/resources/application.yml
+++ b/apps/dolly-frontend/src/main/resources/application.yml
@@ -27,6 +27,13 @@ spring:
           jwk-set-uri: ${TOKEN_X_JWKS_URI}
           accepted-audience: ${TOKEN_X_CLIENT_ID}
 
+server:
+  servlet:
+    encoding:
+      charset: UTF-8
+  error:
+    include-message: always
+
 consumers:
   testnav-tps-messaging-service:
     cluster: dev-gcp

--- a/apps/dolly-frontend/src/main/resources/application.yml
+++ b/apps/dolly-frontend/src/main/resources/application.yml
@@ -27,13 +27,6 @@ spring:
           jwk-set-uri: ${TOKEN_X_JWKS_URI}
           accepted-audience: ${TOKEN_X_CLIENT_ID}
 
-server:
-  servlet:
-    encoding:
-      charset: UTF-8
-  error:
-    include-message: always
-
 consumers:
   testnav-tps-messaging-service:
     cluster: dev-gcp
@@ -240,6 +233,8 @@ server:
   servlet:
     encoding:
       charset: UTF-8
+  error:
+    include-message: always
 
 logging:
   pattern:

--- a/apps/dollystatus/src/main/resources/application.yml
+++ b/apps/dollystatus/src/main/resources/application.yml
@@ -15,6 +15,8 @@ server:
   servlet:
     encoding:
       charset: UTF-8
+  error:
+    include-message: always
 
 logging:
   level:

--- a/apps/endringsmelding-frontend/src/main/resources/application.yml
+++ b/apps/endringsmelding-frontend/src/main/resources/application.yml
@@ -60,6 +60,8 @@ server:
   servlet:
     encoding:
       charset: UTF-8
+  error:
+    include-message: always
 
 logging:
   level:

--- a/apps/endringsmelding-service/src/main/resources/application.yml
+++ b/apps/endringsmelding-service/src/main/resources/application.yml
@@ -67,3 +67,5 @@ server:
   servlet:
     encoding:
       charset: UTF-8
+  error:
+    include-message: always

--- a/apps/ereg-batch-status-service/src/main/resources/application.yml
+++ b/apps/ereg-batch-status-service/src/main/resources/application.yml
@@ -51,3 +51,5 @@ server:
   servlet:
     encoding:
       charset: UTF-8
+  error:
+    include-message: always

--- a/apps/faste-data-frontend/src/main/resources/application.yml
+++ b/apps/faste-data-frontend/src/main/resources/application.yml
@@ -76,6 +76,8 @@ server:
   servlet:
     encoding:
       charset: UTF-8
+  error:
+    include-message: always
 
 logging:
   level:

--- a/apps/generer-arbeidsforhold-populasjon-service/src/main/resources/application.yml
+++ b/apps/generer-arbeidsforhold-populasjon-service/src/main/resources/application.yml
@@ -65,3 +65,5 @@ server:
   servlet:
     encoding:
       charset: UTF-8
+  error:
+    include-message: always

--- a/apps/generer-navn-service/src/main/resources/application.yml
+++ b/apps/generer-navn-service/src/main/resources/application.yml
@@ -46,3 +46,5 @@ server:
   servlet:
     encoding:
       charset: UTF-8
+  error:
+    include-message: always

--- a/apps/generer-organisasjon-populasjon-service/src/main/resources/application.yml
+++ b/apps/generer-organisasjon-populasjon-service/src/main/resources/application.yml
@@ -55,3 +55,5 @@ server:
   servlet:
     encoding:
       charset: UTF-8
+  error:
+    include-message: always

--- a/apps/geografiske-kodeverk-service/src/main/resources/application.yml
+++ b/apps/geografiske-kodeverk-service/src/main/resources/application.yml
@@ -40,3 +40,5 @@ server:
   servlet:
     encoding:
       charset: UTF-8
+  error:
+    include-message: always

--- a/apps/inntektsmelding-generator-service/src/main/resources/application.yml
+++ b/apps/inntektsmelding-generator-service/src/main/resources/application.yml
@@ -41,3 +41,5 @@ server:
   servlet:
     encoding:
       charset: UTF-8
+  error:
+    include-message: always

--- a/apps/jenkins-batch-status-service/src/main/resources/application.yml
+++ b/apps/jenkins-batch-status-service/src/main/resources/application.yml
@@ -55,3 +55,5 @@ server:
   servlet:
     encoding:
       charset: UTF-8
+  error:
+    include-message: always

--- a/apps/joark-dokument-service/src/main/resources/application.yml
+++ b/apps/joark-dokument-service/src/main/resources/application.yml
@@ -48,3 +48,5 @@ server:
   servlet:
     encoding:
       charset: UTF-8
+  error:
+    include-message: always

--- a/apps/miljoer-service/src/main/resources/application.yml
+++ b/apps/miljoer-service/src/main/resources/application.yml
@@ -48,3 +48,5 @@ server:
   servlet:
     encoding:
       charset: UTF-8
+  error:
+    include-message: always

--- a/apps/oppsummeringsdokument-service/src/main/resources/application.yml
+++ b/apps/oppsummeringsdokument-service/src/main/resources/application.yml
@@ -47,3 +47,5 @@ server:
   servlet:
     encoding:
       charset: UTF-8
+  error:
+    include-message: always

--- a/apps/organisasjon-bestilling-service/src/main/resources/application.yml
+++ b/apps/organisasjon-bestilling-service/src/main/resources/application.yml
@@ -56,3 +56,5 @@ server:
   servlet:
     encoding:
       charset: UTF-8
+  error:
+    include-message: always

--- a/apps/organisasjon-faste-data-service/src/main/resources/application.yml
+++ b/apps/organisasjon-faste-data-service/src/main/resources/application.yml
@@ -55,3 +55,5 @@ server:
   servlet:
     encoding:
       charset: UTF-8
+  error:
+    include-message: always

--- a/apps/organisasjon-forvalter/src/main/resources/application.yml
+++ b/apps/organisasjon-forvalter/src/main/resources/application.yml
@@ -77,3 +77,5 @@ server:
   servlet:
     encoding:
       charset: UTF-8
+  error:
+    include-message: always

--- a/apps/organisasjon-mottak-service/src/main/resources/application.yml
+++ b/apps/organisasjon-mottak-service/src/main/resources/application.yml
@@ -65,3 +65,5 @@ server:
   servlet:
     encoding:
       charset: UTF-8
+  error:
+    include-message: always

--- a/apps/organisasjon-service/src/main/resources/application.yml
+++ b/apps/organisasjon-service/src/main/resources/application.yml
@@ -51,3 +51,5 @@ server:
   servlet:
     encoding:
       charset: UTF-8
+  error:
+    include-message: always

--- a/apps/organisasjon-tilgang-frontend/src/main/resources/application.yml
+++ b/apps/organisasjon-tilgang-frontend/src/main/resources/application.yml
@@ -51,3 +51,5 @@ server:
   servlet:
     encoding:
       charset: UTF-8
+  error:
+    include-message: always

--- a/apps/organisasjon-tilgang-service/src/main/resources/application.yml
+++ b/apps/organisasjon-tilgang-service/src/main/resources/application.yml
@@ -55,3 +55,5 @@ server:
   servlet:
     encoding:
       charset: UTF-8
+  error:
+    include-message: always

--- a/apps/orgnummer-service/src/main/resources/application.yml
+++ b/apps/orgnummer-service/src/main/resources/application.yml
@@ -60,3 +60,5 @@ server:
   servlet:
     encoding:
       charset: UTF-8
+  error:
+    include-message: always

--- a/apps/oversikt-frontend/src/main/resources/application.yml
+++ b/apps/oversikt-frontend/src/main/resources/application.yml
@@ -55,6 +55,8 @@ server:
   servlet:
     encoding:
       charset: UTF-8
+  error:
+    include-message: always
 
 logging:
   level:

--- a/apps/pdl-forvalter/src/main/resources/application.yaml
+++ b/apps/pdl-forvalter/src/main/resources/application.yaml
@@ -71,3 +71,5 @@ server:
   servlet:
     encoding:
       charset: UTF-8
+  error:
+    include-message: always

--- a/apps/person-faste-data-service/src/main/resources/application.yml
+++ b/apps/person-faste-data-service/src/main/resources/application.yml
@@ -46,3 +46,5 @@ server:
   servlet:
     encoding:
       charset: UTF-8
+  error:
+    include-message: always

--- a/apps/person-organisasjon-tilgang-service/src/main/resources/application.yml
+++ b/apps/person-organisasjon-tilgang-service/src/main/resources/application.yml
@@ -50,3 +50,5 @@ server:
   servlet:
     encoding:
       charset: UTF-8
+  error:
+    include-message: always

--- a/apps/person-search-service/src/main/resources/application.yml
+++ b/apps/person-search-service/src/main/resources/application.yml
@@ -58,3 +58,5 @@ server:
   servlet:
     encoding:
       charset: UTF-8
+  error:
+    include-message: always

--- a/apps/person-service/src/main/resources/application.yml
+++ b/apps/person-service/src/main/resources/application.yml
@@ -60,3 +60,5 @@ server:
   servlet:
     encoding:
       charset: UTF-8
+  error:
+    include-message: always

--- a/apps/profil-api/src/main/resources/application.yml
+++ b/apps/profil-api/src/main/resources/application.yml
@@ -55,3 +55,5 @@ server:
   servlet:
     encoding:
       charset: UTF-8
+  error:
+    include-message: always

--- a/apps/sykemelding-api/src/main/resources/application.yml
+++ b/apps/sykemelding-api/src/main/resources/application.yml
@@ -48,6 +48,8 @@ server:
   servlet:
     encoding:
       charset: UTF-8
+  error:
+    include-message: always
 ibm:
   mq:
     queueManager: ${IBM_MQ_QUEUE_MANAGER}

--- a/apps/synt-sykemelding-api/src/main/resources/application.yml
+++ b/apps/synt-sykemelding-api/src/main/resources/application.yml
@@ -76,3 +76,5 @@ server:
   servlet:
     encoding:
       charset: UTF-8
+  error:
+    include-message: always

--- a/apps/synt-vedtakshistorikk-service/src/main/resources/application.yml
+++ b/apps/synt-vedtakshistorikk-service/src/main/resources/application.yml
@@ -16,7 +16,6 @@ spring:
     vault:
       enabled: false
 
-
 springdoc:
   swagger-ui:
     disable-swagger-default-url: true
@@ -83,3 +82,5 @@ server:
   servlet:
     encoding:
       charset: UTF-8
+  error:
+    include-message: always

--- a/apps/testnav-ident-pool/src/main/resources/application.yaml
+++ b/apps/testnav-ident-pool/src/main/resources/application.yaml
@@ -62,3 +62,10 @@ consumers:
         cluster: dev-gcp
         namespace: dolly
         name: testnav-tps-messaging-service
+
+server:
+  servlet:
+    encoding:
+      charset: UTF-8
+  error:
+    include-message: always

--- a/apps/testnorge-statisk-data-forvalter/src/main/resources/application.yml
+++ b/apps/testnorge-statisk-data-forvalter/src/main/resources/application.yml
@@ -97,3 +97,5 @@ server:
   servlet:
     encoding:
       charset: UTF-8
+  error:
+    include-message: always

--- a/apps/tilbakemelding-api/src/main/resources/application.yml
+++ b/apps/tilbakemelding-api/src/main/resources/application.yml
@@ -52,3 +52,5 @@ server:
   servlet:
     encoding:
       charset: UTF-8
+  error:
+    include-message: always

--- a/apps/tps-messaging-service/src/main/resources/application.yaml
+++ b/apps/tps-messaging-service/src/main/resources/application.yaml
@@ -69,3 +69,5 @@ server:
   servlet:
     encoding:
       charset: UTF-8
+  error:
+    include-message: always

--- a/apps/udi-stub/src/main/resources/application.yml
+++ b/apps/udi-stub/src/main/resources/application.yml
@@ -48,4 +48,6 @@ server:
   servlet:
     encoding:
       charset: UTF-8
+  error:
+    include-message: always
 

--- a/apps/varslinger-service/src/main/resources/application.yml
+++ b/apps/varslinger-service/src/main/resources/application.yml
@@ -43,3 +43,5 @@ server:
   servlet:
     encoding:
       charset: UTF-8
+  error:
+    include-message: always

--- a/proxies/aareg-proxy/src/main/resources/application.yaml
+++ b/proxies/aareg-proxy/src/main/resources/application.yaml
@@ -28,6 +28,13 @@ springdoc:
     disable-swagger-default-url: true
     url: /v3/api-docs
 
+server:
+  servlet:
+    encoding:
+      charset: UTF-8
+  error:
+    include-message: always
+
 consumers:
     aareg-services:
       name: aareg-services-nais-{env}

--- a/proxies/aareg-synt-services-proxy/src/main/resources/application.yml
+++ b/proxies/aareg-synt-services-proxy/src/main/resources/application.yml
@@ -21,3 +21,10 @@ spring:
         response-timeout: 600s
     vault:
       enabled: false
+
+server:
+  servlet:
+    encoding:
+      charset: UTF-8
+  error:
+    include-message: always

--- a/proxies/arbeidsplassencv-proxy/src/main/resources/application.yml
+++ b/proxies/arbeidsplassencv-proxy/src/main/resources/application.yml
@@ -22,6 +22,13 @@ spring:
     vault:
       enabled: false
 
+server:
+  servlet:
+    encoding:
+      charset: UTF-8
+  error:
+    include-message: always
+
 consumers:
   arbeidsplassencv:
     name: pam-cv-api-gcp

--- a/proxies/arena-forvalteren-proxy/src/main/resources/application.yml
+++ b/proxies/arena-forvalteren-proxy/src/main/resources/application.yml
@@ -22,6 +22,13 @@ spring:
     vault:
       enabled: false
 
+server:
+  servlet:
+    encoding:
+      charset: UTF-8
+  error:
+    include-message: always
+
 consumers:
   arena-services:
     name: arena-services-MILJOE

--- a/proxies/batch-adeo-proxy/src/main/resources/application.yml
+++ b/proxies/batch-adeo-proxy/src/main/resources/application.yml
@@ -21,3 +21,10 @@ spring:
         response-timeout: 30s
     vault:
       enabled: false
+
+server:
+  servlet:
+    encoding:
+      charset: UTF-8
+  error:
+    include-message: always

--- a/proxies/brregstub-proxy/src/main/resources/application.yml
+++ b/proxies/brregstub-proxy/src/main/resources/application.yml
@@ -21,3 +21,10 @@ spring:
         response-timeout: 30s
     vault:
       enabled: false
+
+server:
+  servlet:
+    encoding:
+      charset: UTF-8
+  error:
+    include-message: always

--- a/proxies/dokarkiv-proxy/src/main/resources/application.yml
+++ b/proxies/dokarkiv-proxy/src/main/resources/application.yml
@@ -22,6 +22,13 @@ spring:
     vault:
       enabled: false
 
+server:
+  servlet:
+    encoding:
+      charset: UTF-8
+  error:
+    include-message: always
+
 consumers:
   dokarkiv:
     url: http://dokarkiv-MILJOE.teamdokumenthandtering.svc.nais.local

--- a/proxies/ereg-proxy/src/main/resources/application.yml
+++ b/proxies/ereg-proxy/src/main/resources/application.yml
@@ -19,3 +19,10 @@ spring:
     gateway:
       httpclient:
         response-timeout: 120s
+
+server:
+  servlet:
+    encoding:
+      charset: UTF-8
+  error:
+    include-message: always

--- a/proxies/histark-proxy/src/main/resources/application.yml
+++ b/proxies/histark-proxy/src/main/resources/application.yml
@@ -21,3 +21,10 @@ spring:
         response-timeout: 600s
     vault:
       enabled: false
+
+server:
+  servlet:
+    encoding:
+      charset: UTF-8
+  error:
+    include-message: always

--- a/proxies/inntektstub-proxy/src/main/resources/application.yml
+++ b/proxies/inntektstub-proxy/src/main/resources/application.yml
@@ -21,3 +21,10 @@ spring:
         response-timeout: 600s
     vault:
       enabled: false
+
+server:
+  servlet:
+    encoding:
+      charset: UTF-8
+  error:
+    include-message: always

--- a/proxies/inst-proxy/src/main/resources/application.yml
+++ b/proxies/inst-proxy/src/main/resources/application.yml
@@ -22,6 +22,13 @@ spring:
       httpclient:
         response-timeout: 180s
 
+server:
+  servlet:
+    encoding:
+      charset: UTF-8
+  error:
+    include-message: always
+
 consumers:
   inst:
     name: opphold-testdata

--- a/proxies/kontoregister-person-proxy/src/main/resources/application.yml
+++ b/proxies/kontoregister-person-proxy/src/main/resources/application.yml
@@ -22,6 +22,13 @@ spring:
     vault:
       enabled: false
 
+server:
+  servlet:
+    encoding:
+      charset: UTF-8
+  error:
+    include-message: always
+
 consumers:
   kontoregister:
     name: sokos-kontoregister-person

--- a/proxies/krrstub-proxy/src/main/resources/application.yml
+++ b/proxies/krrstub-proxy/src/main/resources/application.yml
@@ -22,6 +22,13 @@ spring:
     vault:
       enabled: false
 
+server:
+  servlet:
+    encoding:
+      charset: UTF-8
+  error:
+    include-message: always
+
 consumers:
   krrstub:
     name: digdir-krr-stub

--- a/proxies/medl-proxy/src/main/resources/application.yml
+++ b/proxies/medl-proxy/src/main/resources/application.yml
@@ -22,6 +22,13 @@ spring:
     vault:
       enabled: false
 
+server:
+  servlet:
+    encoding:
+      charset: UTF-8
+  error:
+    include-message: always
+
 consumers:
   medlstub:
     name: medlemskap-medl-testdata

--- a/proxies/norg2-proxy/src/main/resources/application.yml
+++ b/proxies/norg2-proxy/src/main/resources/application.yml
@@ -19,3 +19,10 @@ spring:
     gateway:
       httpclient:
         response-timeout: 600s
+
+server:
+  servlet:
+    encoding:
+      charset: UTF-8
+  error:
+    include-message: always

--- a/proxies/pdl-proxy/src/main/resources/application.yml
+++ b/proxies/pdl-proxy/src/main/resources/application.yml
@@ -25,6 +25,13 @@ sts:
     provider:
       url: https://security-token-service.dev.adeo.no/rest/v1/sts/token
 
+server:
+  servlet:
+    encoding:
+      charset: UTF-8
+  error:
+    include-message: always
+
 consumers:
   pdl-testdata:
     url: http://pdl-testdata.pdl.svc.nais.local

--- a/proxies/pensjon-testdata-facade-proxy/src/main/resources/application.yml
+++ b/proxies/pensjon-testdata-facade-proxy/src/main/resources/application.yml
@@ -22,6 +22,13 @@ spring:
     vault:
       enabled: false
 
+server:
+  servlet:
+    encoding:
+      charset: UTF-8
+  error:
+    include-message: always
+
 consumers:
   samboer-testdata:
     name: pensjon-samboerforhold-backend-MILJOE

--- a/proxies/saf-proxy/src/main/resources/application.yml
+++ b/proxies/saf-proxy/src/main/resources/application.yml
@@ -22,6 +22,13 @@ spring:
     vault:
       enabled: false
 
+server:
+  servlet:
+    encoding:
+      charset: UTF-8
+  error:
+    include-message: always
+
 consumers:
   saf:
     url: http://saf-MILJOE.teamdokumenthandtering.svc.nais.local

--- a/proxies/sigrunstub-proxy/src/main/resources/application.yml
+++ b/proxies/sigrunstub-proxy/src/main/resources/application.yml
@@ -21,3 +21,10 @@ spring:
         response-timeout: 600s
     vault:
       enabled: false
+
+server:
+  servlet:
+    encoding:
+      charset: UTF-8
+  error:
+    include-message: always

--- a/proxies/skjermingsregister-proxy/src/main/resources/application.yml
+++ b/proxies/skjermingsregister-proxy/src/main/resources/application.yml
@@ -22,6 +22,13 @@ spring:
       httpclient:
         response-timeout: 30s
 
+server:
+  servlet:
+    encoding:
+      charset: UTF-8
+  error:
+    include-message: always
+
 consumers:
   skjermingsregister:
     name: skjermede-personer

--- a/proxies/synthdata-meldekort-proxy/src/main/resources/application.yml
+++ b/proxies/synthdata-meldekort-proxy/src/main/resources/application.yml
@@ -15,6 +15,13 @@ spring:
     vault:
       enabled: false
 
+server:
+  servlet:
+    encoding:
+      charset: UTF-8
+  error:
+    include-message: always
+
 consumers:
   synt-meldekort:
     url: https://synthdata-arena-meldekort.intern.dev.nav.no

--- a/proxies/tps-forvalteren-proxy/src/main/resources/application.yml
+++ b/proxies/tps-forvalteren-proxy/src/main/resources/application.yml
@@ -19,3 +19,10 @@ spring:
     gateway:
       httpclient:
         response-timeout: 1200s
+
+server:
+  servlet:
+    encoding:
+      charset: UTF-8
+  error:
+    include-message: always

--- a/proxies/udistub-proxy/src/main/resources/application.yml
+++ b/proxies/udistub-proxy/src/main/resources/application.yml
@@ -20,6 +20,13 @@ spring:
       httpclient:
         response-timeout: 1200s
 
+server:
+  servlet:
+    encoding:
+      charset: UTF-8
+  error:
+    include-message: always
+
 consumers:
   testnav-udistub:
     url: http://testnav-udi-stub.dolly.svc.nais.local


### PR DESCRIPTION
The configuration changes mean error messages will now be included in API responses for all applications. This improves error traceability and debugging. Changes were made in the 'application.yml' or 'application.yaml' files across multiple applications.