### PR TITLE
Add support for person identification in tests

### DIFF
--- a/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/service/AdresseService.java
+++ b/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/service/AdresseService.java
@@ -18,6 +18,8 @@ import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 import static no.nav.pdl.forvalter.utils.ArtifactUtils.getKilde;
 import static no.nav.pdl.forvalter.utils.ArtifactUtils.getMaster;
+import static no.nav.pdl.forvalter.utils.IdenttypeUtility.isNotNpidIdent;
+import static no.nav.pdl.forvalter.utils.TestnorgeIdentUtility.isTestnorgeIdent;
 import static org.apache.commons.lang3.BooleanUtils.isFalse;
 import static org.apache.commons.lang3.BooleanUtils.isTrue;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
@@ -224,5 +226,9 @@ public abstract class AdresseService<T extends AdresseDTO, R> implements BiValid
         for (var i = adresser.size(); i > 0; i--) {
             adresser.get(i - 1).setId(adresser.size() - i + 1);
         }
+    }
+    protected boolean isIdSupported(AdresseDTO adresse, String ident) {
+
+        return isNotNpidIdent(ident) && !isTestnorgeIdent(ident) && !adresse.isPdlMaster();
     }
 }

--- a/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/service/BostedAdresseService.java
+++ b/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/service/BostedAdresseService.java
@@ -24,6 +24,7 @@ import java.util.stream.Stream;
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 import static no.nav.pdl.forvalter.utils.IdenttypeUtility.getIdenttype;
+import static no.nav.pdl.forvalter.utils.TestnorgeIdentUtility.isTestnorgeIdent;
 import static no.nav.testnav.libs.data.pdlforvalter.v1.AdressebeskyttelseDTO.AdresseBeskyttelse.STRENGT_FORTROLIG;
 import static no.nav.testnav.libs.data.pdlforvalter.v1.Identtype.FNR;
 import static org.apache.commons.lang3.BooleanUtils.isNotTrue;
@@ -115,7 +116,13 @@ public class BostedAdresseService extends AdresseService<BostedadresseDTO, Perso
                 }
 
             } else if (bostedadresse.countAdresser() == 0) {
-                bostedadresse.setVegadresse(new VegadresseDTO());
+
+                if (isTestnorgeIdent(person.getIdent())) {
+                    bostedadresse.setUtenlandskAdresse(new UtenlandskAdresseDTO());
+
+                } else {
+                    bostedadresse.setVegadresse(new VegadresseDTO());
+                }
             }
 
         } else if (bostedadresse.countAdresser() == 0) {
@@ -139,14 +146,14 @@ public class BostedAdresseService extends AdresseService<BostedadresseDTO, Perso
 
             var vegadresse =
                     adresseServiceConsumer.getVegadresse(bostedadresse.getVegadresse(), bostedadresse.getAdresseIdentifikatorFraMatrikkelen());
-            bostedadresse.setAdresseIdentifikatorFraMatrikkelen(vegadresse.getMatrikkelId());
+            bostedadresse.setAdresseIdentifikatorFraMatrikkelen(isIdSupported(bostedadresse, person.getIdent()) ? vegadresse.getMatrikkelId() : null);
             mapperFacade.map(vegadresse, bostedadresse.getVegadresse());
 
         } else if (nonNull(bostedadresse.getMatrikkeladresse())) {
 
             var matrikkeladresse =
                     adresseServiceConsumer.getMatrikkeladresse(bostedadresse.getMatrikkeladresse(), bostedadresse.getAdresseIdentifikatorFraMatrikkelen());
-            bostedadresse.setAdresseIdentifikatorFraMatrikkelen(matrikkeladresse.getMatrikkelId());
+            bostedadresse.setAdresseIdentifikatorFraMatrikkelen(isIdSupported(bostedadresse, person.getIdent()) ? matrikkeladresse.getMatrikkelId() : null);
             mapperFacade.map(matrikkeladresse, bostedadresse.getMatrikkeladresse());
 
         } else if (nonNull(bostedadresse.getUtenlandskAdresse())) {

--- a/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/service/KontaktAdresseService.java
+++ b/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/service/KontaktAdresseService.java
@@ -114,7 +114,7 @@ public class KontaktAdresseService extends AdresseService<KontaktadresseDTO, Per
         if (nonNull(kontaktadresse.getVegadresse())) {
             var vegadresse =
                     adresseServiceConsumer.getVegadresse(kontaktadresse.getVegadresse(), kontaktadresse.getAdresseIdentifikatorFraMatrikkelen());
-            kontaktadresse.setAdresseIdentifikatorFraMatrikkelen(kontaktadresse.getMaster() == Master.FREG ? vegadresse.getMatrikkelId() : null);
+            kontaktadresse.setAdresseIdentifikatorFraMatrikkelen(isIdSupported(kontaktadresse, person.getIdent()) ? vegadresse.getMatrikkelId() : null);
             mapperFacade.map(vegadresse, kontaktadresse.getVegadresse());
             kontaktadresse.getVegadresse().setKommunenummer(null);
 

--- a/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/service/OppholdsadresseService.java
+++ b/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/service/OppholdsadresseService.java
@@ -6,7 +6,6 @@ import no.nav.pdl.forvalter.consumer.GenererNavnServiceConsumer;
 import no.nav.pdl.forvalter.exception.InvalidRequestException;
 import no.nav.pdl.forvalter.utils.IdenttypeUtility;
 import no.nav.testnav.libs.data.pdlforvalter.v1.AdressebeskyttelseDTO;
-import no.nav.testnav.libs.data.pdlforvalter.v1.DbVersjonDTO.Master;
 import no.nav.testnav.libs.data.pdlforvalter.v1.OppholdsadresseDTO;
 import no.nav.testnav.libs.data.pdlforvalter.v1.PersonDTO;
 import no.nav.testnav.libs.data.pdlforvalter.v1.StatsborgerskapDTO;
@@ -114,14 +113,14 @@ public class OppholdsadresseService extends AdresseService<OppholdsadresseDTO, P
         if (nonNull(oppholdsadresse.getVegadresse())) {
             var vegadresse =
                     adresseServiceConsumer.getVegadresse(oppholdsadresse.getVegadresse(), oppholdsadresse.getAdresseIdentifikatorFraMatrikkelen());
-            oppholdsadresse.setAdresseIdentifikatorFraMatrikkelen(oppholdsadresse.getMaster() == Master.FREG ?
+            oppholdsadresse.setAdresseIdentifikatorFraMatrikkelen(isIdSupported(oppholdsadresse, person.getIdent()) ?
                     vegadresse.getMatrikkelId() : null);
             mapperFacade.map(vegadresse, oppholdsadresse.getVegadresse());
 
         } else if (nonNull(oppholdsadresse.getMatrikkeladresse())) {
             var matrikkeladresse =
                     adresseServiceConsumer.getMatrikkeladresse(oppholdsadresse.getMatrikkeladresse(), oppholdsadresse.getAdresseIdentifikatorFraMatrikkelen());
-            oppholdsadresse.setAdresseIdentifikatorFraMatrikkelen(matrikkeladresse.getMatrikkelId());
+            oppholdsadresse.setAdresseIdentifikatorFraMatrikkelen(isIdSupported(oppholdsadresse, person.getIdent()) ? matrikkeladresse.getMatrikkelId() : null);
             mapperFacade.map(matrikkeladresse, oppholdsadresse.getMatrikkeladresse());
 
         } else if (nonNull(oppholdsadresse.getUtenlandskAdresse())) {

--- a/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/utils/ArtifactUtils.java
+++ b/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/utils/ArtifactUtils.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.util.Objects.nonNull;
+import static no.nav.pdl.forvalter.utils.TestnorgeIdentUtility.isTestnorgeIdent;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 @UtilityClass
@@ -30,7 +31,8 @@ public class ArtifactUtils {
 
     public static DbVersjonDTO.Master getMaster(DbVersjonDTO artifact, PersonDTO person) {
 
-        return getMaster(artifact, person.getIdenttype());
+        return isTestnorgeIdent(person.getIdent()) ? DbVersjonDTO.Master.PDL :
+                getMaster(artifact, person.getIdenttype());
     }
 
     public static DbVersjonDTO.Master getMaster(DbVersjonDTO artifact, Identtype identtype) {

--- a/apps/pdl-forvalter/src/test/java/no/nav/pdl/forvalter/service/AdressebeskyttelseServiceTest.java
+++ b/apps/pdl-forvalter/src/test/java/no/nav/pdl/forvalter/service/AdressebeskyttelseServiceTest.java
@@ -70,6 +70,7 @@ class AdressebeskyttelseServiceTest {
     void whenStrengtFortroligUtland_thenSetMasterToPdl() {
 
         var request = PersonDTO.builder()
+                .ident(DNR_IDENT)
                 .adressebeskyttelse(List.of(AdressebeskyttelseDTO.builder()
                         .gradering(STRENGT_FORTROLIG_UTLAND)
                         .isNew(true)
@@ -85,6 +86,7 @@ class AdressebeskyttelseServiceTest {
     void whenStrengtFortrolig_thenSetKontaktadresseClearOtherAdresses() {
 
         var request = PersonDTO.builder()
+                .ident(DNR_IDENT)
                 .adressebeskyttelse(List.of(AdressebeskyttelseDTO.builder()
                         .gradering(STRENGT_FORTROLIG)
                         .isNew(true)

--- a/apps/pdl-forvalter/src/test/java/no/nav/pdl/forvalter/service/FolkeregisterPersonstatusServiceTest.java
+++ b/apps/pdl-forvalter/src/test/java/no/nav/pdl/forvalter/service/FolkeregisterPersonstatusServiceTest.java
@@ -41,6 +41,7 @@ class FolkeregisterPersonstatusServiceTest {
 
         var target = folkeregisterPersonstatusService.convert(
                 PersonDTO.builder()
+                        .ident(FNR_IDENT)
                         .folkeregisterPersonstatus(List.of(FolkeregisterPersonstatusDTO.builder()
                                 .status(FORSVUNNET)
                                 .isNew(true)
@@ -55,6 +56,7 @@ class FolkeregisterPersonstatusServiceTest {
 
         var target = folkeregisterPersonstatusService.convert(
                 PersonDTO.builder()
+                        .ident(FNR_IDENT)
                         .folkeregisterPersonstatus(
                                 List.of(FolkeregisterPersonstatusDTO.builder()
                                         .isNew(true)
@@ -73,6 +75,7 @@ class FolkeregisterPersonstatusServiceTest {
 
         var target = folkeregisterPersonstatusService.convert(
                 PersonDTO.builder()
+                        .ident(FNR_IDENT)
                         .folkeregisterPersonstatus(
                                 List.of(FolkeregisterPersonstatusDTO.builder()
                                         .isNew(true)
@@ -90,6 +93,7 @@ class FolkeregisterPersonstatusServiceTest {
 
         var target = folkeregisterPersonstatusService.convert(
                 PersonDTO.builder()
+                        .ident(FNR_IDENT)
                         .folkeregisterPersonstatus(
                                 List.of(FolkeregisterPersonstatusDTO.builder()
                                         .isNew(true)

--- a/apps/pdl-forvalter/src/test/java/no/nav/pdl/forvalter/service/InnflyttingServiceTest.java
+++ b/apps/pdl-forvalter/src/test/java/no/nav/pdl/forvalter/service/InnflyttingServiceTest.java
@@ -23,6 +23,8 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class InnflyttingServiceTest {
 
+    private static final String DNR_IDENT = "45023412345";
+
     @Mock
     private KodeverkConsumer kodeverkConsumer;
 
@@ -52,6 +54,7 @@ class InnflyttingServiceTest {
         when(kodeverkConsumer.getTilfeldigLand()).thenReturn("IND");
 
         var request = PersonDTO.builder()
+                .ident(DNR_IDENT)
                 .innflytting(List.of(InnflyttingDTO.builder()
                         .isNew(true)
                         .build()))

--- a/apps/pdl-forvalter/src/test/java/no/nav/pdl/forvalter/service/UtflyttingServiceTest.java
+++ b/apps/pdl-forvalter/src/test/java/no/nav/pdl/forvalter/service/UtflyttingServiceTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class UtflyttingServiceTest {
 
+    private static final String FNR_IDENT = "03012312345";
     @Mock
     private KodeverkConsumer kodeverkConsumer;
 
@@ -52,6 +53,7 @@ class UtflyttingServiceTest {
         when(kodeverkConsumer.getTilfeldigLand()).thenReturn("TGW");
 
         var request = PersonDTO.builder()
+                .ident(FNR_IDENT)
                 .utflytting(List.of(UtflyttingDTO.builder().isNew(true).build()))
                 .build();
 


### PR DESCRIPTION
#deploy-test-pdl-forvalter #deploy-pdl-forvalter

Added support for setting person identification (FNR_IDENT and DNR_IDENT) in various tests to ensure correct data handling. Enhanced validation logic for address handling based on the type of identification in service classes.