### PR TITLE
change/health-endpoint-details

### DIFF
--- a/apps/dolly-backend/src/main/resources/application.yaml
+++ b/apps/dolly-backend/src/main/resources/application.yaml
@@ -65,8 +65,13 @@ management:
       path-mapping:
         prometheus: metrics
   endpoint:
-    prometheus.enabled: true
-    heapdump.enabled: true
+    health:
+      show-components: always
+      show-details: always
+    heapdump:
+      enabled: true
+    prometheus:
+      enabled: true
   prometheus:
     metrics:
       export:


### PR DESCRIPTION
Mer detaljert output fra health actuator, som rapporterer status down (men HTTP 200, så det er OK for NAIS).