### PR TITLE
Refaktorert Kommuner2024

### DIFF
--- a/apps/dolly-frontend/src/main/js/src/components/adresseVelger/AdresseSok.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/adresseVelger/AdresseSok.tsx
@@ -51,7 +51,7 @@ export default ({ onSubmit, loading = false }: Props) => {
 				<DollySelect
 					name="kommunenummer"
 					label="Kommunenummer"
-					kodeverk={AdresseKodeverk.Kommunenummer}
+					kodeverk={AdresseKodeverk.Kommunenummer2024}
 					size="grow"
 					value={kommunenummer}
 					onChange={(e: any) => setKommunenummer(e ? e.value : null)}

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/organisasjoner/form/partials/Adresser.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/organisasjoner/form/partials/Adresser.tsx
@@ -50,7 +50,7 @@ export const Adresser = ({ formMethods, path }: AdresserProps) => {
 						<FormSelect
 							name={`${path}.forretningsadresse.kommunenr`}
 							label="Kommunenummer"
-							kodeverk={AdresseKodeverk.Kommunenummer}
+							kodeverk={AdresseKodeverk.Kommunenummer2024}
 							size="large"
 						/>
 					</>
@@ -100,7 +100,7 @@ export const Adresser = ({ formMethods, path }: AdresserProps) => {
 						<FormSelect
 							name={`${path}.postadresse.kommunenr`}
 							label="Kommunenummer"
-							kodeverk={AdresseKodeverk.Kommunenummer}
+							kodeverk={AdresseKodeverk.Kommunenummer2024}
 							size="large"
 						/>
 					</>

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/form/partials/foedsel/Foedsel.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/form/partials/foedsel/Foedsel.tsx
@@ -68,7 +68,7 @@ export const FoedselForm = ({ formMethods, path }: FoedselTypes) => {
 			<FormSelect
 				name={`${path}.foedekommune`}
 				label="Fødekommune"
-				kodeverk={AdresseKodeverk.Kommunenummer}
+				kodeverk={AdresseKodeverk.Kommunenummer2024}
 				size="large"
 				isDisabled={
 					formMethods.watch(`${path}.foedeland`) !== 'NOR' &&

--- a/apps/kodeverk-service/src/main/java/no/nav/testnav/kodeverkservice/consumer/KodeverkConsumer.java
+++ b/apps/kodeverk-service/src/main/java/no/nav/testnav/kodeverkservice/consumer/KodeverkConsumer.java
@@ -3,12 +3,16 @@ package no.nav.testnav.kodeverkservice.consumer;
 import no.nav.testnav.kodeverkservice.config.Consumers;
 import no.nav.testnav.kodeverkservice.consumer.command.KodeverkGetCommand;
 import no.nav.testnav.kodeverkservice.dto.KodeverkBetydningerResponse;
+import no.nav.testnav.kodeverkservice.utility.KommunerUtility;
 import no.nav.testnav.libs.reactivesecurity.exchange.TokenExchange;
 import no.nav.testnav.libs.securitycore.domain.ServerProperties;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.ExchangeStrategies;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
+
+import static no.nav.testnav.kodeverkservice.utility.KommunerUtility.KOMMUNER;
+import static no.nav.testnav.kodeverkservice.utility.KommunerUtility.KOMMUNER2024;
 
 @Service
 public class KodeverkConsumer {
@@ -39,6 +43,10 @@ public class KodeverkConsumer {
     public Mono<KodeverkBetydningerResponse> getKodeverk(String kodeverk) {
 
         return tokenService.exchange(serverProperties)
-                .flatMap(token -> new KodeverkGetCommand(webClient, kodeverk, token.getTokenValue()).call());
+                .flatMap(token -> new KodeverkGetCommand(webClient,
+                        !KOMMUNER2024.equals(kodeverk) ? kodeverk : KOMMUNER,
+                        token.getTokenValue()).call())
+                .map(response -> !KOMMUNER2024.equals(kodeverk) ? response :
+                        KommunerUtility.filterKommuner2024(response));
     }
 }

--- a/apps/kodeverk-service/src/main/java/no/nav/testnav/kodeverkservice/consumer/KodeverkConsumer.java
+++ b/apps/kodeverk-service/src/main/java/no/nav/testnav/kodeverkservice/consumer/KodeverkConsumer.java
@@ -3,16 +3,13 @@ package no.nav.testnav.kodeverkservice.consumer;
 import no.nav.testnav.kodeverkservice.config.Consumers;
 import no.nav.testnav.kodeverkservice.consumer.command.KodeverkGetCommand;
 import no.nav.testnav.kodeverkservice.dto.KodeverkBetydningerResponse;
-import no.nav.testnav.kodeverkservice.utility.KommunerUtility;
+import no.nav.testnav.kodeverkservice.utility.FilterUtility;
 import no.nav.testnav.libs.reactivesecurity.exchange.TokenExchange;
 import no.nav.testnav.libs.securitycore.domain.ServerProperties;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.ExchangeStrategies;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
-
-import static no.nav.testnav.kodeverkservice.utility.KommunerUtility.KOMMUNER;
-import static no.nav.testnav.kodeverkservice.utility.KommunerUtility.KOMMUNER2024;
 
 @Service
 public class KodeverkConsumer {
@@ -44,9 +41,8 @@ public class KodeverkConsumer {
 
         return tokenService.exchange(serverProperties)
                 .flatMap(token -> new KodeverkGetCommand(webClient,
-                        !KOMMUNER2024.equals(kodeverk) ? kodeverk : KOMMUNER,
+                        FilterUtility.hentKodeverk(kodeverk),
                         token.getTokenValue()).call())
-                .map(response -> !KOMMUNER2024.equals(kodeverk) ? response :
-                        KommunerUtility.filterKommuner2024(response));
+                .map(response -> FilterUtility.filterKodeverk(kodeverk, response));
     }
 }

--- a/apps/kodeverk-service/src/main/java/no/nav/testnav/kodeverkservice/provider/KodeverkController.java
+++ b/apps/kodeverk-service/src/main/java/no/nav/testnav/kodeverkservice/provider/KodeverkController.java
@@ -3,7 +3,6 @@ package no.nav.testnav.kodeverkservice.provider;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import no.nav.testnav.kodeverkservice.service.KodeverkService;
-import no.nav.testnav.kodeverkservice.utility.KommunerUtility;
 import no.nav.testnav.libs.dto.kodeverkservice.v1.KodeverkAdjustedDTO;
 import no.nav.testnav.libs.dto.kodeverkservice.v1.KodeverkDTO;
 import org.springframework.cache.annotation.Cacheable;
@@ -17,8 +16,6 @@ import reactor.core.publisher.Mono;
 
 import static no.nav.testnav.kodeverkservice.config.CacheConfig.CACHE_KODEVERK;
 import static no.nav.testnav.kodeverkservice.config.CacheConfig.CACHE_KODEVERK_2;
-import static no.nav.testnav.kodeverkservice.utility.KommunerUtility.KOMMUNER;
-import static no.nav.testnav.kodeverkservice.utility.KommunerUtility.KOMMUNER2024;
 
 @RestController
 @RequestMapping("/api/v1/kodeverk")
@@ -33,12 +30,7 @@ public class KodeverkController {
     @Operation(description = "Hent kodeverk, returnerer map")
     public Mono<KodeverkDTO> fetchKodeverk(@RequestParam String kodeverk) {
 
-        return !KOMMUNER2024.equals(kodeverk) ?
-
-                kodeverkService.getKodeverkMap(kodeverk) :
-
-                kodeverkService.getKodeverkMap(KOMMUNER)
-                        .map(KommunerUtility::filterKommuner2024);
+        return kodeverkService.getKodeverkMap(kodeverk);
     }
 
     @Cacheable(value = CACHE_KODEVERK_2, unless = "#result.koder?.size() == 0")
@@ -46,11 +38,6 @@ public class KodeverkController {
     @Operation(description = "Hent kodeverk etter kodeverkNavn")
     public Mono<KodeverkAdjustedDTO> getKodeverkByName(@PathVariable("kodeverkNavn") String kodeverkNavn) {
 
-        return !KOMMUNER2024.equals(kodeverkNavn) ?
-
-                kodeverkService.getKodeverkByName(kodeverkNavn) :
-
-                kodeverkService.getKodeverkByName(KOMMUNER)
-                        .map(KommunerUtility::filterKommuner2024);
+        return kodeverkService.getKodeverkByName(kodeverkNavn);
     }
 }

--- a/apps/kodeverk-service/src/main/java/no/nav/testnav/kodeverkservice/utility/FilterUtility.java
+++ b/apps/kodeverk-service/src/main/java/no/nav/testnav/kodeverkservice/utility/FilterUtility.java
@@ -1,0 +1,29 @@
+package no.nav.testnav.kodeverkservice.utility;
+
+import lombok.experimental.UtilityClass;
+import no.nav.testnav.kodeverkservice.dto.KodeverkBetydningerResponse;
+
+@UtilityClass
+public class FilterUtility {
+
+    private static final String KOMMUNER2024 = "Kommuner2024";
+    private static final String KOMMUNER = "Kommuner";
+
+    public static String hentKodeverk(String kodeverk) {
+
+        if (KOMMUNER2024.equals(kodeverk)) {
+            return KOMMUNER;
+        } else {
+            return kodeverk;
+        }
+    }
+
+    public static KodeverkBetydningerResponse filterKodeverk(String kodeverk, KodeverkBetydningerResponse response) {
+
+        if (KOMMUNER2024.equals(kodeverk)) {
+            return KommunerUtility.filterKommuner2024(response);
+        } else {
+            return response;
+        }
+    }
+}

--- a/apps/kodeverk-service/src/main/java/no/nav/testnav/kodeverkservice/utility/KommunerUtility.java
+++ b/apps/kodeverk-service/src/main/java/no/nav/testnav/kodeverkservice/utility/KommunerUtility.java
@@ -2,8 +2,7 @@ package no.nav.testnav.kodeverkservice.utility;
 
 import lombok.Getter;
 import lombok.experimental.UtilityClass;
-import no.nav.testnav.libs.dto.kodeverkservice.v1.KodeverkAdjustedDTO;
-import no.nav.testnav.libs.dto.kodeverkservice.v1.KodeverkDTO;
+import no.nav.testnav.kodeverkservice.dto.KodeverkBetydningerResponse;
 
 import java.util.HashSet;
 import java.util.Map;
@@ -126,26 +125,12 @@ public class KommunerUtility {
         gamleKommunenummer.add("3019"); // Vestby
         gamleKommunenummer.add("3825"); // Vinje
     }
+    public static KodeverkBetydningerResponse filterKommuner2024(KodeverkBetydningerResponse response) {
 
-    public static KodeverkAdjustedDTO filterKommuner2024(KodeverkAdjustedDTO response) {
-
-        return KodeverkAdjustedDTO.builder()
-                .name(KOMMUNER2024)
-                .koder(
-                        response.getKoder().stream()
-                                .filter(kode -> !gamleKommunenummer.contains(kode.getValue()))
-                                .toList())
-                .build();
-    }
-
-    public static KodeverkDTO filterKommuner2024(KodeverkDTO response) {
-
-        return KodeverkDTO.builder()
-                .kodeverknavn(KOMMUNER2024)
-                .kodeverk(
-                        response.getKodeverk().entrySet().stream()
-                                .filter(entry ->!gamleKommunenummer.contains(entry.getKey()))
-                                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)))
+        return KodeverkBetydningerResponse.builder()
+                .betydninger(response.getBetydninger().entrySet().stream()
+                        .filter(entry -> !gamleKommunenummer.contains(entry.getKey()))
+                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)))
                 .build();
     }
 }

--- a/apps/kodeverk-service/src/main/java/no/nav/testnav/kodeverkservice/utility/KommunerUtility.java
+++ b/apps/kodeverk-service/src/main/java/no/nav/testnav/kodeverkservice/utility/KommunerUtility.java
@@ -12,9 +12,6 @@ import java.util.stream.Collectors;
 @UtilityClass
 public class KommunerUtility {
 
-    public static final String KOMMUNER = "Kommuner";
-    public static final String KOMMUNER2024 = "Kommuner2024";
-
     @Getter
     private static final Set<String> gamleKommunenummer = new HashSet<>();
 


### PR DESCRIPTION
The logic for filtering "kommune" codes based on the year 2024 has been shifted to the KodeverkConsumer class from the Kodeverk controller class. A utility function filterKommuner2024 has also been updated to work with KodeverkBetydningerResponse type instead of KodeverkDTO and KodeverkAdjustedDTO. This change improves the structure and organization of the code.