### PR TITLE
Update condition for displaying existing person component

### DIFF
--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/form/partials/familierelasjoner/foreldreansvar/Foreldreansvar.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/form/partials/familierelasjoner/foreldreansvar/Foreldreansvar.tsx
@@ -167,7 +167,7 @@ export const ForeldreansvarForm = ({
 					eksisterendeNyPerson={eksisterendeNyPerson}
 				/>
 			)}
-			{kanHaForeldreansvar && opts?.personFoerLeggTil && (
+			{ansvar === 'ANDRE' && kanHaForeldreansvar && opts?.personFoerLeggTil && (
 				<PdlEksisterendePerson
 					eksisterendePersonPath={`${path}.ansvarssubjekt`}
 					label="Ansvarssubjekt (barn)"


### PR DESCRIPTION
Changed condition to display the PdlEksisterendePerson component when `ansvar` equals 'ANDRE' instead of only `kanHaForeldreansvar`. This ensures the correct UI behavior based on the specified responsibility criteria.