### PR TITLE
Refactor PdlPerson class to handle birth details

### DIFF
--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/brregstub/mapper/BrregRolleMappingStrategy.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/brregstub/mapper/BrregRolleMappingStrategy.java
@@ -38,9 +38,9 @@ public class BrregRolleMappingStrategy implements MappingStrategy {
                         rolleoversiktTo.setAdresse(mapperFacade.map(personBolk.getPerson(), AdresseTo.class));
                         rolleoversiktTo.setEnheter(mapperFacade.mapAsList(bregdata.getEnheter(), RolleTo.class));
                         rolleoversiktTo.setFnr(personBolk.getIdent());
-                        rolleoversiktTo.setFodselsdato(personBolk.getPerson().getFoedsel().stream().findFirst()
-                                .orElse(new PdlPerson.Foedsel())
-                                .getFoedselsdato());
+                        rolleoversiktTo.setFodselsdato(personBolk.getPerson().getFoedselsdato().stream()
+                                .map(PdlPerson.Foedselsdato::getFoedselsdato)
+                                .findFirst().orElse(null));
                         rolleoversiktTo.setHovedstatus(0);
                         rolleoversiktTo.setNavn(mapperFacade.map(personBolk.getPerson().getNavn().stream().findFirst()
                                 .orElse(new PdlPerson.Navn()), NavnTo.class));
@@ -66,7 +66,7 @@ public class BrregRolleMappingStrategy implements MappingStrategy {
                     public void mapAtoB(PdlPerson.Person person, AdresseTo adresseTo, MappingContext context) {
 
                         if (!person.getBostedsadresse().isEmpty()) {
-                            var adresse = person.getBostedsadresse().get(0);
+                            var adresse = person.getBostedsadresse().getFirst();
                             if (nonNull(adresse.getVegadresse())) {
                                 adresseTo.setAdresse1(format("%s %s", adresse.getVegadresse().getAdressenavn(),
                                         adresse.getVegadresse().getHusnummer()));

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/pensjonforvalter/mapper/PensjonPersonMappingStrategy.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/pensjonforvalter/mapper/PensjonPersonMappingStrategy.java
@@ -42,8 +42,8 @@ public class PensjonPersonMappingStrategy implements MappingStrategy {
 
                         pensjonPersonRequest.setFnr(person.getIdent());
 
-                        pensjonPersonRequest.setFodselsDato(getFoedselsdato(person.getPerson().getFoedsel().stream()
-                                .map(PdlPerson.Foedsel::getFoedselsdato)
+                        pensjonPersonRequest.setFodselsDato(getFoedselsdato(person.getPerson().getFoedselsdato().stream()
+                                .map(PdlPerson.Foedselsdato::getFoedselsdato)
                                 .filter(Objects::nonNull)
                                 .findFirst().orElse(null), pensjonPersonRequest.getFnr()));
 

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/sykemelding/mapper/SykemeldingMappingStrategy.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/sykemelding/mapper/SykemeldingMappingStrategy.java
@@ -103,7 +103,9 @@ public class SykemeldingMappingStrategy implements MappingStrategy {
                                 .findFirst().orElse(new PdlPerson.Navn()), pasient);
                         pasient.setAdresse(mapperFacade.map(person.getPerson().getBostedsadresse().stream()
                                 .findFirst().orElse(new BostedadresseDTO()), Adresse.class, context));
-                        pasient.setFoedselsdato(person.getPerson().getFoedselsdato().getFirst().getFoedselsdato());
+                        pasient.setFoedselsdato(person.getPerson().getFoedselsdato().stream()
+                                .map(PdlPerson.Foedselsdato::getFoedselsdato)
+                                .findFirst().orElse(null));
 
                         pasient.setTelefon(person.getPerson().getTelefonnummer().stream()
                                 .filter(telefonnummer -> telefonnummer.getPrioritet() == 1)

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/sykemelding/mapper/SykemeldingMappingStrategy.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/sykemelding/mapper/SykemeldingMappingStrategy.java
@@ -103,7 +103,7 @@ public class SykemeldingMappingStrategy implements MappingStrategy {
                                 .findFirst().orElse(new PdlPerson.Navn()), pasient);
                         pasient.setAdresse(mapperFacade.map(person.getPerson().getBostedsadresse().stream()
                                 .findFirst().orElse(new BostedadresseDTO()), Adresse.class, context));
-                        pasient.setFoedselsdato(person.getPerson().getFoedsel().getFirst().getFoedselsdato());
+                        pasient.setFoedselsdato(person.getPerson().getFoedselsdato().getFirst().getFoedselsdato());
 
                         pasient.setTelefon(person.getPerson().getTelefonnummer().stream()
                                 .filter(telefonnummer -> telefonnummer.getPrioritet() == 1)

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/udistub/util/UdiMergeService.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/udistub/util/UdiMergeService.java
@@ -31,7 +31,8 @@ public class UdiMergeService {
         udiPerson.setIdent(personBolk.getIdent());
         udiPerson.setNavn(mapperFacade.map(personBolk.getPerson().getNavn().stream()
                 .findFirst().orElse(new PdlPerson.Navn()), UdiPersonNavn.class));
-        udiPerson.setFoedselsDato(personBolk.getPerson().getFoedsel().stream().map(PdlPerson.Foedsel::getFoedselsdato)
+        udiPerson.setFoedselsDato(personBolk.getPerson().getFoedselsdato().stream()
+                .map(PdlPerson.Foedselsdato::getFoedselsdato)
                 .findFirst().orElse(null));
 
         udiPerson.setAliaser(personBolk.getPerson().getFolkeregisteridentifikator().stream()

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/domain/PdlPerson.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/domain/PdlPerson.java
@@ -18,6 +18,7 @@ import no.nav.testnav.libs.data.pdlforvalter.v1.DbVersjonDTO;
 import no.nav.testnav.libs.data.pdlforvalter.v1.DeltBostedDTO;
 import no.nav.testnav.libs.data.pdlforvalter.v1.DoedfoedtBarnDTO;
 import no.nav.testnav.libs.data.pdlforvalter.v1.FalskIdentitetDTO;
+import no.nav.testnav.libs.data.pdlforvalter.v1.FoedestedDTO;
 import no.nav.testnav.libs.data.pdlforvalter.v1.ForeldreansvarDTO;
 import no.nav.testnav.libs.data.pdlforvalter.v1.FullmaktDTO;
 import no.nav.testnav.libs.data.pdlforvalter.v1.InnflyttingDTO;
@@ -103,7 +104,8 @@ public class PdlPerson {
     public static class Person {
 
         private List<PdlPerson.Navn> navn;
-        private List<PdlPerson.Foedsel> foedsel;
+        private List<PdlPerson.Foedselsdato> foedselsdato;
+        private List<FoedestedDTO> foedested;
         private List<PdlPerson.ForelderBarnRelasjon> forelderBarnRelasjon;
         private List<PdlPerson.Sivilstand> sivilstand;
         private List<PdlPerson.Doedsfall> doedsfall;
@@ -135,13 +137,6 @@ public class PdlPerson {
                 navn = new ArrayList<>();
             }
             return navn;
-        }
-
-        public List<PdlPerson.Foedsel> getFoedsel() {
-            if (isNull(foedsel)) {
-                foedsel = new ArrayList<>();
-            }
-            return foedsel;
         }
 
         public List<PdlPerson.ForelderBarnRelasjon> getForelderBarnRelasjon() {
@@ -311,6 +306,20 @@ public class PdlPerson {
             }
             return innflyttingTilNorge;
         }
+
+        public List<Foedselsdato> getFoedselsdato() {
+            if (isNull(foedselsdato)) {
+                foedselsdato = new ArrayList<>();
+            }
+            return foedselsdato;
+        }
+
+        public List<FoedestedDTO> getFoedested() {
+            if (isNull(foedested)) {
+                return foedested;
+            }
+            return foedested;
+        }
     }
 
     @lombok.Data
@@ -359,6 +368,17 @@ public class PdlPerson {
         private String foedekommune;
         private String foedeland;
         private String foedested;
+        private Integer foedselsaar;
+        private LocalDate foedselsdato;
+    }
+
+    @lombok.Data
+    @SuperBuilder
+    @EqualsAndHashCode(callSuper = true)
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Foedselsdato extends DbVersjonDTO {
+
         private Integer foedselsaar;
         private LocalDate foedselsdato;
     }
@@ -514,7 +534,7 @@ public class PdlPerson {
             MIDLERTIDIG("midlertidig"),
             INAKTIV("inaktiv");
 
-            private String beskrivelse;
+            private final String beskrivelse;
 
             Personstatus(String camelCaseValue) {
                 this.beskrivelse = camelCaseValue;

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/mapper/strategy/OriginatorMappingStrategy.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/mapper/strategy/OriginatorMappingStrategy.java
@@ -6,6 +6,8 @@ import ma.glasnost.orika.MappingContext;
 import no.nav.dolly.domain.resultset.pdldata.PdlPersondata;
 import no.nav.dolly.mapper.MappingStrategy;
 import no.nav.testnav.libs.data.pdlforvalter.v1.BestillingRequestDTO;
+import no.nav.testnav.libs.data.pdlforvalter.v1.FoedestedDTO;
+import no.nav.testnav.libs.data.pdlforvalter.v1.FoedselsdatoDTO;
 import no.nav.testnav.libs.data.pdlforvalter.v1.Identtype;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
@@ -34,6 +36,8 @@ public class OriginatorMappingStrategy implements MappingStrategy {
                         if (StringUtils.isBlank(destinasjon.getOpprettFraIdent()) && isNull(destinasjon.getIdenttype())) {
                             destinasjon.setIdenttype(Identtype.FNR);
                         }
+                        destinasjon.getPerson().setFoedselsdato(mapperFacade.mapAsList(kilde.getPerson().getFoedselsdato(), FoedselsdatoDTO.class));
+                        destinasjon.getPerson().setFoedested(mapperFacade.mapAsList(kilde.getPerson().getFoedested(), FoedestedDTO.class));
                     }
                 })
                 .byDefault()

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/mapper/strategy/OriginatorMappingStrategy.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/mapper/strategy/OriginatorMappingStrategy.java
@@ -36,8 +36,10 @@ public class OriginatorMappingStrategy implements MappingStrategy {
                         if (StringUtils.isBlank(destinasjon.getOpprettFraIdent()) && isNull(destinasjon.getIdenttype())) {
                             destinasjon.setIdenttype(Identtype.FNR);
                         }
-                        destinasjon.getPerson().setFoedselsdato(mapperFacade.mapAsList(kilde.getPerson().getFoedselsdato(), FoedselsdatoDTO.class));
-                        destinasjon.getPerson().setFoedested(mapperFacade.mapAsList(kilde.getPerson().getFoedested(), FoedestedDTO.class));
+                        if (nonNull(destinasjon.getPerson())) {
+                            destinasjon.getPerson().setFoedselsdato(mapperFacade.mapAsList(kilde.getPerson().getFoedselsdato(), FoedselsdatoDTO.class));
+                            destinasjon.getPerson().setFoedested(mapperFacade.mapAsList(kilde.getPerson().getFoedested(), FoedestedDTO.class));
+                        }
                     }
                 })
                 .byDefault()

--- a/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/mapper/IdentPoolMappingStrategy.java
+++ b/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/mapper/IdentPoolMappingStrategy.java
@@ -77,8 +77,11 @@ public class IdentPoolMappingStrategy implements MappingStrategy {
                     public void mapAtoB(BestillingRequestDTO kilde, HentIdenterRequest destinasjon, MappingContext context) {
 
                         destinasjon.setIdenttype(mapIdenttype(kilde.getIdenttype()));
-                        var foedsel = kilde.getPerson().getFoedsel().stream()
-                                .findFirst().orElse(new FoedselDTO());
+                        var foedsel = kilde.getPerson().getFoedselsdato().stream()
+                                .findFirst()
+                                .orElse(kilde.getPerson().getFoedsel().stream()
+                                        .findFirst()
+                                        .orElse(new FoedselDTO()));
 
                         if (nonNull(foedsel.getFoedselsaar())) {
                             destinasjon.setFoedtEtter(LocalDate.of(foedsel.getFoedselsaar() - 1, 12, 31));

--- a/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/mapper/KontaktInformasjonForDoedsboMappingStrategy.java
+++ b/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/mapper/KontaktInformasjonForDoedsboMappingStrategy.java
@@ -92,7 +92,7 @@ public class KontaktInformasjonForDoedsboMappingStrategy implements MappingStrat
                     public void mapAtoB(Map kilde, KontaktinformasjonForDoedsboAdresse destinasjon, MappingContext context) {
 
                         var adresselinjer = (List<String>) kilde.get("adresselinjer");
-                        destinasjon.setAdresselinje1(!adresselinjer.isEmpty() ? adresselinjer.get(0) : "Ingen adresselinje funnet");
+                        destinasjon.setAdresselinje1(!adresselinjer.isEmpty() ? adresselinjer.getFirst() : "Ingen adresselinje funnet");
                         destinasjon.setAdresselinje2(adresselinjer.size() > 1 ? adresselinjer.get(1) : null);
 
                         destinasjon.setPostnummer((String) kilde.get("postnr"));

--- a/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/service/CreatePersonService.java
+++ b/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/service/CreatePersonService.java
@@ -9,7 +9,8 @@ import no.nav.pdl.forvalter.database.repository.PersonRepository;
 import no.nav.pdl.forvalter.dto.HentIdenterRequest;
 import no.nav.testnav.libs.data.pdlforvalter.v1.AdressebeskyttelseDTO;
 import no.nav.testnav.libs.data.pdlforvalter.v1.BostedadresseDTO;
-import no.nav.testnav.libs.data.pdlforvalter.v1.FoedselDTO;
+import no.nav.testnav.libs.data.pdlforvalter.v1.FoedestedDTO;
+import no.nav.testnav.libs.data.pdlforvalter.v1.FoedselsdatoDTO;
 import no.nav.testnav.libs.data.pdlforvalter.v1.FolkeregisterPersonstatusDTO;
 import no.nav.testnav.libs.data.pdlforvalter.v1.FolkeregistermetadataDTO;
 import no.nav.testnav.libs.data.pdlforvalter.v1.KjoennDTO;
@@ -56,7 +57,10 @@ public class CreatePersonService {
                 .kjoenn(List.of(KjoennDTO.builder().kjoenn(request.getKjoenn())
                         .folkeregistermetadata(new FolkeregistermetadataDTO())
                         .build()))
-                .foedsel(List.of(FoedselDTO.builder()
+                .foedselsdato(List.of(FoedselsdatoDTO.builder()
+                        .folkeregistermetadata(new FolkeregistermetadataDTO())
+                        .build()))
+                .foedested(List.of(FoedestedDTO.builder()
                         .folkeregistermetadata(new FolkeregistermetadataDTO())
                         .build()))
                 .navn(List.of(nonNull(request.getNyttNavn()) ?

--- a/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/service/CreatePersonService.java
+++ b/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/service/CreatePersonService.java
@@ -44,7 +44,8 @@ public class CreatePersonService {
     private final MergeService mergeService;
     private final PersonRepository personRepository;
     private final KjoennService kjoennService;
-    private final FoedselService foedselService;
+    private final FoedselsdatoService foedselsdatoService;
+    private final FoedestedService foedestedService;
     private final StatsborgerskapService statsborgerskapService;
     private final BostedAdresseService bostedAdresseService;
     private final NavnService navnService;
@@ -103,9 +104,10 @@ public class CreatePersonService {
                 .getIdent());
 
         Stream.of(
-                        Flux.just(foedselService.convert(mergedPerson)),
+                        Flux.just(foedselsdatoService.convert(mergedPerson)),
                         Flux.just(navnService.convert(mergedPerson)),
                         Flux.just(bostedAdresseService.convert(mergedPerson, null)),
+                        Flux.just(foedestedService.convert(mergedPerson)),
                         Flux.just(kjoennService.convert(mergedPerson)),
                         Flux.just(statsborgerskapService.convert(mergedPerson)),
                         Flux.just(adressebeskyttelseService.convert(mergedPerson)))

--- a/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/service/DeltBostedService.java
+++ b/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/service/DeltBostedService.java
@@ -4,11 +4,10 @@ import lombok.RequiredArgsConstructor;
 import ma.glasnost.orika.MapperFacade;
 import no.nav.pdl.forvalter.consumer.AdresseServiceConsumer;
 import no.nav.pdl.forvalter.database.repository.PersonRepository;
-import no.nav.pdl.forvalter.utils.DatoFraIdentUtility;
+import no.nav.pdl.forvalter.utils.FoedselsdatoUtility;
 import no.nav.pdl.forvalter.utils.IdenttypeUtility;
 import no.nav.testnav.libs.data.pdlforvalter.v1.BostedadresseDTO;
 import no.nav.testnav.libs.data.pdlforvalter.v1.DeltBostedDTO;
-import no.nav.testnav.libs.data.pdlforvalter.v1.FoedselDTO;
 import no.nav.testnav.libs.data.pdlforvalter.v1.PersonDTO;
 import no.nav.testnav.libs.data.pdlforvalter.v1.UkjentBostedDTO;
 import org.springframework.stereotype.Service;
@@ -73,10 +72,8 @@ public class DeltBostedService {
             personRepository.findByIdent(barnIdent)
                     .ifPresent(dbPerson -> {
                         if (isNull(deltBosted.getStartdatoForKontrakt())) {
-                            deltBosted.setStartdatoForKontrakt(dbPerson.getPerson().getFoedsel().stream()
-                                    .map(FoedselDTO::getFoedselsdato)
-                                    .findFirst()
-                                    .orElse(DatoFraIdentUtility.getDato(barnIdent).atStartOfDay()));
+                            deltBosted.setStartdatoForKontrakt(
+                                    FoedselsdatoUtility.getFoedselsdato(dbPerson.getPerson()));
                         }
                         setDeltBosted(dbPerson.getPerson(), deltBosted);
                     });

--- a/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/service/FolkeregisterPersonstatusService.java
+++ b/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/service/FolkeregisterPersonstatusService.java
@@ -121,6 +121,7 @@ public class FolkeregisterPersonstatusService implements BiValidation<Folkeregis
             personstatus.setStatus(UTFLYTTET);
             personstatus.setGyldigFraOgMed(person.getUtflytting().stream()
                     .map(UtflyttingDTO::getUtflyttingsdato)
+                    .filter(Objects::nonNull)
                     .findFirst()
                     .orElse(LocalDateTime.now()));
 

--- a/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/service/ForelderBarnRelasjonService.java
+++ b/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/service/ForelderBarnRelasjonService.java
@@ -242,11 +242,11 @@ public class ForelderBarnRelasjonService implements BiValidation<ForelderBarnRel
             PersonDTO relatertPerson = createPersonService.execute(relasjon.getNyRelatertPerson());
 
             if (isNotTrue(relasjon.getBorIkkeSammen()) && !hovedperson.getBostedsadresse().isEmpty()) {
-                BostedadresseDTO fellesAdresse = hovedperson.getBostedsadresse().stream()
+                var fellesAdresse = mapperFacade.map(hovedperson.getBostedsadresse().stream()
                         .findFirst()
                         .orElse(BostedadresseDTO.builder()
                                 .vegadresse(mapperFacade.map(defaultAdresse(), VegadresseDTO.class))
-                                .build());
+                                .build()), BostedadresseDTO.class);
                 fellesAdresse.setGyldigFraOgMed(getMaxDato(getLastFlyttedato(hovedperson), getLastFlyttedato(relatertPerson)));
                 if (!relatertPerson.getBostedsadresse().isEmpty()) {
                     relatertPerson.getBostedsadresse().set(0, fellesAdresse);

--- a/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/service/ForeldreansvarService.java
+++ b/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/service/ForeldreansvarService.java
@@ -87,8 +87,10 @@ public class ForeldreansvarService implements BiValidation<ForeldreansvarDTO, Pe
 
                 type.setKilde(getKilde(type));
                 type.setMaster(getMaster(type, person));
-                if (person.getFoedsel().stream()
-                        .anyMatch(alder -> alder.getFoedselsdato().isBefore(LocalDateTime.now().minusYears(MYNDIG_ALDER)))) {
+                if (person.getFoedselsdato().stream()
+                        .anyMatch(alder -> alder.getFoedselsdato().isBefore(LocalDateTime.now().minusYears(MYNDIG_ALDER))) ||
+                        person.getFoedsel().stream()
+                                .anyMatch(alder -> alder.getFoedselsdato().isBefore(LocalDateTime.now().minusYears(MYNDIG_ALDER)))) {
                     // hovedperson er voksen
                     handle(type, person);
                 } else {
@@ -197,11 +199,11 @@ public class ForeldreansvarService implements BiValidation<ForeldreansvarDTO, Pe
                 .anyMatch(relasjon -> List.of(roller).contains(relasjon.getRelatertPersonsRolle()));
     }
 
-    private boolean isRelasjonForeldre(PersonDTO hovedperson) {
+    private boolean isRelasjonForeldre(PersonDTO person) {
 
-        return hovedperson.getForelderBarnRelasjon().stream()
+        return person.getForelderBarnRelasjon().stream()
                 .anyMatch(relasjon -> relasjon.isForeldre() && isNotTrue(relasjon.getPartnerErIkkeForelder())) &&
-                hovedperson.getSivilstand().stream()
+                person.getSivilstand().stream()
                         .anyMatch(sivilstand -> (sivilstand.isGift() || sivilstand.isSeparert()));
     }
 

--- a/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/service/ForeldreansvarService.java
+++ b/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/service/ForeldreansvarService.java
@@ -416,7 +416,7 @@ public class ForeldreansvarService implements BiValidation<ForeldreansvarDTO, Pe
         var foreldre = barn.getForelderBarnRelasjon().stream()
                 .filter(ForelderBarnRelasjonDTO::isBarn)
                 .toList();
-        foreldreansvar.setAnsvarlig(foreldre.get(0).getRelatertPerson());
+        foreldreansvar.setAnsvarlig(foreldre.getFirst().getRelatertPerson());
         relasjonService.setRelasjon(barn.getIdent(), foreldreansvar.getAnsvarlig(), FORELDREANSVAR_FORELDER);
         relasjonService.setRelasjon(foreldreansvar.getAnsvarlig(), barn.getIdent(), FORELDREANSVAR_BARN);
 

--- a/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/service/IdentitetService.java
+++ b/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/service/IdentitetService.java
@@ -55,12 +55,12 @@ public class IdentitetService {
                 .filter(StringUtils::isNumeric)
                 .findFirst();
 
-        List<String> navn = List.of(query.split(" ")).stream()
+        List<String> navn = Stream.of(query.split(" "))
                 .filter(fragment -> isNotBlank(fragment) && !StringUtils.isNumeric(fragment))
                 .toList();
 
         return personRepository.findByWildcardIdent(ident.orElse(null),
-                !navn.isEmpty() ? navn.get(0).toUpperCase() : null,
+                !navn.isEmpty() ? navn.getFirst().toUpperCase() : null,
                 navn.size() > 1 ? navn.get(1).toUpperCase() : null,
                 PageRequest.of(paginering.getSidenummer(),
                         paginering.getSidestoerrelse(),

--- a/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/service/MetadataTidspunkterService.java
+++ b/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/service/MetadataTidspunkterService.java
@@ -10,7 +10,7 @@ import no.nav.testnav.libs.data.pdlforvalter.v1.DbVersjonDTO;
 import no.nav.testnav.libs.data.pdlforvalter.v1.DeltBostedDTO;
 import no.nav.testnav.libs.data.pdlforvalter.v1.DoedsfallDTO;
 import no.nav.testnav.libs.data.pdlforvalter.v1.FalskIdentitetDTO;
-import no.nav.testnav.libs.data.pdlforvalter.v1.FoedselDTO;
+import no.nav.testnav.libs.data.pdlforvalter.v1.FoedselsdatoDTO;
 import no.nav.testnav.libs.data.pdlforvalter.v1.FolkeregisterPersonstatusDTO;
 import no.nav.testnav.libs.data.pdlforvalter.v1.FolkeregistermetadataDTO;
 import no.nav.testnav.libs.data.pdlforvalter.v1.ForeldreansvarDTO;
@@ -68,6 +68,10 @@ public class MetadataTidspunkterService {
                             .forEach(this::fixDoedsfall);
                     person.getFoedsel()
                             .forEach(foedsel -> fixFoedsel(foedsel, person));
+                    person.getFoedselsdato()
+                            .forEach(foedselsdato -> fixFoedsel(foedselsdato, person));
+                    person.getFoedested()
+                            .forEach(this::fixVersioning);
                     person.getFalskIdentitet()
                             .forEach(this::fixFalskIdentitet);
                     person.getFolkeregisterPersonstatus()
@@ -264,7 +268,7 @@ public class MetadataTidspunkterService {
                 });
     }
 
-    private static LocalDateTime getFoedselsdato(PersonDTO personDTO, FoedselDTO foedsel) {
+    private static LocalDateTime getFoedselsdato(PersonDTO personDTO, FoedselsdatoDTO foedsel) {
 
         return nonNull(foedsel.getFoedselsdato()) ? foedsel.getFoedselsdato() :
                 LocalDate.of(foedsel.getFoedselsaar(),
@@ -280,7 +284,7 @@ public class MetadataTidspunkterService {
         doedsfallDTO.getFolkeregistermetadata().setGyldighetstidspunkt(doedsfallDTO.getDoedsdato());
     }
 
-    private void fixFoedsel(FoedselDTO foedselDTO, PersonDTO personDTO) {
+    private void fixFoedsel(FoedselsdatoDTO foedselDTO, PersonDTO personDTO) {
 
         fixFolkeregisterMetadata(foedselDTO);
 

--- a/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/service/NavnService.java
+++ b/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/service/NavnService.java
@@ -3,14 +3,11 @@ package no.nav.pdl.forvalter.service;
 import lombok.RequiredArgsConstructor;
 import no.nav.pdl.forvalter.consumer.GenererNavnServiceConsumer;
 import no.nav.pdl.forvalter.exception.InvalidRequestException;
-import no.nav.pdl.forvalter.utils.DatoFraIdentUtility;
-import no.nav.testnav.libs.data.pdlforvalter.v1.FoedselDTO;
+import no.nav.pdl.forvalter.utils.FoedselsdatoUtility;
 import no.nav.testnav.libs.data.pdlforvalter.v1.NavnDTO;
 import no.nav.testnav.libs.data.pdlforvalter.v1.PersonDTO;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -26,7 +23,7 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 @Service
 @RequiredArgsConstructor
-public class NavnService implements BiValidation<NavnDTO, PersonDTO>  {
+public class NavnService implements BiValidation<NavnDTO, PersonDTO> {
 
     private static final String NAVN_INVALID_ERROR = "Navn er ikke i liste over gyldige verdier";
     private final GenererNavnServiceConsumer genererNavnServiceConsumer;
@@ -84,10 +81,7 @@ public class NavnService implements BiValidation<NavnDTO, PersonDTO>  {
 
     private List<NavnDTO> fixGyldigFraOgMed(PersonDTO person) {
 
-        var foedselsdato = person.getFoedsel().stream()
-                .map(foedsel -> getFoedselsdato(person, foedsel))
-                .findFirst()
-                .orElse(LocalDateTime.now());
+        var foedselsdato = FoedselsdatoUtility.getFoedselsdato(person);
 
         var maksDato = person.getNavn().stream()
                 .filter(navn -> nonNull(navn.getGyldigFraOgMed()))
@@ -115,13 +109,5 @@ public class NavnService implements BiValidation<NavnDTO, PersonDTO>  {
                 .forEach(navn -> navn.setId(person.getNavn().size() - version1.getAndIncrement()));
 
         return person.getNavn();
-    }
-
-    private static LocalDateTime getFoedselsdato(PersonDTO personDTO, FoedselDTO foedsel) {
-
-        return nonNull(foedsel.getFoedselsdato()) ? foedsel.getFoedselsdato() :
-                LocalDate.of(foedsel.getFoedselsaar(),
-                        DatoFraIdentUtility.getDato(personDTO.getIdent()).getMonthValue(),
-                        DatoFraIdentUtility.getDato(personDTO.getIdent()).getDayOfMonth()).atStartOfDay();
     }
 }

--- a/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/service/PersonArtifactService.java
+++ b/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/service/PersonArtifactService.java
@@ -40,12 +40,12 @@ public class PersonArtifactService {
     public PersonDTO buildPerson(PersonDTO person, Boolean relaxed) {
 
         // Orders below matters to some degree, don´t rearrange without checking consequences
+        person.setFoedsel(foedselService.convert(person));
+        person.setFoedselsdato(foedselsdatoService.convert(person));
         person.setKjoenn(kjoennService.convert(person));
         person.setBostedsadresse(bostedAdresseService.convert(person, relaxed));
         person.setInnflytting(innflyttingService.convert(person));
         person.setFoedested(foedestedService.convert(person));
-        person.setFoedsel(foedselService.convert(person));
-        person.setFoedselsdato(foedselsdatoService.convert(person));
         person.setStatsborgerskap(statsborgerskapService.convert(person));
         person.setNavn(navnService.convert(person));
         person.setOppholdsadresse(oppholdsadresseService.convert(person));

--- a/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/service/SwopIdentsService.java
+++ b/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/service/SwopIdentsService.java
@@ -8,6 +8,7 @@ import no.nav.pdl.forvalter.database.repository.AliasRepository;
 import no.nav.pdl.forvalter.database.repository.PersonRepository;
 import no.nav.pdl.forvalter.database.repository.RelasjonRepository;
 import no.nav.pdl.forvalter.utils.FoedselsdatoUtility;
+import no.nav.testnav.libs.data.pdlforvalter.v1.FoedestedDTO;
 import no.nav.testnav.libs.data.pdlforvalter.v1.FoedselDTO;
 import no.nav.testnav.libs.data.pdlforvalter.v1.NavnDTO;
 import no.nav.testnav.libs.data.pdlforvalter.v1.PersonDTO;
@@ -35,10 +36,7 @@ public class SwopIdentsService {
 
     private static String opaqifyIdent(String ident) {
 
-        return new StringBuilder()
-                .append('X')
-                .append(ident.substring(1))
-                .toString();
+        return 'X' + ident.substring(1);
     }
 
     private void swopOpplysninger(DbPerson person1, DbPerson person2) {
@@ -82,11 +80,18 @@ public class SwopIdentsService {
         }
 
         var foedsel = person2.getPerson().getFoedsel().stream().findFirst().orElse(new FoedselDTO());
+        var foedested = person2.getPerson().getFoedested().stream().findFirst().orElse(new FoedestedDTO());
         person1.getPerson().getFoedsel()
                 .forEach(foedsel1 -> {
                     foedsel1.setFoedeland(foedsel.getFoedeland());
                     foedsel1.setFoedekommune(foedsel.getFoedekommune());
                     foedsel1.setFoedested(foedsel.getFoedested());
+                });
+        person1.getPerson().getFoedested()
+                .forEach(foedsel1 -> {
+                    foedsel1.setFoedeland(foedested.getFoedeland());
+                    foedsel1.setFoedekommune(foedested.getFoedekommune());
+                    foedsel1.setFoedested(foedested.getFoedested());
                 });
 
         person1.getPerson().setNyident(null);

--- a/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/service/ValidateArtifactsService.java
+++ b/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/service/ValidateArtifactsService.java
@@ -20,7 +20,8 @@ public class ValidateArtifactsService {
     private final DoedfoedtBarnService doedfoedtBarnService;
     private final DoedsfallService doedsfallService;
     private final FalskIdentitetService falskIdentitetService;
-    private final FoedselService foedselService;
+    private final FoedselsdatoService foedselsdatoService;
+    private final FoedestedService foedestedService;
     private final FolkeregisterPersonstatusService folkeregisterPersonstatusService;
     private final ForelderBarnRelasjonService forelderBarnRelasjonService;
     private final ForeldreansvarService foreldreansvarService;
@@ -48,7 +49,8 @@ public class ValidateArtifactsService {
                         validate(kjoennService, person.getKjoenn(), person),
                         validate(innflyttingService, person.getInnflytting()),
                         validate(bostedAdresseService, person.getBostedsadresse(), person),
-                        validate(foedselService, person.getFoedsel(), person),
+                        validate(foedselsdatoService, person.getFoedselsdato(), person),
+                        validate(foedestedService, person.getFoedested(), person),
                         validate(statsborgerskapService, person.getStatsborgerskap()),
                         validate(navnService, person.getNavn(), person),
                         validate(oppholdsadresseService, person.getOppholdsadresse(), person),

--- a/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/utils/FoedselsdatoUtility.java
+++ b/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/utils/FoedselsdatoUtility.java
@@ -17,9 +17,11 @@ public class FoedselsdatoUtility {
     public LocalDateTime getFoedselsdato(PersonDTO person) {
 
         return person.getFoedselsdato().stream()
+                .filter(foedsel -> nonNull(foedsel.getFoedselsdato()) || nonNull(foedsel.getFoedselsaar()))
                 .map(foedsel-> getFoedselsdato(foedsel, person.getIdent()))
                 .findFirst()
                 .orElse(person.getFoedsel().stream()
+                        .filter(foedsel -> nonNull(foedsel.getFoedselsdato()) || nonNull(foedsel.getFoedselsaar()))
                         .map(foedsel-> getFoedselsdato(foedsel, person.getIdent()))
                         .findFirst()
                         .orElse(DatoFraIdentUtility.getDato(person.getIdent()).atStartOfDay()));

--- a/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/utils/FoedselsdatoUtility.java
+++ b/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/utils/FoedselsdatoUtility.java
@@ -1,12 +1,13 @@
 package no.nav.pdl.forvalter.utils;
 
 import lombok.experimental.UtilityClass;
-import no.nav.testnav.libs.data.pdlforvalter.v1.FoedselDTO;
+import no.nav.testnav.libs.data.pdlforvalter.v1.FoedselsdatoDTO;
 import no.nav.testnav.libs.data.pdlforvalter.v1.PersonDTO;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.Objects;
+
+import static java.util.Objects.nonNull;
 
 @UtilityClass
 public class FoedselsdatoUtility {
@@ -15,14 +16,24 @@ public class FoedselsdatoUtility {
 
     public LocalDateTime getFoedselsdato(PersonDTO person) {
 
-        return person.getFoedsel().stream()
-                .map(FoedselDTO::getFoedselsdato)
-                .filter(Objects::nonNull)
+        return person.getFoedselsdato().stream()
+                .map(foedsel-> getFoedselsdato(foedsel, person.getIdent()))
                 .findFirst()
-                .orElse(DatoFraIdentUtility.getDato(person.getIdent()).atStartOfDay());
+                .orElse(person.getFoedsel().stream()
+                        .map(foedsel-> getFoedselsdato(foedsel, person.getIdent()))
+                        .findFirst()
+                        .orElse(DatoFraIdentUtility.getDato(person.getIdent()).atStartOfDay()));
     }
 
-    public boolean isMyndig(PersonDTO person) {
+    private static LocalDateTime getFoedselsdato(FoedselsdatoDTO foedsel, String ident) {
+
+        return nonNull(foedsel.getFoedselsdato()) ? foedsel.getFoedselsdato() :
+                LocalDate.of(foedsel.getFoedselsaar(),
+                        DatoFraIdentUtility.getDato(ident).getMonthValue(),
+                        DatoFraIdentUtility.getDato(ident).getDayOfMonth()).atStartOfDay();
+    }
+
+    public static boolean isMyndig(PersonDTO person) {
 
         var foedselsdato = getFoedselsdato(person);
 
@@ -30,7 +41,7 @@ public class FoedselsdatoUtility {
                 foedselsdato.toLocalDate().plusYears(MYNDIGHETSALDER).isEqual(LocalDate.now());
     }
 
-    public LocalDateTime getMyndighetsdato(PersonDTO person) {
+    public static LocalDateTime getMyndighetsdato(PersonDTO person) {
 
         return getFoedselsdato(person).plusYears(MYNDIGHETSALDER);
     }

--- a/apps/pdl-forvalter/src/test/java/no/nav/pdl/forvalter/service/BostedAdresseServiceTest.java
+++ b/apps/pdl-forvalter/src/test/java/no/nav/pdl/forvalter/service/BostedAdresseServiceTest.java
@@ -178,7 +178,7 @@ class BostedAdresseServiceTest {
                         .build())))
                 .build();
 
-        var target = bostedAdresseService.convert(request, null).get(0);
+        var target = bostedAdresseService.convert(request, null).getFirst();
 
         assertThat(target.getGyldigFraOgMed(), is(equalTo(LocalDate.of(2020, 1, 1).atStartOfDay())));
     }
@@ -190,7 +190,7 @@ class BostedAdresseServiceTest {
 
         var request = PersonDTO.builder()
                 .ident(FNR_IDENT)
-                .bostedsadresse(new ArrayList(List.of(BostedadresseDTO.builder()
+                .bostedsadresse(new ArrayList<>(List.of(BostedadresseDTO.builder()
                                 .gyldigFraOgMed(LocalDate.of(2020, 2, 4).atStartOfDay())
                                 .vegadresse(new VegadresseDTO())
                                 .isNew(true)
@@ -238,7 +238,7 @@ class BostedAdresseServiceTest {
         when(adresseServiceConsumer.getVegadresse(any(VegadresseDTO.class), any()))
                 .thenReturn(new no.nav.testnav.libs.dto.adresseservice.v1.VegadresseDTO());
 
-        var target = bostedAdresseService.convert(request, null).get(0);
+        var target = bostedAdresseService.convert(request, null).getFirst();
 
         assertThat(target.countAdresser(), is(1));
         assertThat(target.getVegadresse(), is(notNullValue()));
@@ -256,7 +256,7 @@ class BostedAdresseServiceTest {
 
         when(enkelAdresseService.getUtenlandskAdresse(any(), any(), any())).thenReturn(new UtenlandskAdresseDTO());
 
-        var target = bostedAdresseService.convert(request, null).get(0);
+        var target = bostedAdresseService.convert(request, null).getFirst();
 
         assertThat(target.countAdresser(), is(1));
         assertThat(target.getUtenlandskAdresse(), is(notNullValue()));

--- a/apps/pdl-forvalter/src/test/java/no/nav/pdl/forvalter/service/FolkeregisterPersonstatusServiceTest.java
+++ b/apps/pdl-forvalter/src/test/java/no/nav/pdl/forvalter/service/FolkeregisterPersonstatusServiceTest.java
@@ -45,7 +45,7 @@ class FolkeregisterPersonstatusServiceTest {
                                 .status(FORSVUNNET)
                                 .isNew(true)
                                 .build()))
-                        .build()).get(0);
+                        .build()).getFirst();
 
         assertThat(target.getStatus(), is(equalTo(FORSVUNNET)));
     }
@@ -63,7 +63,7 @@ class FolkeregisterPersonstatusServiceTest {
                                 DoedsfallDTO.builder()
                                         .doedsdato(LocalDateTime.now())
                                         .build()))
-                        .build()).get(0);
+                        .build()).getFirst();
 
         assertThat(target.getStatus(), is(equalTo(DOED)));
     }
@@ -80,7 +80,7 @@ class FolkeregisterPersonstatusServiceTest {
                         .opphold(List.of(OppholdDTO.builder()
                                 .type(OppholdDTO.OppholdType.OPPLYSNING_MANGLER)
                                 .build()))
-                        .build()).get(0);
+                        .build()).getFirst();
 
         assertThat(target.getStatus(), is(equalTo(MIDLERTIDIG)));
     }
@@ -97,7 +97,7 @@ class FolkeregisterPersonstatusServiceTest {
                         .utflytting(List.of(UtflyttingDTO.builder()
                                 .tilflyttingsland("FRA")
                                 .build()))
-                        .build()).get(0);
+                        .build()).getFirst();
 
         assertThat(target.getStatus(), is(equalTo(UTFLYTTET)));
     }
@@ -115,7 +115,7 @@ class FolkeregisterPersonstatusServiceTest {
                         .bostedsadresse(List.of(BostedadresseDTO.builder()
                                 .vegadresse(new VegadresseDTO())
                                 .build()))
-                        .build()).get(0);
+                        .build()).getFirst();
 
         assertThat(target.getStatus(), is(equalTo(BOSATT)));
     }
@@ -133,7 +133,7 @@ class FolkeregisterPersonstatusServiceTest {
                         .bostedsadresse(List.of(BostedadresseDTO.builder()
                                 .matrikkeladresse(new MatrikkeladresseDTO())
                                 .build()))
-                        .build()).get(0);
+                        .build()).getFirst();
 
         assertThat(target.getStatus(), is(equalTo(BOSATT)));
     }
@@ -151,7 +151,7 @@ class FolkeregisterPersonstatusServiceTest {
                         .bostedsadresse(List.of(BostedadresseDTO.builder()
                                 .utenlandskAdresse(new UtenlandskAdresseDTO())
                                 .build()))
-                        .build()).get(0);
+                        .build()).getFirst();
 
         assertThat(target.getStatus(), is(equalTo(IKKE_BOSATT)));
     }
@@ -166,7 +166,7 @@ class FolkeregisterPersonstatusServiceTest {
                                 List.of(FolkeregisterPersonstatusDTO.builder()
                                         .isNew(true)
                                         .build()))
-                        .build()).get(0);
+                        .build()).getFirst();
 
         assertThat(target.getStatus(), is(equalTo(FOEDSELSREGISTRERT)));
     }

--- a/apps/pdl-forvalter/src/test/java/no/nav/pdl/forvalter/service/ForelderBarnRelasjonServiceTest.java
+++ b/apps/pdl-forvalter/src/test/java/no/nav/pdl/forvalter/service/ForelderBarnRelasjonServiceTest.java
@@ -183,7 +183,7 @@ class ForelderBarnRelasjonServiceTest {
         for (int i = 0; i < request.size(); i++) {
             request.get(i).setId(request.size() - i);
         }
-        assertThat(request.get(0).getId(), is(equalTo(2)));
+        assertThat(request.getFirst().getId(), is(equalTo(2)));
         assertThat(request.get(1).getId(), is(equalTo(1)));
     }
 }

--- a/apps/pdl-forvalter/src/test/java/no/nav/pdl/forvalter/service/KjoennServiceTest.java
+++ b/apps/pdl-forvalter/src/test/java/no/nav/pdl/forvalter/service/KjoennServiceTest.java
@@ -31,7 +31,7 @@ class KjoennServiceTest {
                 PersonDTO.builder()
                         .kjoenn(List.of(KjoennDTO.builder().isNew(true).build()))
                         .ident(IDENT_KVINNE)
-                        .build()).get(0);
+                        .build()).getFirst();
 
         assertThat(target.getKjoenn(), is(equalTo(KVINNE)));
     }
@@ -43,7 +43,7 @@ class KjoennServiceTest {
                 PersonDTO.builder()
                         .kjoenn(List.of(KjoennDTO.builder().isNew(true).build()))
                         .ident(IDENT_MANN)
-                        .build()).get(0);
+                        .build()).getFirst();
 
         assertThat(target.getKjoenn(), is(equalTo(MANN)));
     }
@@ -58,7 +58,7 @@ class KjoennServiceTest {
                                 .isNew(true)
                                 .build()))
                         .ident(IDENT_KVINNE)
-                        .build()).get(0);
+                        .build()).getFirst();
 
         assertThat(target.getKjoenn(), is(equalTo(MANN)));
     }
@@ -73,7 +73,7 @@ class KjoennServiceTest {
                                 .isNew(true)
                                 .build()))
                         .ident(IDENT_MANN)
-                        .build()).get(0);
+                        .build()).getFirst();
 
         assertThat(target.getKjoenn(), is(equalTo(KVINNE)));
     }

--- a/apps/pdl-forvalter/src/test/java/no/nav/pdl/forvalter/service/KontaktAdresseServiceTest.java
+++ b/apps/pdl-forvalter/src/test/java/no/nav/pdl/forvalter/service/KontaktAdresseServiceTest.java
@@ -130,7 +130,7 @@ class KontaktAdresseServiceTest {
                 .build();
 
         var kontaktadresse =
-                kontaktAdresseService.convert(request, null).get(0);
+                kontaktAdresseService.convert(request, null).getFirst();
 
         verify(adresseServiceConsumer).getVegadresse(any(VegadresseDTO.class), nullable(String.class));
         verify(mapperFacade).map(eq(vegadresse), any(VegadresseDTO.class));

--- a/apps/pdl-forvalter/src/test/java/no/nav/pdl/forvalter/service/NavnServiceTest.java
+++ b/apps/pdl-forvalter/src/test/java/no/nav/pdl/forvalter/service/NavnServiceTest.java
@@ -25,6 +25,8 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class NavnServiceTest {
 
+    private static final String IDENT = "12305678901";
+
     @Mock
     private GenererNavnServiceConsumer genererNavnServiceConsumer;
 
@@ -54,6 +56,7 @@ class NavnServiceTest {
     void whenNameVerifies_acceptProposal() {
 
         var request = PersonDTO.builder()
+                .ident(IDENT)
                 .navn(List.of(NavnDTO.builder()
                         .fornavn("Gyldig")
                         .mellomnavn("Sjanglende")
@@ -62,7 +65,7 @@ class NavnServiceTest {
                         .build()))
                 .build();
 
-        var target = navnService.convert(request).get(0);
+        var target = navnService.convert(request).getFirst();
 
         assertThat(target.getFornavn(), is(equalTo("Gyldig")));
         assertThat(target.getMellomnavn(), is(equalTo("Sjanglende")));
@@ -73,6 +76,7 @@ class NavnServiceTest {
     void whenNamesNotProvidedWithoutMellomnavn_provideNames() {
 
         var request = PersonDTO.builder()
+                .ident(IDENT)
                 .navn(List.of(NavnDTO.builder()
                         .isNew(true)
                         .build()))
@@ -84,7 +88,7 @@ class NavnServiceTest {
                 .substantiv("Sjømann")
                 .build()));
 
-        var target = navnService.convert(request).get(0);
+        var target = navnService.convert(request).getFirst();
 
         assertThat(target.getFornavn(), is(equalTo("Full")));
         assertThat(target.getMellomnavn(), nullValue());
@@ -95,6 +99,7 @@ class NavnServiceTest {
     void whenNamesNotProvidedWithMellomnavn_provideNames() {
 
         var request = PersonDTO.builder()
+                .ident(IDENT)
                 .navn(List.of(NavnDTO.builder()
                         .hasMellomnavn(true)
                         .isNew(true)
@@ -107,7 +112,7 @@ class NavnServiceTest {
                 .substantiv("Sjømann")
                 .build()));
 
-        var target = navnService.convert(request).get(0);
+        var target = navnService.convert(request).getFirst();
 
         assertThat(target.getFornavn(), is(equalTo("Full")));
         assertThat(target.getMellomnavn(), is(equalTo("Sjanglende")));

--- a/apps/pdl-forvalter/src/test/java/no/nav/pdl/forvalter/service/OppholdServiceTest.java
+++ b/apps/pdl-forvalter/src/test/java/no/nav/pdl/forvalter/service/OppholdServiceTest.java
@@ -102,7 +102,7 @@ class OppholdServiceTest {
                 .oppholdFra(LocalDate.of(2020, 1, 1).atStartOfDay())
                 .type(OPPLYSNING_MANGLER)
                 .isNew(true)
-                .build())).get(0);
+                .build())).getFirst();
 
         assertThat(target.getOppholdFra(), is(equalTo(LocalDate.of(2020, 1, 1).atStartOfDay())));
     }

--- a/apps/pdl-forvalter/src/test/java/no/nav/pdl/forvalter/service/OppholdsadresseServiceTest.java
+++ b/apps/pdl-forvalter/src/test/java/no/nav/pdl/forvalter/service/OppholdsadresseServiceTest.java
@@ -78,7 +78,7 @@ class OppholdsadresseServiceTest {
                                 .build()))
                         .build()));
 
-        assertThat(exception.getMessage(), containsString("" +
+        assertThat(exception.getMessage(), containsString(
                 "Oppholdsadresse: Personer med adressebeskyttelse == STRENGT_FORTROLIG skal ikke ha oppholdsadresse"));
     }
 
@@ -149,7 +149,7 @@ class OppholdsadresseServiceTest {
                         .build()))
                 .build();
 
-        var target = oppholdsadresseService.convert(request).get(0);
+        var target = oppholdsadresseService.convert(request).getFirst();
 
         assertThat(target.countAdresser(), is(0));
     }
@@ -167,7 +167,7 @@ class OppholdsadresseServiceTest {
         when(adresseServiceConsumer.getVegadresse(any(VegadresseDTO.class), any()))
                 .thenReturn(new no.nav.testnav.libs.dto.adresseservice.v1.VegadresseDTO());
 
-        var target = oppholdsadresseService.convert(request).get(0);
+        var target = oppholdsadresseService.convert(request).getFirst();
 
         assertThat(target.countAdresser(), is(1));
         assertThat(target.getVegadresse(), is(notNullValue()));
@@ -186,7 +186,7 @@ class OppholdsadresseServiceTest {
 
         when(enkelAdresseService.getUtenlandskAdresse(any(), any(), any())).thenReturn(new UtenlandskAdresseDTO());
 
-        var target = oppholdsadresseService.convert(request).get(0);
+        var target = oppholdsadresseService.convert(request).getFirst();
 
         assertThat(target.countAdresser(), is(1));
         assertThat(target.getUtenlandskAdresse(), is(notNullValue()));

--- a/apps/pdl-forvalter/src/test/java/no/nav/pdl/forvalter/service/RelasjonerAlderServiceTest.java
+++ b/apps/pdl-forvalter/src/test/java/no/nav/pdl/forvalter/service/RelasjonerAlderServiceTest.java
@@ -70,7 +70,7 @@ class RelasjonerAlderServiceTest {
         var oppdatertBestilling = relasjonerAlderService.fixRelasjonerAlder(bestilling);
         assertThat(oppdatertBestilling.getFoedtFoer().toLocalDate(),
                 is(equalTo(LocalDate.now(clock).minusYears(18 + 23))));
-        assertThat(oppdatertBestilling.getPerson().getSivilstand().get(0).getNyRelatertPerson().getFoedtFoer().toLocalDate(),
+        assertThat(oppdatertBestilling.getPerson().getSivilstand().getFirst().getNyRelatertPerson().getFoedtFoer().toLocalDate(),
                 is(equalTo(LocalDate.now(clock).minusYears(18 + 23))));
     }
 

--- a/libs/data-transfer-search-objects/src/main/java/no/nav/testnav/libs/data/pdlforvalter/v1/FoedselDTO.java
+++ b/libs/data-transfer-search-objects/src/main/java/no/nav/testnav/libs/data/pdlforvalter/v1/FoedselDTO.java
@@ -16,7 +16,7 @@ import java.time.LocalDateTime;
 @EqualsAndHashCode(callSuper = true)
 @NoArgsConstructor
 @AllArgsConstructor
-public class FoedselDTO extends DbVersjonDTO {
+public class FoedselDTO extends FoedselsdatoDTO {
 
     private String foedekommune;
     private String foedeland;


### PR DESCRIPTION
#deploy-dolly-backend #deploy-test-dolly-backend

The birth details handling in the PdlPerson class has been refactored, changing 'foedsel' to 'foedselsdato' and 'foedested'. This change is reflected across multiple methods and services, ensuring consistent fetch and set operations on birth data throughout the application.