### PR TITLE
Enhance PdlApiConsumer with additional metadata fields

### DIFF
--- a/apps/person-service/src/main/java/no/nav/testnav/apps/personservice/consumer/v1/PdlApiConsumer.java
+++ b/apps/person-service/src/main/java/no/nav/testnav/apps/personservice/consumer/v1/PdlApiConsumer.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import no.nav.testnav.apps.personservice.config.Consumers;
 import no.nav.testnav.apps.personservice.consumer.v1.command.GetPdlAktoerCommand;
 import no.nav.testnav.apps.personservice.consumer.v1.command.GetPdlPersonCommand;
+import no.nav.testnav.apps.personservice.consumer.v1.pdl.graphql.HentPerson;
 import no.nav.testnav.apps.personservice.consumer.v1.pdl.graphql.MetadataDTO;
 import no.nav.testnav.apps.personservice.consumer.v1.pdl.graphql.PdlAktoer;
 import no.nav.testnav.apps.personservice.domain.Person;
@@ -19,14 +20,16 @@ import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 import reactor.util.function.Tuple2;
 
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static java.util.Collections.emptyList;
+import static java.util.Collections.emptySet;
 import static java.util.Objects.nonNull;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
@@ -80,65 +83,6 @@ public class PdlApiConsumer {
                 });
     }
 
-    private boolean isNotPresent(PdlAktoer pdlAktoer) {
-
-        return pdlAktoer.getErrors().stream().anyMatch(value -> value.getMessage().equals("Fant ikke person"));
-    }
-
-    private boolean isGruppe(PdlAktoer.AktoerIdent ident, String gruppe) {
-
-        return isNotBlank(ident.getIdent()) && !ident.getHistorisk() && gruppe.equals(ident.getGruppe());
-    }
-
-    private boolean isPresent(String ident, Tuple2<PdlAktoer, PdlAktoer> pdlAktoer, Set<String> opplysningId) {
-
-        var statusQ1 = isPresent(ident, pdlAktoer.getT1(), "q1", opplysningId);
-        var statusQ2 = isPresent(ident, pdlAktoer.getT2(), "q2", opplysningId);
-
-        log.info("Ident {}, isPresent() {}, (q1: {}, q2: {})", ident, statusQ1 && statusQ2, statusQ1, statusQ2);
-        return statusQ1 && statusQ2;
-    }
-
-    private boolean isPresent(String ident, PdlAktoer pdlAktoer, String miljoe, Set<String> opplysningId) {
-
-        var person = pdlAktoer.getData().getHentPerson();
-        log.info("Sjekker ident {} i miljø {}, med PDL opplysningId {}, sjekkes for mottatt opplysningId {}", ident, miljoe,
-                nonNull(person) ?
-                        Stream.of(person.getNavn(), person.getFoedselsdato(), person.getKjoenn(), person.getFolkeregisterpersonstatus())
-                                .flatMap(Collection::stream)
-                                .map(MetadataDTO::getMetadata)
-                                .map(MetadataDTO.Metadata::getOpplysningsId)
-                                .collect(Collectors.joining(", ")) : null,
-                nonNull(opplysningId) ?
-                        String.join(", ", opplysningId) :
-                        null);
-
-        boolean resultat;
-        if (nonNull(opplysningId)) {
-
-            resultat = nonNull(person) &&
-                    Stream.of(person.getNavn(), person.getFoedselsdato(), person.getKjoenn(), person.getFolkeregisterpersonstatus())
-                            .flatMap(Collection::stream)
-                            .map(MetadataDTO::getMetadata)
-                            .map(MetadataDTO.Metadata::getOpplysningsId)
-                            .anyMatch(opplysningId::contains);
-
-        } else {
-
-            List<PdlAktoer.AktoerIdent> identer = nonNull(pdlAktoer) && nonNull(pdlAktoer.getData()) && nonNull(pdlAktoer.getData().getHentIdenter()) ?
-                    pdlAktoer.getData().getHentIdenter().getIdenter() : emptyList();
-
-            resultat = nonNull(pdlAktoer) &&
-                    pdlAktoer.getErrors().stream().noneMatch(value -> value.getMessage().equals("Fant ikke person")) &&
-                    identer.stream()
-                            .filter(ident1 -> identer.stream().anyMatch(ident2 -> isGruppe(ident2, "AKTORID")))
-                            .anyMatch(ident1 -> identer.stream().anyMatch(ident2 -> isGruppe(ident2, "FOLKEREGISTERIDENT")) ||
-                                    identer.stream().anyMatch(ident2 -> isGruppe(ident2, "NPID")));
-        }
-
-        return resultat;
-    }
-
     public Mono<Optional<PdlAktoer.AktoerIdent>> getAktoer(String ident) {
 
         log.info("Henter ident {} fra PDL", ident);
@@ -161,5 +105,74 @@ public class PdlApiConsumer {
                 .flatMap(token -> Mono.zip(new GetPdlAktoerCommand(webClient, PDL_Q1_URL, ident, token.getTokenValue()).call(),
                                 new GetPdlAktoerCommand(webClient, PDL_URL, ident, token.getTokenValue()).call())
                         .map(tuple -> isPresent(ident, tuple, opplysningId)));
+    }
+
+    private static boolean isNotPresent(PdlAktoer pdlAktoer) {
+
+        return pdlAktoer.getErrors().stream().anyMatch(value -> value.getMessage().equals("Fant ikke person"));
+    }
+
+    private static boolean isGruppe(PdlAktoer.AktoerIdent ident, String gruppe) {
+
+        return isNotBlank(ident.getIdent()) && !ident.getHistorisk() && gruppe.equals(ident.getGruppe());
+    }
+
+    private static boolean isPresent(String ident, Tuple2<PdlAktoer, PdlAktoer> pdlAktoer, Set<String> opplysningId) {
+
+        var statusQ1 = isPresent(ident, pdlAktoer.getT1(), "q1", opplysningId);
+        var statusQ2 = isPresent(ident, pdlAktoer.getT2(), "q2", opplysningId);
+
+        log.info("Ident {}, isPresent() {}, (q1: {}, q2: {})", ident, statusQ1 && statusQ2, statusQ1, statusQ2);
+        return statusQ1 && statusQ2;
+    }
+
+    private static boolean isPresent(String ident, PdlAktoer pdlAktoer, String miljoe, Set<String> opplysningId) {
+
+        var opplysningIdsFraPdl = getOpplysningIds(pdlAktoer.getData().getHentPerson());
+
+        log.info("Sjekker ident {} i miljø {}, med PDL opplysningId {}, sjekkes for mottatt opplysningId {}", ident, miljoe,
+                String.join(",",opplysningIdsFraPdl),
+                nonNull(opplysningId) ?
+                        String.join(", ", opplysningId) :
+                        null);
+
+        boolean resultat;
+        if (nonNull(opplysningId)) {
+
+            return opplysningId.stream()
+                    .anyMatch(opplysningIdsFraPdl::contains);
+
+        } else {
+
+            List<PdlAktoer.AktoerIdent> identer = nonNull(pdlAktoer) && nonNull(pdlAktoer.getData()) && nonNull(pdlAktoer.getData().getHentIdenter()) ?
+                    pdlAktoer.getData().getHentIdenter().getIdenter() : emptyList();
+
+            resultat = nonNull(pdlAktoer) &&
+                    pdlAktoer.getErrors().stream().noneMatch(value -> value.getMessage().equals("Fant ikke person")) &&
+                    identer.stream()
+                            .filter(ident1 -> identer.stream().anyMatch(ident2 -> isGruppe(ident2, "AKTORID")))
+                            .anyMatch(ident1 -> identer.stream().anyMatch(ident2 -> isGruppe(ident2, "FOLKEREGISTERIDENT")) ||
+                                    identer.stream().anyMatch(ident2 -> isGruppe(ident2, "NPID")));
+        }
+
+        return resultat;
+    }
+
+    private static Set<String> getOpplysningIds(HentPerson hentPerson) {
+
+        return nonNull(hentPerson) ? Arrays.stream(hentPerson.getClass().getMethods())
+                .filter(method -> method.getName().contains("get"))
+                .filter(method -> method.getReturnType().equals(List.class))
+                .map(method -> {
+                    try {
+                        return (List<? extends MetadataDTO>) method.invoke(hentPerson);
+                    } catch (IllegalAccessException | InvocationTargetException e) {
+                        throw new RuntimeException(e);
+                    }
+                })
+                .flatMap(Collection::stream)
+                .map(MetadataDTO::getMetadata)
+                .map(MetadataDTO.Metadata::getOpplysningsId)
+                .collect(Collectors.toSet()) : emptySet();
     }
 }

--- a/apps/person-service/src/main/java/no/nav/testnav/apps/personservice/consumer/v1/pdl/graphql/HentPerson.java
+++ b/apps/person-service/src/main/java/no/nav/testnav/apps/personservice/consumer/v1/pdl/graphql/HentPerson.java
@@ -19,6 +19,28 @@ public class HentPerson {
     List<Bostedsadresse> bostedsadresse;
     List<Folkeregisteridentifikator> folkeregisteridentifikator;
     List<Folkeregisterpersonstatus> folkeregisterpersonstatus;
+    List<MetadataDTO> foedested;
+    List<MetadataDTO> doedsfall;
+    List<MetadataDTO> sivilstand;
+    List<MetadataDTO> oppholdsadresse;
+    List<MetadataDTO> kontaktadresse;
+    List<MetadataDTO> innflyttingTilNorge;
+    List<MetadataDTO> utflyttingFraNorge;
+    List<MetadataDTO> vergemaalEllerFremtidsfullmakt;
+    List<MetadataDTO> doedfoedtBarn;
+    List<MetadataDTO> adressebeskyttelse;
+    List<MetadataDTO> falskIdentitet;
+    List<MetadataDTO> utenlandskIdentifikasjonsnummer;
+    List<MetadataDTO> tilrettelagtKommunikasjon;
+    List<MetadataDTO> sikkerhetstiltak;
+    List<MetadataDTO> deltBosted;
+    List<MetadataDTO> forelderBarnRelasjon;
+    List<MetadataDTO> foreldreansvar;
+    List<MetadataDTO> kontaktinformasjonForDoedsbo;
+    List<MetadataDTO> navspersonidentifikator;
+    List<MetadataDTO> statsborgerskap;
+    List<MetadataDTO> opphold;
+    List<MetadataDTO> fullmakt;
 
     public List<Navn> getNavn() {
 
@@ -54,7 +76,7 @@ public class HentPerson {
 
     public List<Bostedsadresse> getBostedsadresse() {
 
-        if(isNull(bostedsadresse)) {
+        if (isNull(bostedsadresse)) {
             bostedsadresse = new ArrayList<>();
         }
         return bostedsadresse;
@@ -66,5 +88,181 @@ public class HentPerson {
             folkeregisterpersonstatus = new ArrayList<>();
         }
         return folkeregisterpersonstatus;
+    }
+
+    public List<MetadataDTO> getFoedested() {
+
+        if (isNull(foedested)) {
+            foedested = new ArrayList<>();
+        }
+        return foedested;
+    }
+
+    public List<MetadataDTO> getDoedsfall() {
+
+        if (isNull(doedsfall)) {
+            doedsfall = new ArrayList<>();
+        }
+        return doedsfall;
+    }
+
+    public List<MetadataDTO> getVergemaalEllerFremtidsfullmakt() {
+
+        if (isNull(vergemaalEllerFremtidsfullmakt)) {
+            vergemaalEllerFremtidsfullmakt = new ArrayList<>();
+        }
+        return vergemaalEllerFremtidsfullmakt;
+    }
+
+    public List<MetadataDTO> getDoedfoedtBarn() {
+
+        if (isNull(doedfoedtBarn)) {
+            doedfoedtBarn = new ArrayList<>();
+        }
+        return doedfoedtBarn;
+    }
+
+    public List<MetadataDTO> getAdressebeskyttelse() {
+
+        if (isNull(adressebeskyttelse)) {
+            adressebeskyttelse = new ArrayList<>();
+        }
+        return adressebeskyttelse;
+    }
+
+    public List<MetadataDTO> getFalskIdentitet() {
+
+        if (isNull(falskIdentitet)) {
+            falskIdentitet = new ArrayList<>();
+        }
+        return falskIdentitet;
+    }
+
+    public List<MetadataDTO> getUtenlandskIdentifikasjonsnummer() {
+
+        if (isNull(utenlandskIdentifikasjonsnummer)) {
+            utenlandskIdentifikasjonsnummer = new ArrayList<>();
+        }
+        return utenlandskIdentifikasjonsnummer;
+    }
+
+    public List<MetadataDTO> getTilrettelagtKommunikasjon() {
+
+        if (isNull(tilrettelagtKommunikasjon)) {
+            tilrettelagtKommunikasjon = new ArrayList<>();
+        }
+        return tilrettelagtKommunikasjon;
+    }
+
+    public List<MetadataDTO> getSikkerhetstiltak() {
+
+        if (isNull(sikkerhetstiltak)) {
+            sikkerhetstiltak = new ArrayList<>();
+        }
+        return sikkerhetstiltak;
+    }
+
+    public List<MetadataDTO> getDeltBosted() {
+
+        if (isNull(deltBosted)) {
+            deltBosted = new ArrayList<>();
+        }
+        return deltBosted;
+    }
+
+    public List<MetadataDTO> getForelderBarnRelasjon() {
+
+        if (isNull(forelderBarnRelasjon)) {
+            forelderBarnRelasjon = new ArrayList<>();
+        }
+        return forelderBarnRelasjon;
+    }
+
+    public List<MetadataDTO> getForeldreansvar() {
+
+        if (isNull(foreldreansvar)) {
+            foreldreansvar = new ArrayList<>();
+        }
+        return foreldreansvar;
+    }
+
+    public List<MetadataDTO> getKontaktinformasjonForDoedsbo() {
+
+        if (isNull(kontaktinformasjonForDoedsbo)) {
+            kontaktinformasjonForDoedsbo = new ArrayList<>();
+        }
+        return kontaktinformasjonForDoedsbo;
+    }
+
+    public List<MetadataDTO> getNavspersonidentifikator() {
+
+        if (isNull(navspersonidentifikator)) {
+            navspersonidentifikator = new ArrayList<>();
+        }
+        return navspersonidentifikator;
+    }
+
+    public List<MetadataDTO> getSivilstand() {
+
+        if (isNull(sivilstand)) {
+            sivilstand = new ArrayList<>();
+        }
+        return sivilstand;
+    }
+
+    public List<MetadataDTO> getStatsborgerskap() {
+
+        if (isNull(statsborgerskap)) {
+            statsborgerskap = new ArrayList<>();
+        }
+        return statsborgerskap;
+    }
+
+    public List<MetadataDTO> getOppholdsadresse() {
+
+        if (isNull(oppholdsadresse)) {
+            oppholdsadresse = new ArrayList<>();
+        }
+        return oppholdsadresse;
+    }
+
+    public List<MetadataDTO> getKontaktadresse() {
+
+        if (isNull(kontaktadresse)) {
+            kontaktadresse = new ArrayList<>();
+        }
+        return kontaktadresse;
+    }
+
+    public List<MetadataDTO> getInnflyttingTilNorge() {
+
+        if (isNull(innflyttingTilNorge)) {
+            innflyttingTilNorge = new ArrayList<>();
+        }
+        return innflyttingTilNorge;
+    }
+
+    public List<MetadataDTO> getUtflyttingFraNorge() {
+
+        if (isNull(utflyttingFraNorge)) {
+            utflyttingFraNorge = new ArrayList<>();
+        }
+        return utflyttingFraNorge;
+    }
+
+    public List<MetadataDTO> getOpphold() {
+
+        if (isNull(opphold)) {
+            opphold = new ArrayList<>();
+        }
+        return opphold;
+    }
+
+    public List<MetadataDTO> getFullmakt() {
+
+        if (isNull(fullmakt)) {
+            fullmakt = new ArrayList<>();
+        }
+        return fullmakt;
     }
 }

--- a/apps/person-service/src/main/resources/pdl/pdl-api-schema.graphql
+++ b/apps/person-service/src/main/resources/pdl/pdl-api-schema.graphql
@@ -899,7 +899,7 @@ input SearchRule {
     " Begrenser treff til kun de hvor felt har input verdi"
     equals: String
     " Sjekker om feltet finnes / at det ikke har en null verdi."
-    exists: String
+    exists: Boolean
     """
 
     Søk fra og med (se fromExcluding for bare fra men ikke med)
@@ -921,7 +921,7 @@ input SearchRule {
     " Filtrerer bort treff hvor felt inneholder input verdi"
     notEquals: String
     " Søk som gir tilfeldig poengsum til hvert treff (kun ment til generering av testdata)"
-    random: String
+    random: Float
     " Regex søk for spesielle situasjoner (Dette er en treg opprasjon og bør ikke brukes)"
     regex: String
     " Gir treff når opgitt feltstarter med opgitt verdi."

--- a/apps/person-service/src/main/resources/pdl/pdlPersonQuery.graphql
+++ b/apps/person-service/src/main/resources/pdl/pdlPersonQuery.graphql
@@ -11,12 +11,137 @@ query($ident1: ID!) {
                 opplysningsId
             }
         }
+        foedested {
+            metadata {
+                opplysningsId
+            }
+        }
         kjoenn {
             metadata {
                 opplysningsId
             }
         }
+        bostedsadresse {
+            metadata {
+                opplysningsId
+            }
+        }
+        oppholdsadresse {
+            metadata {
+                opplysningsId
+            }
+        }
+        kontaktadresse {
+            metadata {
+                opplysningsId
+            }
+        }
+        innflyttingTilNorge {
+            metadata {
+                opplysningsId
+            }
+        }
+        utflyttingFraNorge {
+            metadata {
+                opplysningsId
+            }
+        }
+        doedsfall {
+            metadata {
+                opplysningsId
+            }
+        }
+        vergemaalEllerFremtidsfullmakt {
+            metadata {
+                opplysningsId
+            }
+        }
+        doedfoedtBarn {
+            metadata {
+                opplysningsId
+            }
+        }
+        adressebeskyttelse {
+            metadata {
+                opplysningsId
+            }
+        }
+        falskIdentitet {
+            metadata {
+                opplysningsId
+            }
+        }
+        utenlandskIdentifikasjonsnummer {
+            metadata {
+                opplysningsId
+            }
+        }
+        tilrettelagtKommunikasjon {
+            metadata {
+                opplysningsId
+            }
+        }
+        sikkerhetstiltak {
+            metadata {
+                opplysningsId
+            }
+        }
         folkeregisterpersonstatus {
+            metadata {
+                opplysningsId
+            }
+        }
+        deltBosted {
+            metadata {
+                opplysningsId
+            }
+        }
+        forelderBarnRelasjon {
+            metadata {
+                opplysningsId
+            }
+        }
+        foreldreansvar {
+            metadata {
+                opplysningsId
+            }
+        }
+        kontaktinformasjonForDoedsbo {
+            metadata {
+                opplysningsId
+            }
+        }
+        navspersonidentifikator {
+            metadata {
+                opplysningsId
+            }
+        }
+        folkeregisteridentifikator {
+            metadata {
+                opplysningsId
+            }
+        }
+        sivilstand {
+            metadata {
+                opplysningsId
+            }
+        }
+        statsborgerskap {
+            metadata {
+                opplysningsId
+            }
+        }
+        telefonnummer {
+            metadata {
+                opplysningsId
+            }
+        }
+        opphold {
+            metadata {
+                opplysningsId
+            }
+        }
+        fullmakt {
             metadata {
                 opplysningsId
             }


### PR DESCRIPTION
#deploy-person-service

Added new metadata fields to the PdlApiConsumer and updated related GraphQL queries to fetch comprehensive person details. This enhancement includes fields like address protection, birthplaces, and security measures, improving the data completeness for consumer operations.