### PR TITLE
Add new AzureAdApplication and GitHub workflow files

### DIFF
--- a/.github/workflows/app.team-dolly-lokal-app.yml
+++ b/.github/workflows/app.team-dolly-lokal-app.yml
@@ -1,0 +1,21 @@
+name: team-dolly-lokal-app
+
+on:
+  push:
+    paths:
+      - .nais/team-dolly-lokal-app.yml
+      - .github/workflows/app.team-dolly-lokal-app.yml
+
+jobs:
+  deploy-redis:
+    name: Deploy team-dolly-lokal-app
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: nais/deploy/actions/deploy@v2
+        env:
+          CLUSTER: dev-gcp
+          RESOURCE: .nais/team-dolly-lokal-app.yml

--- a/.nais/team-dolly-lokal-app.yml
+++ b/.nais/team-dolly-lokal-app.yml
@@ -9,7 +9,7 @@ spec:
   logoutUrl: https://localhost:8080/oauth2/logout
   preAuthorizedApplications:
     - application: testnorge-oversikt-frontend
-      cluster: dev-fss
+      cluster: dev-gcp
       namespace: dolly
   replyUrls:
     - url: http://localhost:8080/login/oauth2/code/aad

--- a/.nais/team-dolly-lokal-app.yml
+++ b/.nais/team-dolly-lokal-app.yml
@@ -1,0 +1,17 @@
+apiVersion: nais.io/v1
+kind: AzureAdApplication
+metadata:
+  labels:
+    team: dolly
+  name: team-dolly-lokal-app
+  namespace: dolly
+spec:
+  logoutUrl: https://localhost:8080/oauth2/logout
+  preAuthorizedApplications:
+    - application: testnorge-oversikt-frontend
+      cluster: dev-fss
+      namespace: dolly
+  replyUrls:
+    - url: http://localhost:8080/login/oauth2/code/aad
+  secretName: azuread-team-dolly-lokal-app
+  tenant: nav.no


### PR DESCRIPTION
This commit creates a new AzureAdApplication named team-dolly-lokal-app. The configuration includes specific pre-authorized applications, a logoutURL, and various other details. Additionally, a new GitHub workflow file for deploying this application is added, which includes the necessary steps, permissions, and uses the new team-dolly-lokal-app.yml for deployment.