### PR TITLE
bugfix/inntektsmelding_naturalytelse

### DIFF
--- a/apps/dolly-backend/src/main/java/no/nav/dolly/domain/resultset/inntektsmeldingstub/NaturalytelseType.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/domain/resultset/inntektsmeldingstub/NaturalytelseType.java
@@ -1,24 +1,35 @@
 package no.nav.dolly.domain.resultset.inntektsmeldingstub;
 
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
 public enum NaturalytelseType {
 
-    AKSJER_GRUNNFONDSBEVIS_TIL_UNDERKURS,
-    LOSJI,
-    KOST_DOEGN,
-    BESOEKSREISER_HJEMMET_ANNET,
-    KOSTBESPARELSE_I_HJEMMET,
-    RENTEFORDEL_LAAN,
-    BIL,
-    KOST_DAGER,
-    BOLIG,
-    SKATTEPLIKTIG_DEL_FORSIKRINGER,
-    FRI_TRANSPORT,
-    OPSJONER,
-    TILSKUDD_BARNEHAGEPLASS,
-    ANNET,
-    BEDRIFTSBARNEHAGEPLASS,
-    YRKEBIL_TJENESTLIGBEHOV_KILOMETER,
-    YRKEBIL_TJENESTLIGBEHOV_LISTEPRIS,
-    INNBETALING_TIL_UTENLANDSK_PENSJONSORDNING,
-    ELEKTRONISK_KOMMUNIKASJON
+    AKSJER_GRUNNFONDSBEVIS_TIL_UNDERKURS("aksjerGrunnfondsbevisTilUnderkurs"),
+    LOSJI("losji"),
+    KOST_DOEGN("kostDoegn"),
+    BESOEKSREISER_HJEMMET_ANNET("besoeksreiserHjemmetAnnet"),
+    KOSTBESPARELSE_I_HJEMMET("kostbesparelseIHjemmet"),
+    RENTEFORDEL_LAAN("rentefordelLaan"),
+    BIL("bil"),
+    KOST_DAGER("kostDager"),
+    BOLIG("bolig"),
+    SKATTEPLIKTIG_DEL_FORSIKRINGER("skattepliktigDelForsikringer"),
+    FRI_TRANSPORT("friTransport"),
+    OPSJONER("opsjoner"),
+    TILSKUDD_BARNEHAGEPLASS("tilskuddBarnehageplass"),
+    ANNET("annet"),
+    BEDRIFTSBARNEHAGEPLASS("bedriftsbarnehageplass"),
+    YRKEBIL_TJENESTLIGBEHOV_KILOMETER("yrkebilTjenestligbehovKilometer"),
+    YRKEBIL_TJENESTLIGBEHOV_LISTEPRIS("yrkebilTjenestligbehovListepris"),
+    INNBETALING_TIL_UTENLANDSK_PENSJONSORDNING("innbetalingTilUtenlandskPensjonsordning"),
+    ELEKTRONISK_KOMMUNIKASJON("elektroniskKommunikasjon");
+
+    @JsonValue
+    private final String jsonValue;
+
 }

--- a/apps/dolly-backend/src/test/java/no/nav/dolly/bestilling/inntektsmelding/domain/InntektsmeldingRequestTest.java
+++ b/apps/dolly-backend/src/test/java/no/nav/dolly/bestilling/inntektsmelding/domain/InntektsmeldingRequestTest.java
@@ -1,0 +1,28 @@
+package no.nav.dolly.bestilling.inntektsmelding.domain;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import no.nav.dolly.domain.resultset.inntektsmeldingstub.NaturalytelseType;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+class InntektsmeldingRequestTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void testJsonSerializationOfNaturalYtelseDetaljer()
+            throws JsonProcessingException {
+
+        for (NaturalytelseType type : NaturalytelseType.values()) {
+            var detail = new InntektsmeldingRequest.NaturalYtelseDetaljer();
+            detail.setNaturalytelseType(type);
+            var json = objectMapper.writeValueAsString(detail);
+            assertThat(json)
+                    .contains("\"naturalytelseType\":\"" + type.getJsonValue() + "\"");
+        }
+
+    }
+
+}


### PR DESCRIPTION
Ref. https://nav-it.slack.com/archives/CA3P9NGA2/p1720679077666849.

Verdier hentet fra https://github.com/navikt/k9-format/blob/master/inntektsmelding/src/main/resources/xsd/Inntektsmelding_kodelister_20210216.xsd.