### PR TITLE
change/nais_db_tier

### DIFF
--- a/.github/workflows/common.integration-test.yml
+++ b/.github/workflows/common.integration-test.yml
@@ -37,7 +37,7 @@ jobs:
         run: ./gradlew assemble --scan
       - name: "Start docker containers"
         run: |
-          JWK=$(cat ./mocks/jwk.json) docker-compose up -d --build
+          JWK=$(cat ./mocks/jwk.json) docker compose up --build --detach
       - name: "Health check"
         timeout-minutes: 5
         run: |
@@ -52,4 +52,4 @@ jobs:
         run: ./gradlew iTest --scan
       - name: "Stop docker containers"
         run: |
-          docker-compose down -v --remove-orphans
+          docker compose down --remove-orphans --volumes

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Eller kjør:
 Kjør kommandoen: 
 
 ```
-JWK=$(cat ./mocks/jwk.json) docker-compose up --build
+JWK=$(cat ./mocks/jwk.json) docker compose up --build
 ```
 
 Deretter kan itegrasjonstester kjøres med kommandoen: 

--- a/apps/app-tilgang-analyse-service/config.yml
+++ b/apps/app-tilgang-analyse-service/config.yml
@@ -26,6 +26,7 @@ spec:
   gcp:
     sqlInstances:
       - type: POSTGRES_12
+        tier: db-custom-1-3840
         databases:
           - name: testnav-app-tilgang-analyse-service-db
   liveness:

--- a/apps/bruker-service/config.test.yml
+++ b/apps/bruker-service/config.test.yml
@@ -49,6 +49,7 @@ spec:
   gcp:
     sqlInstances:
       - type: POSTGRES_12
+        tier: db-custom-1-3840
         databases:
           - name: testnav-bruker-service-dev-db
   resources:

--- a/apps/bruker-service/config.yml
+++ b/apps/bruker-service/config.yml
@@ -45,6 +45,7 @@ spec:
   gcp:
     sqlInstances:
       - type: POSTGRES_12
+        tier: db-custom-1-3840
         databases:
           - name: testnav-bruker-service-db
   envFrom:

--- a/apps/dolly-backend/config.test.yml
+++ b/apps/dolly-backend/config.test.yml
@@ -105,6 +105,7 @@ spec:
   gcp:
     sqlInstances:
       - type: POSTGRES_14
+        tier: db-custom-1-3840
         name: testnav-dolly-backend-dev
         databases:
           - name: testnav-dolly-backend-dev

--- a/apps/dolly-backend/config.yml
+++ b/apps/dolly-backend/config.yml
@@ -105,8 +105,8 @@ spec:
   gcp:
     sqlInstances:
       - type: POSTGRES_14
+        tier: db-custom-2-7680
         name: testnav-dolly-backend
         databases:
           - name: testnav-dolly-backend
-        tier: db-custom-2-3840
         autoBackupHour: 2

--- a/apps/generer-organisasjon-populasjon-service/config.yml
+++ b/apps/generer-organisasjon-populasjon-service/config.yml
@@ -31,6 +31,7 @@ spec:
   gcp:
     sqlInstances:
       - type: POSTGRES_12
+        tier: db-custom-1-3840
         databases:
           - name: testnav-generer-organisasjon-populasjon-db
   liveness:

--- a/apps/inntektsmelding-service/config.yml
+++ b/apps/inntektsmelding-service/config.yml
@@ -35,6 +35,7 @@ spec:
   gcp:
     sqlInstances:
       - type: POSTGRES_12
+        tier: db-custom-1-3840
         databases:
           - name: testnav-inntektsmelding-service-db
   liveness:

--- a/apps/levende-arbeidsforhold-ansettelse/config.yml
+++ b/apps/levende-arbeidsforhold-ansettelse/config.yml
@@ -54,14 +54,14 @@ spec:
     - "https://testnav-levende-arbeidsforhold-ansettelse.intern.dev.nav.no"
   gcp:
     sqlInstances:
-      - autoBackupHour: 3 #Lager backup av hele SQL instancen hver dag kl 03:00
-        type: POSTGRES_14
+      - type: POSTGRES_14
+        tier: db-custom-1-3840
         databases:
           - name: testnav-levende-arbeidsforhold-db
         insights:
           enabled: true
           recordApplicationTags: true
           recordClientAddress: true
-        tier: db-f1-micro
         diskAutoresize: true #Kanskje ikke nødvendig?
+        autoBackupHour: 3 #Lager backup av hele SQL instancen hver dag kl 03:00
         #collation: DESC

--- a/apps/organisasjon-bestilling-service/config.yml
+++ b/apps/organisasjon-bestilling-service/config.yml
@@ -41,6 +41,7 @@ spec:
   gcp:
     sqlInstances:
       - type: POSTGRES_12
+        tier: db-custom-1-3840
         databases:
           - name: organisasjon-bestilling-db
   liveness:

--- a/apps/organisasjon-faste-data-service/config.yml
+++ b/apps/organisasjon-faste-data-service/config.yml
@@ -41,6 +41,7 @@ spec:
   gcp:
     sqlInstances:
       - type: POSTGRES_12
+        tier: db-custom-1-3840
         databases:
           - name: testnav-organisasjon-faste-data-db
   liveness:

--- a/apps/organisasjon-forvalter/config.yml
+++ b/apps/organisasjon-forvalter/config.yml
@@ -46,6 +46,7 @@ spec:
   gcp:
     sqlInstances:
       - type: POSTGRES_12
+        tier: db-custom-1-3840
         databases:
           - name: organisasjon-forvalter-db
   liveness:

--- a/apps/organisasjon-tilgang-service/config.yml
+++ b/apps/organisasjon-tilgang-service/config.yml
@@ -66,6 +66,7 @@ spec:
   gcp:
     sqlInstances:
       - type: POSTGRES_15
+        tier: db-custom-1-3840
         name: testnav-organisasjon-tilganger
         databases:
           - name: testnav-organisasjon-tilganger

--- a/apps/orgnummer-service/config.yml
+++ b/apps/orgnummer-service/config.yml
@@ -62,6 +62,7 @@ spec:
   gcp:
     sqlInstances:
       - type: POSTGRES_14
+        tier: db-custom-1-3840
         name: testnav-orgnummer-pool
         databases:
           - name: testnav-orgnummer-pool

--- a/apps/pdl-forvalter/config.test.yml
+++ b/apps/pdl-forvalter/config.test.yml
@@ -68,5 +68,6 @@ spec:
   gcp:
     sqlInstances:
       - type: POSTGRES_12
+        tier: db-custom-1-3840
         databases:
           - name: testnav-pdl-forvalter-dev-db

--- a/apps/pdl-forvalter/config.yml
+++ b/apps/pdl-forvalter/config.yml
@@ -66,6 +66,6 @@ spec:
   gcp:
     sqlInstances:
       - type: POSTGRES_12
+        tier: db-custom-1-3840
         databases:
           - name: testnav-pdl-forvalter-db
-        tier: db-custom-2-3840

--- a/apps/person-faste-data-service/config.yml
+++ b/apps/person-faste-data-service/config.yml
@@ -29,6 +29,7 @@ spec:
   gcp:
     sqlInstances:
       - type: POSTGRES_12
+        tier: db-custom-1-3840
         databases:
           - name: testnav-person-faste-data-db
   liveness:

--- a/apps/testnav-ident-pool/config.yml
+++ b/apps/testnav-ident-pool/config.yml
@@ -62,8 +62,8 @@ spec:
   gcp:
     sqlInstances:
       - type: POSTGRES_14
+        tier: db-custom-1-3840
         name: testnav-identpool
         databases:
           - name: testnav-identpool
-        tier: db-custom-1-3840
         autoBackupHour: 2

--- a/apps/varslinger-service/config.test.yml
+++ b/apps/varslinger-service/config.test.yml
@@ -26,6 +26,7 @@ spec:
   gcp:
     sqlInstances:
       - type: POSTGRES_12
+        tier: db-custom-1-3840
         databases:
           - name: testnav-varslinger-db-dev
   liveness:

--- a/apps/varslinger-service/config.yml
+++ b/apps/varslinger-service/config.yml
@@ -27,6 +27,7 @@ spec:
   gcp:
     sqlInstances:
       - type: POSTGRES_12
+        tier: db-custom-1-3840
         databases:
           - name: testnav-varslinger-db
   liveness:


### PR DESCRIPTION
Ref. https://nav-it.slack.com/archives/C01DE3M9YBV/p1724141273103439.

Lagt til `db-custom-1-3840` der det manglet og normalisert config for lettere oversikt. Har også rettet et par steder der en ikke-lista tier ble brukt.

I følge NAIS har ikke dette noen funksjon da DBene allerede er satt opp, men nå er det i hvert fall ihht. spec slik at app'ene lar seg deploye.

**Edit:**
La også til en fiks for manglende `docker-compose` i denne PRen, siden det var easy fix og lett å teste. Fikser feilende integrasjonstester.