### PR TITLE
Fjerner sjekk for kommunenr på adresser i org-faste-data-service

### DIFF
--- a/apps/organisasjon-faste-data-service/src/main/java/no/nav/registre/testnorge/organisasjonfastedataservice/consumer/OrganisasjonMottakConsumer.java
+++ b/apps/organisasjon-faste-data-service/src/main/java/no/nav/registre/testnorge/organisasjonfastedataservice/consumer/OrganisasjonMottakConsumer.java
@@ -12,7 +12,6 @@ import no.nav.testnav.libs.avro.organisasjon.v1.Metadata;
 import no.nav.testnav.libs.avro.organisasjon.v1.Opprettelsesdokument;
 import no.nav.testnav.libs.kafkaproducers.organisasjon.v2.EndringsdokumentV2Producer;
 import no.nav.testnav.libs.kafkaproducers.organisasjon.v2.OpprettelsesdokumentV2Producer;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 
 import java.util.Optional;
@@ -84,11 +83,6 @@ public class OrganisasjonMottakConsumer {
 
     private no.nav.testnav.libs.avro.organisasjon.v1.Adresse create(Adresse adresse) {
         if (adresse == null) {
-            return null;
-        }
-
-        if (StringUtils.isBlank(adresse.getKommunenr())) {
-            log.warn("Kommunenr kan ikke være null. Adresse blir satt til null.");
             return null;
         }
 


### PR DESCRIPTION
Denne sjekken gjør at resten av adresse ikke sendes inn dersom kommunenummer mangler, men ser det er flere tilfeller av slike org i q2 og de andre miljøene allerede, tilsynelatende uten feil. 