### PR TITLE
Refactor to use WebClient.Builder in consumers

### DIFF
--- a/apps/adresse-service/src/main/java/no/nav/testnav/apps/adresseservice/consumer/PdlAdresseConsumer.java
+++ b/apps/adresse-service/src/main/java/no/nav/testnav/apps/adresseservice/consumer/PdlAdresseConsumer.java
@@ -11,17 +11,18 @@ import org.springframework.web.reactive.function.client.WebClient;
 
 @Service
 public class PdlAdresseConsumer {
+
     private final WebClient webClient;
     private final TokenExchange tokenExchange;
     private final ServerProperties serverProperties;
 
     public PdlAdresseConsumer(
             TokenExchange tokenExchange,
-            Consumers consumers) {
+            Consumers consumers,
+            WebClient.Builder webClientBuilder) {
         this.tokenExchange = tokenExchange;
         serverProperties = consumers.getPdlServices();
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .baseUrl(serverProperties.getUrl())
                 .build();
     }

--- a/apps/amelding-service/src/main/java/no/nav/registre/testnav/ameldingservice/consumer/OppsummeringsdokumentConsumer.java
+++ b/apps/amelding-service/src/main/java/no/nav/registre/testnav/ameldingservice/consumer/OppsummeringsdokumentConsumer.java
@@ -30,10 +30,11 @@ public class OppsummeringsdokumentConsumer {
     public OppsummeringsdokumentConsumer(
             Consumers consumers,
             ObjectMapper objectMapper,
-            ApplicationProperties applicationProperties) {
+            ApplicationProperties applicationProperties,
+            WebClient.Builder webClientBuilder) {
+
         this.applicationProperties = applicationProperties;
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .baseUrl(consumers.getOppsummeringsdokumentService().getUrl())
                 .codecs(
                         clientDefaultCodecsConfigurer -> {

--- a/apps/app-tilgang-analyse-service/src/main/java/no/nav/testnav/apps/apptilganganalyseservice/consumer/GithubConsumer.java
+++ b/apps/app-tilgang-analyse-service/src/main/java/no/nav/testnav/apps/apptilganganalyseservice/consumer/GithubConsumer.java
@@ -18,10 +18,11 @@ public class GithubConsumer {
     private static final int PAGE_SIZE = 100;
     private final WebClient webClient;
 
-    public GithubConsumer(@Value("${consumers.github.url}") String url, @Value("${consumers.github.token}") String token) {
+    public GithubConsumer(@Value("${consumers.github.url}") String url,
+                          @Value("${consumers.github.token}") String token,
+                          WebClient.Builder webClientBuilder) {
 
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .baseUrl(url)
                 .defaultHeader(HttpHeaders.AUTHORIZATION, "token " + token)
                 .exchangeStrategies(ExchangeStrategies.builder()

--- a/apps/arbeidsforhold-service/src/main/java/no/nav/registre/testnorge/arbeidsforholdservice/consumer/AaregConsumer.java
+++ b/apps/arbeidsforhold-service/src/main/java/no/nav/registre/testnorge/arbeidsforholdservice/consumer/AaregConsumer.java
@@ -32,7 +32,9 @@ public class AaregConsumer {
     public AaregConsumer(
             Consumers consumers,
             TokenExchange tokenExchange,
-            ObjectMapper objectMapper) {
+            ObjectMapper objectMapper,
+            WebClient.Builder webClientBuilder) {
+
         serverProperties = consumers.getTestnavAaregProxy();
         this.tokenExchange = tokenExchange;
         ExchangeStrategies jacksonStrategy = ExchangeStrategies
@@ -47,8 +49,7 @@ public class AaregConsumer {
                                     .jackson2JsonDecoder(new Jackson2JsonDecoder(objectMapper, MediaType.APPLICATION_JSON));
                         })
                 .build();
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .exchangeStrategies(jacksonStrategy)
                 .baseUrl(serverProperties.getUrl())
                 .build();

--- a/apps/bruker-service/src/main/java/no/nav/testnav/apps/brukerservice/consumer/PersonOrganisasjonTilgangConsumer.java
+++ b/apps/bruker-service/src/main/java/no/nav/testnav/apps/brukerservice/consumer/PersonOrganisasjonTilgangConsumer.java
@@ -23,7 +23,8 @@ public class PersonOrganisasjonTilgangConsumer {
     public PersonOrganisasjonTilgangConsumer(
             Consumers consumers,
             TokenExchange tokenExchange,
-            ObjectMapper objectMapper) {
+            ObjectMapper objectMapper,
+            WebClient.Builder webClientBuilder) {
         serverProperties = consumers.getTestnavPersonOrganisasjonTilgangService();
         this.tokenExchange = tokenExchange;
         ExchangeStrategies jacksonStrategy = ExchangeStrategies
@@ -36,8 +37,7 @@ public class PersonOrganisasjonTilgangConsumer {
                                     .jackson2JsonDecoder(new Jackson2JsonDecoder(objectMapper, MediaType.APPLICATION_JSON));
                         })
                 .build();
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .exchangeStrategies(jacksonStrategy)
                 .baseUrl(serverProperties.getUrl())
                 .build();

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/pensjonforvalter/PensjonforvalterClient.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/pensjonforvalter/PensjonforvalterClient.java
@@ -141,6 +141,7 @@ public class PensjonforvalterClient implements ClientRegister {
                                             log.warn("Persondata for {} gir tom response fra PDL", dollyPerson.getIdent());
                                         }
                                     })
+                                    .filter(utvidetPersondata -> !utvidetPersondata.getT1().isEmpty())
                                     .flatMap(utvidetPersondata -> Flux.concat(
                                                     opprettPersoner(dollyPerson.getIdent(), tilgjengeligeMiljoer, utvidetPersondata.getT1())
                                                             .map(response -> PENSJON_FORVALTER + decodeStatus(response, dollyPerson.getIdent())),
@@ -150,6 +151,7 @@ public class PensjonforvalterClient implements ClientRegister {
                                             )
                                             .collectList()
                                             .doOnNext(statusResultat::addAll)
+                                            .filter(status -> status.stream().allMatch(entry -> entry.contains("OK")))
                                             .map(status -> Flux.just(bestilling1)
                                                     .filter(bestilling2 -> nonNull(bestilling2.getPensjonforvalter()))
                                                     .map(RsDollyUtvidetBestilling::getPensjonforvalter)

--- a/apps/dolly-frontend/src/main/java/no/nav/dolly/web/consumers/BrukerConsumer.java
+++ b/apps/dolly-frontend/src/main/java/no/nav/dolly/web/consumers/BrukerConsumer.java
@@ -19,12 +19,12 @@ public class BrukerConsumer {
     private final AccessService accessService;
 
     public BrukerConsumer(TestnavBrukerServiceProperties serviceProperties,
-                          AccessService accessService) {
+                          AccessService accessService,
+                          WebClient.Builder webClientBuilder) {
 
         this.serviceProperties = serviceProperties;
         this.accessService = accessService;
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .baseUrl(serviceProperties.getUrl())
                 .build();
     }

--- a/apps/dolly-frontend/src/main/java/no/nav/dolly/web/consumers/PersonOrganisasjonTilgangConsumer.java
+++ b/apps/dolly-frontend/src/main/java/no/nav/dolly/web/consumers/PersonOrganisasjonTilgangConsumer.java
@@ -2,8 +2,8 @@ package no.nav.dolly.web.consumers;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
-import no.nav.dolly.web.consumers.command.GetPersonOrganisasjonTilgangCommand;
 import no.nav.dolly.web.config.Consumers;
+import no.nav.dolly.web.consumers.command.GetPersonOrganisasjonTilgangCommand;
 import no.nav.dolly.web.service.AccessService;
 import no.nav.testnav.libs.securitycore.domain.ServerProperties;
 import org.springframework.http.MediaType;
@@ -27,7 +27,8 @@ public class PersonOrganisasjonTilgangConsumer {
     public PersonOrganisasjonTilgangConsumer(
             Consumers consumers,
             AccessService accessService,
-            ObjectMapper objectMapper) {
+            ObjectMapper objectMapper,
+            WebClient.Builder webClientBuilder) {
 
         this.accessService = accessService;
         serverProperties = consumers.getTestnavPersonOrganisasjonTilgangService();
@@ -39,8 +40,7 @@ public class PersonOrganisasjonTilgangConsumer {
                             .jackson2JsonDecoder(new Jackson2JsonDecoder(objectMapper, MediaType.APPLICATION_JSON));
                 }).build();
 
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .exchangeStrategies(jacksonStrategy)
                 .baseUrl(serverProperties.getUrl())
                 .build();

--- a/apps/dolly-frontend/src/main/java/no/nav/dolly/web/consumers/TilbakemeldingConsumer.java
+++ b/apps/dolly-frontend/src/main/java/no/nav/dolly/web/consumers/TilbakemeldingConsumer.java
@@ -23,10 +23,11 @@ public class TilbakemeldingConsumer {
 
     public TilbakemeldingConsumer(
             Consumers consumers,
-            AccessService accessService) {
+            AccessService accessService,
+            WebClient.Builder webClientBuilder) {
 
         serverProperties = consumers.getTestnorgeTilbakemeldingApi();
-        this.webClient = WebClient.builder()
+        this.webClient = webClientBuilder
                 .baseUrl(serverProperties.getUrl())
                 .build();
         this.accessService = accessService;

--- a/apps/endringsmelding-service/src/main/java/no/nav/testnav/endringsmeldingservice/consumer/AdresseServiceConsumer.java
+++ b/apps/endringsmelding-service/src/main/java/no/nav/testnav/endringsmeldingservice/consumer/AdresseServiceConsumer.java
@@ -19,11 +19,12 @@ public class AdresseServiceConsumer {
 
     public AdresseServiceConsumer(
             TokenExchange tokenExchange,
-            Consumers consumers) {
+            Consumers consumers,
+            WebClient.Builder webClientBuilder) {
+
         this.tokenExchange = tokenExchange;
         serverProperties = consumers.getAdresseService();
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .baseUrl(serverProperties.getUrl())
                 .build();
     }

--- a/apps/endringsmelding-service/src/main/java/no/nav/testnav/endringsmeldingservice/consumer/GenererNavnServiceConsumer.java
+++ b/apps/endringsmelding-service/src/main/java/no/nav/testnav/endringsmeldingservice/consumer/GenererNavnServiceConsumer.java
@@ -20,11 +20,12 @@ public class GenererNavnServiceConsumer {
 
     public GenererNavnServiceConsumer(
             TokenExchange tokenExchange,
-            Consumers consumers) {
+            Consumers consumers,
+            WebClient.Builder webClientBuilder) {
+
         this.tokenExchange = tokenExchange;
         serverProperties = consumers.getGenererNavnService();
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .baseUrl(serverProperties.getUrl())
                 .build();
     }

--- a/apps/endringsmelding-service/src/main/java/no/nav/testnav/endringsmeldingservice/consumer/IdentPoolConsumer.java
+++ b/apps/endringsmelding-service/src/main/java/no/nav/testnav/endringsmeldingservice/consumer/IdentPoolConsumer.java
@@ -20,11 +20,12 @@ public class IdentPoolConsumer {
 
     public IdentPoolConsumer(
             TokenExchange tokenExchange,
-            Consumers consumers) {
+            Consumers consumers,
+            WebClient.Builder webClientBuilder) {
+
         this.tokenExchange = tokenExchange;
         serverProperties = consumers.getIdentPool();
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .baseUrl(serverProperties.getUrl())
                 .build();
     }

--- a/apps/endringsmelding-service/src/main/java/no/nav/testnav/endringsmeldingservice/consumer/TpsMessagingConsumer.java
+++ b/apps/endringsmelding-service/src/main/java/no/nav/testnav/endringsmeldingservice/consumer/TpsMessagingConsumer.java
@@ -45,7 +45,8 @@ public class TpsMessagingConsumer {
     public TpsMessagingConsumer(
             Consumers consumers,
             TokenExchange tokenExchange,
-            ObjectMapper objectMapper) {
+            ObjectMapper objectMapper,
+            WebClient.Builder webClientBuilder) {
 
         serverProperties = consumers.getTpsMessagingService();
         this.accessTokenService = tokenExchange;
@@ -59,8 +60,7 @@ public class TpsMessagingConsumer {
                 }).build();
 
 
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .exchangeStrategies(jacksonStrategy)
                 .baseUrl(serverProperties.getUrl())
                 .build();

--- a/apps/generer-arbeidsforhold-populasjon-service/src/main/java/no/nav/registre/testnav/genererarbeidsforholdpopulasjonservice/consumer/GenererOrganisasjonPopulasjonConsumer.java
+++ b/apps/generer-arbeidsforhold-populasjon-service/src/main/java/no/nav/registre/testnav/genererarbeidsforholdpopulasjonservice/consumer/GenererOrganisasjonPopulasjonConsumer.java
@@ -17,12 +17,12 @@ public class GenererOrganisasjonPopulasjonConsumer {
 
     public GenererOrganisasjonPopulasjonConsumer(
             Consumers consumers,
-            TokenExchange tokenExchange) {
+            TokenExchange tokenExchange,
+            WebClient.Builder webClientBuilder) {
 
         serverProperties = consumers.getTestnavGenererOrganisasjonPopulasjonService();
         this.tokenExchange = tokenExchange;
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .baseUrl(serverProperties.getUrl())
                 .build();
     }

--- a/apps/generer-arbeidsforhold-populasjon-service/src/main/java/no/nav/registre/testnav/genererarbeidsforholdpopulasjonservice/consumer/OppsummeringsdokumentConsumer.java
+++ b/apps/generer-arbeidsforhold-populasjon-service/src/main/java/no/nav/registre/testnav/genererarbeidsforholdpopulasjonservice/consumer/OppsummeringsdokumentConsumer.java
@@ -42,15 +42,15 @@ public class OppsummeringsdokumentConsumer {
             TokenExchange tokenExchange,
             Consumers consumers,
             ObjectMapper objectMapper,
-            ApplicationProperties applicationProperties) {
+            ApplicationProperties applicationProperties,
+            WebClient.Builder webClientBuilder) {
 
         this.applicationProperties = applicationProperties;
         this.tokenExchange = tokenExchange;
         serverProperties = consumers.getOppsummeringsdokumentService();
         this.executor = Executors.newFixedThreadPool(20);
 
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .baseUrl(serverProperties.getUrl())
                 .codecs(clientDefaultCodecsConfigurer -> {
                     clientDefaultCodecsConfigurer.defaultCodecs().maxInMemorySize(BYTE_COUNT);

--- a/apps/generer-arbeidsforhold-populasjon-service/src/main/java/no/nav/registre/testnav/genererarbeidsforholdpopulasjonservice/consumer/OrganisasjonConsumer.java
+++ b/apps/generer-arbeidsforhold-populasjon-service/src/main/java/no/nav/registre/testnav/genererarbeidsforholdpopulasjonservice/consumer/OrganisasjonConsumer.java
@@ -25,12 +25,12 @@ public class OrganisasjonConsumer {
 
     public OrganisasjonConsumer(
             Consumers consumers,
-            TokenExchange tokenExchange) {
+            TokenExchange tokenExchange,
+            WebClient.Builder webClientBuilder) {
 
         serverProperties = consumers.getTestnavOrganisasjonService();
         this.tokenExchange = tokenExchange;
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .baseUrl(serverProperties.getUrl())
                 .build();
     }

--- a/apps/generer-arbeidsforhold-populasjon-service/src/main/java/no/nav/registre/testnav/genererarbeidsforholdpopulasjonservice/consumer/SyntArbeidsforholdConsumer.java
+++ b/apps/generer-arbeidsforhold-populasjon-service/src/main/java/no/nav/registre/testnav/genererarbeidsforholdpopulasjonservice/consumer/SyntArbeidsforholdConsumer.java
@@ -28,13 +28,13 @@ public class SyntArbeidsforholdConsumer {
     public SyntArbeidsforholdConsumer(
             TokenExchange tokenExchange,
             Consumers consumers,
-            ObjectMapper objectMapper) {
+            ObjectMapper objectMapper,
+            WebClient.Builder webClientBuilder) {
 
         this.tokenExchange = tokenExchange;
         serverProperties = consumers.getSyntAmelding();
         this.objectMapper = objectMapper;
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .baseUrl(serverProperties.getUrl())
                 .codecs(clientDefaultCodecsConfigurer -> {
                     clientDefaultCodecsConfigurer

--- a/apps/generer-organisasjon-populasjon-service/src/main/java/no/nav/registre/testnav/genererorganisasjonpopulasjonservice/consumer/GenererNavnConsumer.java
+++ b/apps/generer-organisasjon-populasjon-service/src/main/java/no/nav/registre/testnav/genererorganisasjonpopulasjonservice/consumer/GenererNavnConsumer.java
@@ -17,11 +17,12 @@ public class GenererNavnConsumer {
 
     public GenererNavnConsumer(
             Consumers consumers,
-            TokenExchange tokenExchange) {
+            TokenExchange tokenExchange,
+            WebClient.Builder webClientBuilder) {
+
         this.tokenExchange = tokenExchange;
         serverProperties = consumers.getGenererNavnService();
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .baseUrl(serverProperties.getUrl())
                 .build();
     }

--- a/apps/generer-organisasjon-populasjon-service/src/main/java/no/nav/registre/testnav/genererorganisasjonpopulasjonservice/consumer/OrgnummerConsumer.java
+++ b/apps/generer-organisasjon-populasjon-service/src/main/java/no/nav/registre/testnav/genererorganisasjonpopulasjonservice/consumer/OrgnummerConsumer.java
@@ -16,11 +16,12 @@ public class OrgnummerConsumer {
 
     public OrgnummerConsumer(
             Consumers consumers,
-            TokenExchange tokenExchange) {
+            TokenExchange tokenExchange,
+            WebClient.Builder webClientBuilder) {
+
         serverProperties = consumers.getTestnavOrgnummerService();
         this.tokenExchange = tokenExchange;
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .baseUrl(serverProperties.getUrl())
                 .build();
     }

--- a/apps/generer-synt-amelding-service/src/main/java/no/nav/registre/testnorge/generersyntameldingservice/consumer/SyntAmeldingConsumer.java
+++ b/apps/generer-synt-amelding-service/src/main/java/no/nav/registre/testnorge/generersyntameldingservice/consumer/SyntAmeldingConsumer.java
@@ -22,11 +22,12 @@ public class SyntAmeldingConsumer {
     private final TokenExchange tokenExchange;
 
     public SyntAmeldingConsumer(TokenExchange tokenExchange,
-                                Consumers consumers) {
+                                Consumers consumers,
+                                WebClient.Builder webClientBuilder) {
+
         this.tokenExchange = tokenExchange;
         serverProperties = consumers.getSyntAmelding();
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .exchangeStrategies(
                         ExchangeStrategies
                                 .builder()

--- a/apps/inntektsmelding-service/src/main/java/no/nav/registre/testnav/inntektsmeldingservice/consumer/DokmotConsumer.java
+++ b/apps/inntektsmelding-service/src/main/java/no/nav/registre/testnav/inntektsmeldingservice/consumer/DokmotConsumer.java
@@ -27,11 +27,12 @@ public class DokmotConsumer {
 
     public DokmotConsumer(
             Consumers consumers,
-            TokenExchange tokenExchange) {
+            TokenExchange tokenExchange,
+            WebClient.Builder webClientBuilder) {
+
         this.tokenExchange = tokenExchange;
         serverProperties = consumers.getTestnavDokarkivProxy();
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .baseUrl(serverProperties.getUrl())
                 .build();
     }

--- a/apps/inntektsmelding-service/src/main/java/no/nav/registre/testnav/inntektsmeldingservice/consumer/GenererInntektsmeldingConsumer.java
+++ b/apps/inntektsmelding-service/src/main/java/no/nav/registre/testnav/inntektsmeldingservice/consumer/GenererInntektsmeldingConsumer.java
@@ -7,7 +7,6 @@ import no.nav.testnav.libs.dto.inntektsmeldinggeneratorservice.v1.rs.RsInntektsm
 import no.nav.testnav.libs.securitycore.domain.ServerProperties;
 import no.nav.testnav.libs.servletsecurity.exchange.TokenExchange;
 import org.springframework.stereotype.Component;
-
 import org.springframework.web.reactive.function.client.WebClient;
 
 @Slf4j
@@ -20,11 +19,12 @@ public class GenererInntektsmeldingConsumer {
 
     public GenererInntektsmeldingConsumer(
             Consumers consumers,
-            TokenExchange tokenExchange) {
+            TokenExchange tokenExchange,
+            WebClient.Builder webClientBuilder) {
+
         this.tokenExchange = tokenExchange;
         serverProperties = consumers.getInntektsmeldingGeneratorService();
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .baseUrl(serverProperties.getUrl())
                 .build();
     }

--- a/apps/jenkins-batch-status-service/src/main/java/no/nav/registre/testnorge/jenkinsbatchstatusservice/consumer/JenkinsConsumer.java
+++ b/apps/jenkins-batch-status-service/src/main/java/no/nav/registre/testnorge/jenkinsbatchstatusservice/consumer/JenkinsConsumer.java
@@ -20,11 +20,12 @@ public class JenkinsConsumer {
 
     public JenkinsConsumer(
             Consumers consumers,
-            TokenExchange tokenExchange) {
+            TokenExchange tokenExchange,
+            WebClient.Builder webClientBuilder) {
+
         this.tokenExchange = tokenExchange;
         serverProperties = consumers.getJenkins();
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .baseUrl(serverProperties.getUrl())
                 .build();
     }

--- a/apps/jenkins-batch-status-service/src/main/java/no/nav/registre/testnorge/jenkinsbatchstatusservice/consumer/OrganisasjonBestillingConsumer.java
+++ b/apps/jenkins-batch-status-service/src/main/java/no/nav/registre/testnorge/jenkinsbatchstatusservice/consumer/OrganisasjonBestillingConsumer.java
@@ -27,11 +27,12 @@ public class OrganisasjonBestillingConsumer {
 
     public OrganisasjonBestillingConsumer(
             Consumers consumers,
-            TokenExchange tokenExchange) {
+            TokenExchange tokenExchange,
+            WebClient.Builder webClientBuilder) {
+
         serverProperties = consumers.getOrganisasjonBestillingService();
         this.tokenExchange = tokenExchange;
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .baseUrl(serverProperties.getUrl())
                 .clientConnector(
                         new ReactorClientHttpConnector(

--- a/apps/joark-dokument-service/src/main/java/no/nav/testnav/joarkdokumentservice/consumer/SafConsumer.java
+++ b/apps/joark-dokument-service/src/main/java/no/nav/testnav/joarkdokumentservice/consumer/SafConsumer.java
@@ -24,11 +24,12 @@ public class SafConsumer {
 
     public SafConsumer(
             Consumers consumers,
-            TokenExchange tokenExchange) {
+            TokenExchange tokenExchange,
+            WebClient.Builder webClientBuilder) {
+
         this.tokenExchange = tokenExchange;
         serverProperties = consumers.getTestnavSafProxy();
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .exchangeStrategies(
                         ExchangeStrategies
                                 .builder()

--- a/apps/levende-arbeidsforhold-ansettelse/src/main/java/no/nav/testnav/levendearbeidsforholdansettelse/consumers/AaregConsumer.java
+++ b/apps/levende-arbeidsforhold-ansettelse/src/main/java/no/nav/testnav/levendearbeidsforholdansettelse/consumers/AaregConsumer.java
@@ -23,13 +23,13 @@ public class AaregConsumer {
 
     public AaregConsumer(
             Consumers consumers,
-            TokenExchange tokenExchange) {
+            TokenExchange tokenExchange,
+            WebClient.Builder webClientBuilder) {
 
         this.serverProperties = consumers.getTestnavAaregProxy();
         this.tokenExchange = tokenExchange;
 
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .baseUrl(serverProperties.getUrl())
                 .build();
     }

--- a/apps/levende-arbeidsforhold-ansettelse/src/main/java/no/nav/testnav/levendearbeidsforholdansettelse/consumers/KodeverkServiceConsumer.java
+++ b/apps/levende-arbeidsforhold-ansettelse/src/main/java/no/nav/testnav/levendearbeidsforholdansettelse/consumers/KodeverkServiceConsumer.java
@@ -24,14 +24,14 @@ public class KodeverkServiceConsumer {
 
     public KodeverkServiceConsumer(
             Consumers consumers,
-            TokenExchange tokenExchange) {
+            TokenExchange tokenExchange,
+            WebClient.Builder webClientBuilder) {
 
         serverProperties = consumers.getTestnavKodeverkService();
         ExchangeStrategies exchangeStrategies = ExchangeStrategies.builder()
                 .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(16 * 1024 * 1024))
                 .build();
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .baseUrl(serverProperties.getUrl())
                 .exchangeStrategies(exchangeStrategies)
                 .build();

--- a/apps/levende-arbeidsforhold-ansettelse/src/main/java/no/nav/testnav/levendearbeidsforholdansettelse/consumers/TenorConsumer.java
+++ b/apps/levende-arbeidsforhold-ansettelse/src/main/java/no/nav/testnav/levendearbeidsforholdansettelse/consumers/TenorConsumer.java
@@ -29,13 +29,13 @@ public class TenorConsumer {
 
     public TenorConsumer(
             TokenExchange tokenExchange,
-            Consumers consumers) {
+            Consumers consumers,
+            WebClient.Builder webClientBuilder) {
 
         this.serverProperties = consumers.getTestnavTenorSearchService();
         this.tokenExchange = tokenExchange;
 
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .baseUrl(serverProperties.getUrl())
                 .build();
     }

--- a/apps/levende-arbeidsforhold-scheduler/src/main/java/no/nav/testnav/levendearbeidsforholdscheduler/consumer/AnsettelseConsumer.java
+++ b/apps/levende-arbeidsforhold-scheduler/src/main/java/no/nav/testnav/levendearbeidsforholdscheduler/consumer/AnsettelseConsumer.java
@@ -15,12 +15,13 @@ public class AnsettelseConsumer {
     private final TokenExchange tokenExchange;
 
     public AnsettelseConsumer(Consumers consumers,
-                              TokenExchange tokenExchange) {
+                              TokenExchange tokenExchange,
+                              WebClient.Builder webClientBuilder) {
+
         this.serverProperties = consumers.getLevendeArbeidsforholdAnsettelse();
         this.tokenExchange = tokenExchange;
 
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .baseUrl(serverProperties.getUrl())
                 .build();
     }

--- a/apps/levende-arbeidsforhold-service/src/main/java/no/nav/testnav/levendearbeidsforholdservice/consumers/AaregConsumer.java
+++ b/apps/levende-arbeidsforhold-service/src/main/java/no/nav/testnav/levendearbeidsforholdservice/consumers/AaregConsumer.java
@@ -22,13 +22,13 @@ public class AaregConsumer {
 
     public AaregConsumer(
             Consumers consumers,
-            TokenExchange tokenExchange) {
+            TokenExchange tokenExchange,
+            WebClient.Builder webClientBuilder) {
 
         this.serverProperties = consumers.getTestnavAaregProxy();
         this.tokenExchange = tokenExchange;
 
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .baseUrl(serverProperties.getUrl())
                 .build();
     }

--- a/apps/oppsummeringsdokument-service/src/main/java/no/nav/testnav/apps/oppsummeringsdokumentservice/consumer/AaregSyntConsumer.java
+++ b/apps/oppsummeringsdokument-service/src/main/java/no/nav/testnav/apps/oppsummeringsdokumentservice/consumer/AaregSyntConsumer.java
@@ -21,11 +21,12 @@ public class AaregSyntConsumer {
 
     public AaregSyntConsumer(
             TokenExchange tokenExchange,
-            Consumers consumers) {
+            Consumers consumers,
+            WebClient.Builder webClientBuilder) {
+
         this.tokenExchange = tokenExchange;
         serverProperties = consumers.getAaregSyntServices();
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .baseUrl(serverProperties.getUrl())
                 .build();
     }

--- a/apps/organisasjon-bestilling-service/src/main/java/no/nav/testnav/apps/organisasjonbestillingservice/consumer/JenkinsConsumer.java
+++ b/apps/organisasjon-bestilling-service/src/main/java/no/nav/testnav/apps/organisasjonbestillingservice/consumer/JenkinsConsumer.java
@@ -24,11 +24,11 @@ public class JenkinsConsumer {
 
     public JenkinsConsumer(
             Consumers consumers,
-            TokenExchange tokenExchange) {
+            TokenExchange tokenExchange,
+            WebClient.Builder webClientBuilder) {
         this.tokenExchange = tokenExchange;
         serverProperties = consumers.getJenkins();
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .baseUrl(serverProperties.getUrl())
                 .build();
     }

--- a/apps/organisasjon-faste-data-service/src/main/java/no/nav/registre/testnorge/organisasjonfastedataservice/consumer/OrganisasjonBestillingConsumer.java
+++ b/apps/organisasjon-faste-data-service/src/main/java/no/nav/registre/testnorge/organisasjonfastedataservice/consumer/OrganisasjonBestillingConsumer.java
@@ -18,11 +18,12 @@ public class OrganisasjonBestillingConsumer {
 
     public OrganisasjonBestillingConsumer(
             Consumers consumers,
-            TokenExchange tokenExchange) {
+            TokenExchange tokenExchange,
+            WebClient.Builder webClientBuilder) {
+
         serverProperties = consumers.getOrganisasjonBestillingService();
         this.tokenExchange = tokenExchange;
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .baseUrl(serverProperties.getUrl())
                 .build();
     }

--- a/apps/organisasjon-forvalter/src/main/java/no/nav/organisasjonforvalter/consumer/AdresseServiceConsumer.java
+++ b/apps/organisasjon-forvalter/src/main/java/no/nav/organisasjonforvalter/consumer/AdresseServiceConsumer.java
@@ -24,10 +24,11 @@ public class AdresseServiceConsumer {
 
     public AdresseServiceConsumer(
             Consumers consumers,
-            TokenExchange tokenExchange) {
+            TokenExchange tokenExchange,
+            WebClient.Builder webClientBuilder) {
 
         serverProperties = consumers.getTestnavAdresseService();
-        this.webClient = WebClient.builder()
+        this.webClient = webClientBuilder
                 .baseUrl(serverProperties.getUrl())
                 .build();
         this.tokenExchange = tokenExchange;

--- a/apps/organisasjon-forvalter/src/main/java/no/nav/organisasjonforvalter/consumer/GenererNavnServiceConsumer.java
+++ b/apps/organisasjon-forvalter/src/main/java/no/nav/organisasjonforvalter/consumer/GenererNavnServiceConsumer.java
@@ -23,10 +23,11 @@ public class GenererNavnServiceConsumer {
 
     public GenererNavnServiceConsumer(
             Consumers consumers,
-            TokenExchange tokenExchange) {
+            TokenExchange tokenExchange,
+            WebClient.Builder webClientBuilder) {
 
         serverProperties = consumers.getGenererNavnService();
-        this.webClient = WebClient.builder()
+        this.webClient = webClientBuilder
                 .baseUrl(serverProperties.getUrl())
                 .build();
         this.tokenExchange = tokenExchange;

--- a/apps/organisasjon-forvalter/src/main/java/no/nav/organisasjonforvalter/consumer/MiljoerServiceConsumer.java
+++ b/apps/organisasjon-forvalter/src/main/java/no/nav/organisasjonforvalter/consumer/MiljoerServiceConsumer.java
@@ -25,10 +25,11 @@ public class MiljoerServiceConsumer {
 
     public MiljoerServiceConsumer(
             Consumers consumers,
-            TokenExchange tokenExchange) {
+            TokenExchange tokenExchange,
+            WebClient.Builder webClientBuilder) {
 
         serverProperties = consumers.getTestnavMiljoerService();
-        this.webClient = WebClient.builder()
+        this.webClient = webClientBuilder
                 .baseUrl(serverProperties.getUrl())
                 .build();
         this.tokenExchange = tokenExchange;

--- a/apps/organisasjon-forvalter/src/main/java/no/nav/organisasjonforvalter/consumer/OrganisasjonBestillingConsumer.java
+++ b/apps/organisasjon-forvalter/src/main/java/no/nav/organisasjonforvalter/consumer/OrganisasjonBestillingConsumer.java
@@ -22,10 +22,11 @@ public class OrganisasjonBestillingConsumer {
 
     public OrganisasjonBestillingConsumer(
             Consumers consumers,
-            TokenExchange tokenExchange) {
+            TokenExchange tokenExchange,
+            WebClient.Builder webClientBuilder) {
 
         serverProperties = consumers.getOrganisasjonBestillingService();
-        this.webClient = WebClient.builder()
+        this.webClient = webClientBuilder
                 .baseUrl(serverProperties.getUrl())
                 .build();
         this.tokenExchange = tokenExchange;

--- a/apps/organisasjon-forvalter/src/main/java/no/nav/organisasjonforvalter/consumer/OrganisasjonOrgnummerServiceConsumer.java
+++ b/apps/organisasjon-forvalter/src/main/java/no/nav/organisasjonforvalter/consumer/OrganisasjonOrgnummerServiceConsumer.java
@@ -28,10 +28,11 @@ public class OrganisasjonOrgnummerServiceConsumer {
 
     public OrganisasjonOrgnummerServiceConsumer(
             Consumers consumers,
-            TokenExchange tokenExchange) {
+            TokenExchange tokenExchange,
+            WebClient.Builder webClientBuilder) {
 
         serverProperties = consumers.getTestnavOrgnummerService();
-        this.webClient = WebClient.builder()
+        this.webClient = webClientBuilder
                 .baseUrl(serverProperties.getUrl())
                 .build();
         this.tokenExchange = tokenExchange;

--- a/apps/organisasjon-forvalter/src/main/java/no/nav/organisasjonforvalter/consumer/OrganisasjonServiceConsumer.java
+++ b/apps/organisasjon-forvalter/src/main/java/no/nav/organisasjonforvalter/consumer/OrganisasjonServiceConsumer.java
@@ -25,9 +25,10 @@ public class OrganisasjonServiceConsumer {
 
     public OrganisasjonServiceConsumer(
             Consumers consumers,
-            TokenExchange tokenExchange) {
+            TokenExchange tokenExchange,
+            WebClient.Builder webClientBuilder) {
         serverProperties = consumers.getTestnavOrganisasjonService();
-        this.webClient = WebClient.builder()
+        this.webClient = webClientBuilder
                 .baseUrl(serverProperties.getUrl())
                 .build();
         this.tokenExchange = tokenExchange;

--- a/apps/organisasjon-mottak-service/src/main/java/no/nav/registre/testnorge/organisasjonmottak/consumer/JenkinsBatchStatusConsumer.java
+++ b/apps/organisasjon-mottak-service/src/main/java/no/nav/registre/testnorge/organisasjonmottak/consumer/JenkinsBatchStatusConsumer.java
@@ -15,11 +15,12 @@ public class JenkinsBatchStatusConsumer {
 
     public JenkinsBatchStatusConsumer(
             Consumers consumers,
-            TokenExchange tokenExchange) {
+            TokenExchange tokenExchange,
+            WebClient.Builder webClientBuilder) {
+
         serverProperties = consumers.getJenkinsBatchStatusService();
         this.tokenExchange = tokenExchange;
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .baseUrl(serverProperties.getUrl())
                 .build();
     }

--- a/apps/organisasjon-mottak-service/src/main/java/no/nav/registre/testnorge/organisasjonmottak/consumer/JenkinsConsumer.java
+++ b/apps/organisasjon-mottak-service/src/main/java/no/nav/registre/testnorge/organisasjonmottak/consumer/JenkinsConsumer.java
@@ -29,14 +29,14 @@ public class JenkinsConsumer {
             Consumers consumers,
             TokenExchange tokenExchange,
             JenkinsBatchStatusConsumer jenkinsBatchStatusConsumer,
-            OrganisasjonBestillingConsumer organisasjonBestillingConsumer) {
+            OrganisasjonBestillingConsumer organisasjonBestillingConsumer,
+            WebClient.Builder webClientBuilder) {
         this.organisasjonBestillingConsumer = organisasjonBestillingConsumer;
         serverProperties = consumers.getJenkins();
         this.tokenExchange = tokenExchange;
         this.jenkinsBatchStatusConsumer = jenkinsBatchStatusConsumer;
         this.env = env;
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .baseUrl(serverProperties.getUrl())
                 .build();
     }

--- a/apps/organisasjon-mottak-service/src/main/java/no/nav/registre/testnorge/organisasjonmottak/consumer/OrganisasjonBestillingConsumer.java
+++ b/apps/organisasjon-mottak-service/src/main/java/no/nav/registre/testnorge/organisasjonmottak/consumer/OrganisasjonBestillingConsumer.java
@@ -18,11 +18,12 @@ public class OrganisasjonBestillingConsumer {
 
     public OrganisasjonBestillingConsumer(
             Consumers consumers,
-            TokenExchange tokenExchange) {
+            TokenExchange tokenExchange,
+            WebClient.Builder webClientBuilder) {
+
         serverProperties = consumers.getOrganisasjonBestillingService();
         this.tokenExchange = tokenExchange;
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .baseUrl(serverProperties.getUrl())
                 .build();
     }

--- a/apps/organisasjon-service/src/main/java/no/nav/registre/testnorge/organisasjonservice/consumer/EregConsumer.java
+++ b/apps/organisasjon-service/src/main/java/no/nav/registre/testnorge/organisasjonservice/consumer/EregConsumer.java
@@ -21,10 +21,11 @@ public class EregConsumer {
 
     public EregConsumer(
             Consumers consumers,
-            TokenExchange tokenExchange) {
+            TokenExchange tokenExchange,
+            WebClient.Builder webClientBuilder) {
+
         serverProperties = consumers.getTestnavEregProxy();
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .baseUrl(serverProperties.getUrl())
                 .build();
         this.tokenExchange = tokenExchange;

--- a/apps/organisasjon-tilgang-service/src/main/java/no/nav/testnav/apps/organisasjontilgangservice/consumer/altinn/v1/AltinnConsumer.java
+++ b/apps/organisasjon-tilgang-service/src/main/java/no/nav/testnav/apps/organisasjontilgangservice/consumer/altinn/v1/AltinnConsumer.java
@@ -32,12 +32,12 @@ public class AltinnConsumer {
     public AltinnConsumer(
             AltinnConfig altinnConfig,
             MaskinportenConsumer maskinportenConsumer,
-            ObjectMapper objectMapper) {
+            ObjectMapper objectMapper,
+            WebClient.Builder webClientBuilder) {
 
         this.altinnConfig = altinnConfig;
         this.maskinportenConsumer = maskinportenConsumer;
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .baseUrl(altinnConfig.getUrl())
                 .codecs(clientDefaultCodecsConfigurer -> {
                     clientDefaultCodecsConfigurer

--- a/apps/organisasjon-tilgang-service/src/main/java/no/nav/testnav/apps/organisasjontilgangservice/consumer/maskinporten/v1/MaskinportenConsumer.java
+++ b/apps/organisasjon-tilgang-service/src/main/java/no/nav/testnav/apps/organisasjontilgangservice/consumer/maskinporten/v1/MaskinportenConsumer.java
@@ -33,9 +33,9 @@ public class MaskinportenConsumer {
     private final MaskinportenConfig maskinportenConfig;
     private final Mono<AccessToken> accessToken;
 
-    public MaskinportenConsumer(MaskinportenConfig maskinportenConfig) {
+    public MaskinportenConsumer(MaskinportenConfig maskinportenConfig, WebClient.Builder webClientBuilder) {
 
-        this.webClient = WebClient.builder()
+        this.webClient = webClientBuilder
                 .build();
 
         this.maskinportenConfig = maskinportenConfig;

--- a/apps/orgnummer-service/src/main/java/no/nav/registre/orgnrservice/consumer/OrganisasjonConsumer.java
+++ b/apps/orgnummer-service/src/main/java/no/nav/registre/orgnrservice/consumer/OrganisasjonConsumer.java
@@ -30,16 +30,16 @@ public class OrganisasjonConsumer {
 
     public OrganisasjonConsumer(
             Consumers consumers,
-            TokenExchange tokenExchange) {
+            TokenExchange tokenExchange,
+            WebClient.Builder webClientBuilder) {
+
         miljoerServerProperties = consumers.getTestnavMiljoerService();
         organisasjonServerProperties = consumers.getTestnavOrganisasjonService();
         this.tokenExchange = tokenExchange;
-        this.organisasjonWebClient = WebClient
-                .builder()
+        this.organisasjonWebClient = webClientBuilder
                 .baseUrl(organisasjonServerProperties.getUrl())
                 .build();
-        this.miljoerWebClient = WebClient
-                .builder()
+        this.miljoerWebClient = webClientBuilder
                 .baseUrl(miljoerServerProperties.getUrl())
                 .build();
     }

--- a/apps/oversikt-frontend/src/main/java/no/nav/testnav/apps/oversiktfrontend/consumer/AppTilgangAnalyseConsumer.java
+++ b/apps/oversikt-frontend/src/main/java/no/nav/testnav/apps/oversiktfrontend/consumer/AppTilgangAnalyseConsumer.java
@@ -23,11 +23,12 @@ public class AppTilgangAnalyseConsumer {
 
     public AppTilgangAnalyseConsumer(
             Consumers consumers,
-            TokenExchange tokenExchange) {
+            TokenExchange tokenExchange,
+            WebClient.Builder webClientBuilder) {
+
         serverProperties = consumers.getTestnavAppTilgangAnalyseService();
         this.tokenExchange = tokenExchange;
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .baseUrl(serverProperties.getUrl())
                 .build();
     }

--- a/apps/oversikt-frontend/src/main/java/no/nav/testnav/apps/oversiktfrontend/consumer/BrukerConsumer.java
+++ b/apps/oversikt-frontend/src/main/java/no/nav/testnav/apps/oversiktfrontend/consumer/BrukerConsumer.java
@@ -8,7 +8,6 @@ import no.nav.testnav.apps.oversiktfrontend.consumer.dto.BrukerDTO;
 import no.nav.testnav.libs.reactivesecurity.exchange.TokenExchange;
 import no.nav.testnav.libs.securitycore.domain.ServerProperties;
 import org.springframework.stereotype.Component;
-
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
@@ -21,11 +20,12 @@ public class BrukerConsumer {
 
     public BrukerConsumer(
             Consumers consumers,
-            TokenExchange tokenExchange) {
+            TokenExchange tokenExchange,
+            WebClient.Builder webClientBuilder) {
+
         serverProperties = consumers.getTestnavBrukerService();
         this.tokenExchange = tokenExchange;
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .baseUrl(serverProperties.getUrl())
                 .build();
     }

--- a/apps/oversikt-frontend/src/main/java/no/nav/testnav/apps/oversiktfrontend/consumer/PersonOrganisasjonTilgangConsumer.java
+++ b/apps/oversikt-frontend/src/main/java/no/nav/testnav/apps/oversiktfrontend/consumer/PersonOrganisasjonTilgangConsumer.java
@@ -28,7 +28,9 @@ public class PersonOrganisasjonTilgangConsumer {
     public PersonOrganisasjonTilgangConsumer(
             Consumers consumers,
             TokenExchange tokenExchange,
-            ObjectMapper objectMapper) {
+            ObjectMapper objectMapper,
+            WebClient.Builder webClientBuilder) {
+
         serverProperties = consumers.getTestnavPersonOrganisasjonTilgangService();
         this.tokenExchange = tokenExchange;
         ExchangeStrategies jacksonStrategy = ExchangeStrategies
@@ -43,8 +45,7 @@ public class PersonOrganisasjonTilgangConsumer {
                                     .jackson2JsonDecoder(new Jackson2JsonDecoder(objectMapper, MediaType.APPLICATION_JSON));
                         })
                 .build();
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .exchangeStrategies(jacksonStrategy)
                 .baseUrl(serverProperties.getUrl())
                 .build();

--- a/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/consumer/AdresseServiceConsumer.java
+++ b/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/consumer/AdresseServiceConsumer.java
@@ -27,11 +27,12 @@ public class AdresseServiceConsumer {
 
     public AdresseServiceConsumer(
             TokenExchange tokenExchange,
-            Consumers consumers) {
+            Consumers consumers,
+            WebClient.Builder webClientBuilder) {
+
         this.tokenExchange = tokenExchange;
         serverProperties = consumers.getAdresseService();
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .baseUrl(serverProperties.getUrl())
                 .build();
     }

--- a/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/consumer/GenererNavnServiceConsumer.java
+++ b/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/consumer/GenererNavnServiceConsumer.java
@@ -26,11 +26,12 @@ public class GenererNavnServiceConsumer {
 
     public GenererNavnServiceConsumer(
             TokenExchange tokenExchange,
-            Consumers consumers) {
+            Consumers consumers,
+            WebClient.Builder webClientBuilder) {
+
         this.tokenExchange = tokenExchange;
         serverProperties = consumers.getGenererNavnService();
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .baseUrl(serverProperties.getUrl())
                 .build();
     }

--- a/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/consumer/IdentPoolConsumer.java
+++ b/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/consumer/IdentPoolConsumer.java
@@ -27,18 +27,19 @@ public class IdentPoolConsumer {
     private static final String RELEASE_IDENTS_URL = ACQUIRE_IDENTS_URL + "/frigjoer";
     private static final String IBRUK_IDENTS_URL = ACQUIRE_IDENTS_URL + "/bruk";
     private static final String REKVIRERT_AV = "rekvirertAv=";
-    private final WebClient webClient;
 
+    private final WebClient webClient;
     private final TokenExchange tokenExchange;
     private final ServerProperties serverProperties;
 
     public IdentPoolConsumer(
             TokenExchange tokenExchange,
-            Consumers consumers) {
+            Consumers consumers,
+            WebClient.Builder webClientBuilder) {
+
         this.tokenExchange = tokenExchange;
         serverProperties = consumers.getIdentPool();
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .baseUrl(serverProperties.getUrl())
                 .build();
     }

--- a/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/consumer/KodeverkConsumer.java
+++ b/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/consumer/KodeverkConsumer.java
@@ -30,11 +30,11 @@ public class KodeverkConsumer {
 
     public KodeverkConsumer(
             TokenExchange tokenExchange,
-            Consumers consumers) {
+            Consumers consumers,
+            WebClient.Builder webClientBuilder) {
         this.tokenExchange = tokenExchange;
         serverProperties = consumers.getKodeverkService();
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .baseUrl(serverProperties.getUrl())
                 .build();
     }

--- a/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/consumer/OrganisasjonForvalterConsumer.java
+++ b/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/consumer/OrganisasjonForvalterConsumer.java
@@ -22,11 +22,11 @@ public class OrganisasjonForvalterConsumer {
 
     public OrganisasjonForvalterConsumer(
             TokenExchange tokenExchange,
-            Consumers consumers) {
+            Consumers consumers,
+            WebClient.Builder webClientBuilder) {
         this.tokenExchange = tokenExchange;
         serverProperties = consumers.getOrgForvalter();
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .baseUrl(serverProperties.getUrl())
                 .build();
     }

--- a/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/consumer/PdlTestdataConsumer.java
+++ b/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/consumer/PdlTestdataConsumer.java
@@ -53,11 +53,12 @@ public class PdlTestdataConsumer {
             TokenExchange tokenExchange,
             Consumers consumers,
             ObjectMapper objectMapper,
-            PersonServiceConsumer personServiceConsumer) {
+            PersonServiceConsumer personServiceConsumer,
+            WebClient.Builder webClientBuilder) {
+
         this.tokenExchange = tokenExchange;
         serverProperties = consumers.getPdlProxy();
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .baseUrl(serverProperties.getUrl())
                 .filters(exchangeFilterFunctions -> exchangeFilterFunctions.add(logRequest()))
                 .build();

--- a/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/consumer/PersonServiceConsumer.java
+++ b/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/consumer/PersonServiceConsumer.java
@@ -25,10 +25,11 @@ public class PersonServiceConsumer {
     private final ServerProperties serverProperties;
     private final TokenExchange tokenExchange;
 
-    public PersonServiceConsumer(Consumers consumers, TokenExchange tokenExchange) {
+    public PersonServiceConsumer(Consumers consumers, TokenExchange tokenExchange,
+                                 WebClient.Builder webClientBuilder) {
 
         this.serverProperties = consumers.getPersonService();
-        this.webClient = WebClient.builder()
+        this.webClient = webClientBuilder
                 .baseUrl(serverProperties.getUrl())
                 .build();
         this.tokenExchange = tokenExchange;

--- a/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/consumer/command/PdlDeleteCommandPdl.java
+++ b/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/consumer/command/PdlDeleteCommandPdl.java
@@ -17,6 +17,7 @@ import reactor.util.retry.Retry;
 import java.time.Duration;
 
 import static no.nav.pdl.forvalter.utils.PdlTestDataUrls.TemaGrunnlag.GEN;
+import static no.nav.testnav.libs.reactivecore.utils.WebClientFilter.getMessage;
 
 @Slf4j
 @RequiredArgsConstructor

--- a/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/consumer/command/PdlDeleteHendelseIdCommandPdl.java
+++ b/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/consumer/command/PdlDeleteHendelseIdCommandPdl.java
@@ -17,6 +17,7 @@ import reactor.util.retry.Retry;
 import java.time.Duration;
 
 import static no.nav.pdl.forvalter.utils.PdlTestDataUrls.TemaGrunnlag.GEN;
+import static no.nav.testnav.libs.reactivecore.utils.WebClientFilter.getMessage;
 
 @Slf4j
 @RequiredArgsConstructor

--- a/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/consumer/command/PdlTestdataCommand.java
+++ b/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/consumer/command/PdlTestdataCommand.java
@@ -2,11 +2,9 @@ package no.nav.pdl.forvalter.consumer.command;
 
 import no.nav.testnav.libs.data.pdlforvalter.v1.OrdreResponseDTO;
 import no.nav.testnav.libs.data.pdlforvalter.v1.PdlStatus;
-import org.apache.commons.lang3.StringUtils;
-import org.springframework.web.reactive.function.client.WebClientResponseException;
+import no.nav.testnav.libs.reactivecore.utils.WebClientFilter;
 import reactor.core.publisher.Flux;
 
-import java.nio.charset.StandardCharsets;
 import java.util.concurrent.Callable;
 
 public abstract class PdlTestdataCommand implements Callable<Flux<OrdreResponseDTO.HendelseDTO>> {
@@ -14,20 +12,12 @@ public abstract class PdlTestdataCommand implements Callable<Flux<OrdreResponseD
     static final String HEADER_NAV_PERSON_IDENT = "Nav-Personident";
     static final String TEMA = "Tema";
 
-    protected static String getMessage(Throwable error) {
-
-        return error instanceof WebClientResponseException webClientResponseException &&
-                StringUtils.isNotBlank(webClientResponseException.getResponseBodyAsString(StandardCharsets.UTF_8)) ?
-                webClientResponseException.getResponseBodyAsString(StandardCharsets.UTF_8) :
-                error.getMessage();
-    }
-
     OrdreResponseDTO.HendelseDTO errorHandling(Throwable error, Integer id) {
 
         return OrdreResponseDTO.HendelseDTO.builder()
                 .id(id)
                 .status(PdlStatus.FEIL)
-                .error(getMessage(error))
+                .error(WebClientFilter.getMessage(error))
                 .build();
     }
 }

--- a/apps/person-search-service/src/main/java/no/nav/registre/testnorge/personsearchservice/consumer/ElasticSearchConsumer.java
+++ b/apps/person-search-service/src/main/java/no/nav/registre/testnorge/personsearchservice/consumer/ElasticSearchConsumer.java
@@ -29,11 +29,12 @@ public class ElasticSearchConsumer {
     public ElasticSearchConsumer(
             TokenExchange tokenExchange,
             Consumers consumers,
-            ObjectMapper objectMapper
+            ObjectMapper objectMapper,
+            WebClient.Builder webClientBuilder
     ) {
+
         serverProperties = consumers.getTestnavPdlProxy();
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .baseUrl(serverProperties.getUrl())
                 .exchangeStrategies(getJacksonStrategy(objectMapper))
                 .build();

--- a/apps/person-service/src/main/java/no/nav/testnav/apps/personservice/consumer/v1/PdlApiConsumer.java
+++ b/apps/person-service/src/main/java/no/nav/testnav/apps/personservice/consumer/v1/PdlApiConsumer.java
@@ -48,8 +48,10 @@ public class PdlApiConsumer {
     public PdlApiConsumer(
             Consumers consumers,
             TokenExchange tokenExchange,
-            ObjectMapper objectMapper
+            ObjectMapper objectMapper,
+            WebClient.Builder webClientBuilder
     ) {
+
         serverProperties = consumers.getPdlProxy();
         this.tokenExchange = tokenExchange;
         ExchangeStrategies jacksonStrategy = ExchangeStrategies.builder()
@@ -63,8 +65,7 @@ public class PdlApiConsumer {
                                     .jackson2JsonDecoder(new Jackson2JsonDecoder(objectMapper, MediaType.APPLICATION_JSON));
                         })
                 .build();
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .exchangeStrategies(jacksonStrategy)
                 .baseUrl(serverProperties.getUrl())
                 .build();

--- a/apps/person-service/src/main/java/no/nav/testnav/apps/personservice/consumer/v1/PdlTestdataConsumer.java
+++ b/apps/person-service/src/main/java/no/nav/testnav/apps/personservice/consumer/v1/PdlTestdataConsumer.java
@@ -3,7 +3,11 @@ package no.nav.testnav.apps.personservice.consumer.v1;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import no.nav.testnav.apps.personservice.config.Consumers;
-import no.nav.testnav.apps.personservice.consumer.v1.command.*;
+import no.nav.testnav.apps.personservice.consumer.v1.command.OpprettFoedselsdatoCommand;
+import no.nav.testnav.apps.personservice.consumer.v1.command.OpprettPersonCommand;
+import no.nav.testnav.apps.personservice.consumer.v1.command.PostAdresseCommand;
+import no.nav.testnav.apps.personservice.consumer.v1.command.PostNavnCommand;
+import no.nav.testnav.apps.personservice.consumer.v1.command.PostTagsCommand;
 import no.nav.testnav.apps.personservice.consumer.v1.exception.PdlCreatePersonException;
 import no.nav.testnav.apps.personservice.domain.Person;
 import no.nav.testnav.libs.securitycore.domain.AccessToken;
@@ -27,7 +31,8 @@ public class PdlTestdataConsumer {
     public PdlTestdataConsumer(
             Consumers consumers,
             TokenExchange tokenExchange,
-            ObjectMapper objectMapper
+            ObjectMapper objectMapper,
+            WebClient.Builder webClientBuilder
     ) {
         serverProperties = consumers.getPdlProxy();
         this.tokenExchange = tokenExchange;
@@ -42,8 +47,7 @@ public class PdlTestdataConsumer {
                             .jackson2JsonDecoder(new Jackson2JsonDecoder(objectMapper, MediaType.APPLICATION_JSON));
                 })
                 .build();
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .exchangeStrategies(jacksonStrategy)
                 .baseUrl(serverProperties.getUrl())
                 .build();

--- a/apps/profil-api/src/main/java/no/nav/registre/testnorge/profil/consumer/AzureAdProfileConsumer.java
+++ b/apps/profil-api/src/main/java/no/nav/registre/testnorge/profil/consumer/AzureAdProfileConsumer.java
@@ -27,12 +27,12 @@ public class AzureAdProfileConsumer {
     public AzureAdProfileConsumer(
             @Value("${http.proxy:#{null}}") String proxyHost,
             @Value("${api.azuread.url}") String url,
-            AzureAdTokenService azureAdTokenService) {
+            AzureAdTokenService azureAdTokenService,
+            WebClient.Builder webClientBuilder) {
 
         this.url = url;
         this.azureAdTokenService = azureAdTokenService;
-        WebClient.Builder builder = WebClient
-                .builder()
+        WebClient.Builder builder = webClientBuilder
                 .baseUrl(url)
                 .exchangeStrategies(ExchangeStrategies.builder()
                         .codecs(configurer -> configurer

--- a/apps/profil-api/src/main/java/no/nav/registre/testnorge/profil/consumer/PersonOrganisasjonTilgangConsumer.java
+++ b/apps/profil-api/src/main/java/no/nav/registre/testnorge/profil/consumer/PersonOrganisasjonTilgangConsumer.java
@@ -27,7 +27,8 @@ public class PersonOrganisasjonTilgangConsumer {
     public PersonOrganisasjonTilgangConsumer(
             Consumers consumers,
             TokenExchange tokenExchange,
-            ObjectMapper objectMapper
+            ObjectMapper objectMapper,
+            WebClient.Builder webClientBuilder
     ) {
         serverProperties = consumers.getTestnavPersonOrganisasjonTilgangService();
         this.tokenExchange = tokenExchange;
@@ -43,8 +44,7 @@ public class PersonOrganisasjonTilgangConsumer {
                                     .jackson2JsonDecoder(new Jackson2JsonDecoder(objectMapper, MediaType.APPLICATION_JSON));
                         })
                 .build();
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .exchangeStrategies(jacksonStrategy)
                 .baseUrl(serverProperties.getUrl())
                 .build();

--- a/apps/skattekort-service/src/main/java/no/nav/skattekortservice/consumer/SokosSkattekortConsumer.java
+++ b/apps/skattekort-service/src/main/java/no/nav/skattekortservice/consumer/SokosSkattekortConsumer.java
@@ -19,10 +19,11 @@ public class SokosSkattekortConsumer {
     private final TokenExchange tokenExchange;
     private final ServerProperties serverProperties;
 
-    public SokosSkattekortConsumer(TokenExchange tokenExchange, Consumers consumers) {
+    public SokosSkattekortConsumer(TokenExchange tokenExchange, Consumers consumers,
+                                   WebClient.Builder webClientBuilder) {
 
         this.serverProperties = consumers.getSokosSkattekort();
-        this.webClient = WebClient.builder()
+        this.webClient = webClientBuilder
                 .baseUrl(serverProperties.getUrl())
                 .build();
         this.tokenExchange = tokenExchange;

--- a/apps/synt-sykemelding-api/src/main/java/no/nav/testnav/apps/syntsykemeldingapi/consumer/ArbeidsforholdConsumer.java
+++ b/apps/synt-sykemelding-api/src/main/java/no/nav/testnav/apps/syntsykemeldingapi/consumer/ArbeidsforholdConsumer.java
@@ -8,7 +8,6 @@ import no.nav.testnav.libs.dto.oppsummeringsdokumentservice.v1.ArbeidsforholdDTO
 import no.nav.testnav.libs.securitycore.domain.ServerProperties;
 import no.nav.testnav.libs.servletsecurity.exchange.TokenExchange;
 import org.springframework.stereotype.Component;
-
 import org.springframework.web.reactive.function.client.WebClient;
 
 @Component
@@ -20,11 +19,12 @@ public class ArbeidsforholdConsumer {
 
     public ArbeidsforholdConsumer(
             TokenExchange tokenExchange,
-            Consumers consumers) {
+            Consumers consumers,
+            WebClient.Builder webClientBuilder) {
+
         this.tokenExchange = tokenExchange;
         serverProperties = consumers.getTestnavArbeidsforholdService();
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .baseUrl(serverProperties.getUrl())
                 .build();
     }

--- a/apps/synt-sykemelding-api/src/main/java/no/nav/testnav/apps/syntsykemeldingapi/consumer/HelsepersonellConsumer.java
+++ b/apps/synt-sykemelding-api/src/main/java/no/nav/testnav/apps/syntsykemeldingapi/consumer/HelsepersonellConsumer.java
@@ -9,9 +9,7 @@ import no.nav.testnav.apps.syntsykemeldingapi.exception.HelsepersonellNotFoundEx
 import no.nav.testnav.libs.securitycore.domain.ServerProperties;
 import no.nav.testnav.libs.servletsecurity.exchange.TokenExchange;
 import org.springframework.stereotype.Component;
-
 import org.springframework.web.reactive.function.client.WebClient;
-
 
 import static java.util.Objects.nonNull;
 
@@ -24,11 +22,12 @@ public class HelsepersonellConsumer {
 
     public HelsepersonellConsumer(
             TokenExchange tokenExchange,
-            Consumers consumers) {
+            Consumers consumers,
+            WebClient.Builder webClientBuilder) {
+
         this.tokenExchange = tokenExchange;
         serverProperties = consumers.getTestnavHelsepersonellService();
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .baseUrl(serverProperties.getUrl())
                 .build();
     }

--- a/apps/synt-sykemelding-api/src/main/java/no/nav/testnav/apps/syntsykemeldingapi/consumer/OrganisasjonConsumer.java
+++ b/apps/synt-sykemelding-api/src/main/java/no/nav/testnav/apps/syntsykemeldingapi/consumer/OrganisasjonConsumer.java
@@ -18,11 +18,12 @@ public class OrganisasjonConsumer {
 
     public OrganisasjonConsumer(
             Consumers consumers,
-            TokenExchange tokenExchange) {
+            TokenExchange tokenExchange,
+            WebClient.Builder webClientBuilder) {
+
         serverProperties = consumers.getTestnavOrganisasjonService();
         this.tokenExchange = tokenExchange;
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .baseUrl(serverProperties.getUrl())
                 .build();
     }

--- a/apps/synt-sykemelding-api/src/main/java/no/nav/testnav/apps/syntsykemeldingapi/consumer/PdlProxyConsumer.java
+++ b/apps/synt-sykemelding-api/src/main/java/no/nav/testnav/apps/syntsykemeldingapi/consumer/PdlProxyConsumer.java
@@ -9,7 +9,6 @@ import no.nav.testnav.apps.syntsykemeldingapi.util.FilLaster;
 import no.nav.testnav.libs.securitycore.domain.ServerProperties;
 import no.nav.testnav.libs.servletsecurity.exchange.TokenExchange;
 import org.springframework.stereotype.Component;
-
 import org.springframework.web.reactive.function.client.ExchangeStrategies;
 import org.springframework.web.reactive.function.client.WebClient;
 
@@ -33,11 +32,12 @@ public class PdlProxyConsumer {
 
     public PdlProxyConsumer(
             Consumers consumers,
-            TokenExchange tokenExchange) {
+            TokenExchange tokenExchange,
+            WebClient.Builder webClientBuilder) {
+
         serverProperties = consumers.getTestnavPdlProxy();
         this.tokenExchange = tokenExchange;
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .exchangeStrategies(ExchangeStrategies
                         .builder()
                         .codecs(configurer -> configurer

--- a/apps/synt-sykemelding-api/src/main/java/no/nav/testnav/apps/syntsykemeldingapi/consumer/SykemeldingConsumer.java
+++ b/apps/synt-sykemelding-api/src/main/java/no/nav/testnav/apps/syntsykemeldingapi/consumer/SykemeldingConsumer.java
@@ -7,7 +7,6 @@ import no.nav.testnav.libs.dto.sykemelding.v1.SykemeldingDTO;
 import no.nav.testnav.libs.securitycore.domain.ServerProperties;
 import no.nav.testnav.libs.servletsecurity.exchange.TokenExchange;
 import org.springframework.stereotype.Component;
-
 import org.springframework.web.reactive.function.client.WebClient;
 
 @Slf4j
@@ -20,11 +19,12 @@ public class SykemeldingConsumer {
 
     public SykemeldingConsumer(
             Consumers consumers,
-            TokenExchange tokenExchange) {
+            TokenExchange tokenExchange,
+            WebClient.Builder webClientBuilder) {
+
         serverProperties = consumers.getSykemeldingApi();
         this.tokenExchange = tokenExchange;
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .baseUrl(serverProperties.getUrl())
                 .build();
     }

--- a/apps/synt-sykemelding-api/src/main/java/no/nav/testnav/apps/syntsykemeldingapi/consumer/SyntElsamConsumer.java
+++ b/apps/synt-sykemelding-api/src/main/java/no/nav/testnav/apps/syntsykemeldingapi/consumer/SyntElsamConsumer.java
@@ -27,11 +27,12 @@ public class SyntElsamConsumer {
 
     public SyntElsamConsumer(
             Consumers consumers,
-            TokenExchange tokenExchange) {
+            TokenExchange tokenExchange,
+            WebClient.Builder webClientBuilder) {
+
         serverProperties = consumers.getSyntSykemelding();
         this.tokenExchange = tokenExchange;
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .exchangeStrategies(ExchangeStrategies
                         .builder()
                         .codecs(configurer -> configurer

--- a/apps/synt-vedtakshistorikk-service/src/main/java/no/nav/testnav/apps/syntvedtakshistorikkservice/consumer/ArenaForvalterConsumer.java
+++ b/apps/synt-vedtakshistorikk-service/src/main/java/no/nav/testnav/apps/syntvedtakshistorikkservice/consumer/ArenaForvalterConsumer.java
@@ -50,10 +50,10 @@ public class ArenaForvalterConsumer {
 
     public ArenaForvalterConsumer(
             Consumers consumers,
-            TokenExchange tokenExchange) {
+            TokenExchange tokenExchange,
+            WebClient.Builder webClientBuilder) {
         serverProperties = consumers.getTestnavArenaForvalterenProxy();
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .baseUrl(serverProperties.getUrl())
                 .build();
         this.tokenExchange = tokenExchange;

--- a/apps/synt-vedtakshistorikk-service/src/main/java/no/nav/testnav/apps/syntvedtakshistorikkservice/consumer/InntektstubConsumer.java
+++ b/apps/synt-vedtakshistorikk-service/src/main/java/no/nav/testnav/apps/syntvedtakshistorikkservice/consumer/InntektstubConsumer.java
@@ -25,11 +25,12 @@ public class InntektstubConsumer {
 
     public InntektstubConsumer(
             Consumers consumers,
-            TokenExchange tokenExchange
+            TokenExchange tokenExchange,
+            WebClient.Builder webClientBuilder
     ) {
+
         serverProperties = consumers.getTestnavInntektstubProxy();
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .baseUrl(serverProperties.getUrl())
                 .build();
         this.tokenExchange = tokenExchange;

--- a/apps/synt-vedtakshistorikk-service/src/main/java/no/nav/testnav/apps/syntvedtakshistorikkservice/consumer/OrgFasteDataServiceConsumer.java
+++ b/apps/synt-vedtakshistorikk-service/src/main/java/no/nav/testnav/apps/syntvedtakshistorikkservice/consumer/OrgFasteDataServiceConsumer.java
@@ -22,11 +22,11 @@ public class OrgFasteDataServiceConsumer {
 
     public OrgFasteDataServiceConsumer(
             Consumers consumers,
-            TokenExchange tokenExchange
+            TokenExchange tokenExchange,
+            WebClient.Builder webClientBuilder
     ) {
         serverProperties = consumers.getTestnavOrganisasjonFasteDataService();
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .baseUrl(serverProperties.getUrl())
                 .build();
         this.tokenExchange = tokenExchange;

--- a/apps/synt-vedtakshistorikk-service/src/main/java/no/nav/testnav/apps/syntvedtakshistorikkservice/consumer/PdlProxyConsumer.java
+++ b/apps/synt-vedtakshistorikk-service/src/main/java/no/nav/testnav/apps/syntvedtakshistorikkservice/consumer/PdlProxyConsumer.java
@@ -13,7 +13,6 @@ import no.nav.testnav.apps.syntvedtakshistorikkservice.domain.Tags;
 import no.nav.testnav.libs.securitycore.domain.ServerProperties;
 import no.nav.testnav.libs.standalone.servletsecurity.exchange.TokenExchange;
 import org.springframework.stereotype.Service;
-
 import org.springframework.web.reactive.function.client.WebClient;
 
 import java.io.BufferedReader;
@@ -40,10 +39,10 @@ public class PdlProxyConsumer {
 
     public PdlProxyConsumer(
             Consumers consumers,
-            TokenExchange tokenExchange) {
+            TokenExchange tokenExchange,
+            WebClient.Builder webClientBuilder) {
         serverProperties = consumers.getPdlApiProxy();
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .baseUrl(serverProperties.getUrl())
                 .build();
         this.tokenExchange = tokenExchange;
@@ -57,7 +56,7 @@ public class PdlProxyConsumer {
                     .flatMap(accessToken -> new GetPdlPersonCommand(ident, query, accessToken.getTokenValue(), webClient).call())
                     .block();
             if (nonNull(response) && nonNull(response.getErrors()) && !response.getErrors().isEmpty()) {
-                log.error("Klarte ikke hente pdlperson: " + response.getErrors().get(0).getMessage());
+                log.error("Klarte ikke hente pdlperson: " + response.getErrors().getFirst().getMessage());
                 return null;
             }
             return response;

--- a/apps/synt-vedtakshistorikk-service/src/main/java/no/nav/testnav/apps/syntvedtakshistorikkservice/consumer/PensjonTestdataFacadeConsumer.java
+++ b/apps/synt-vedtakshistorikk-service/src/main/java/no/nav/testnav/apps/syntvedtakshistorikkservice/consumer/PensjonTestdataFacadeConsumer.java
@@ -10,7 +10,6 @@ import no.nav.testnav.apps.syntvedtakshistorikkservice.consumer.response.pensjon
 import no.nav.testnav.libs.securitycore.domain.ServerProperties;
 import no.nav.testnav.libs.standalone.servletsecurity.exchange.TokenExchange;
 import org.springframework.stereotype.Component;
-
 import org.springframework.web.reactive.function.client.WebClient;
 
 import java.util.Collections;
@@ -25,10 +24,11 @@ public class PensjonTestdataFacadeConsumer {
 
     public PensjonTestdataFacadeConsumer(
             Consumers consumers,
-            TokenExchange tokenExchange) {
+            TokenExchange tokenExchange,
+            WebClient.Builder webClientBuilder) {
+
         serverProperties = consumers.getTestnavPensjonTestdataFacadeProxy();
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .baseUrl(serverProperties.getUrl())
                 .build();
         this.tokenExchange = tokenExchange;

--- a/apps/synt-vedtakshistorikk-service/src/main/java/no/nav/testnav/apps/syntvedtakshistorikkservice/consumer/PersonSearchConsumer.java
+++ b/apps/synt-vedtakshistorikk-service/src/main/java/no/nav/testnav/apps/syntvedtakshistorikkservice/consumer/PersonSearchConsumer.java
@@ -20,10 +20,11 @@ public class PersonSearchConsumer {
 
     public PersonSearchConsumer(
             Consumers consumers,
-            TokenExchange tokenExchange) {
+            TokenExchange tokenExchange,
+            WebClient.Builder webClientBuilder) {
+
         serverProperties = consumers.getTestnavPersonSearchService();
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .baseUrl(serverProperties.getUrl())
                 .build();
         this.tokenExchange = tokenExchange;

--- a/apps/synt-vedtakshistorikk-service/src/main/java/no/nav/testnav/apps/syntvedtakshistorikkservice/consumer/SyntDagpengerConsumer.java
+++ b/apps/synt-vedtakshistorikk-service/src/main/java/no/nav/testnav/apps/syntvedtakshistorikkservice/consumer/SyntDagpengerConsumer.java
@@ -26,12 +26,13 @@ public class SyntDagpengerConsumer {
 
     public SyntDagpengerConsumer(
             Consumers consumers,
-            TokenExchange tokenExchange
+            TokenExchange tokenExchange,
+            WebClient.Builder webClientBuilder
     ) {
+
         serverProperties = consumers.getSyntDagpenger();
         this.tokenExchange = tokenExchange;
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .exchangeStrategies(ExchangeStrategies
                         .builder()
                         .codecs(configurer -> configurer
@@ -50,7 +51,7 @@ public class SyntDagpengerConsumer {
                     .flatMap(accessToken -> new HentDagpengevedtakCommand(webClient, request, rettighet, accessToken.getTokenValue()).call())
                     .block();
             if (nonNull(response) && !response.isEmpty()) {
-                return response.get(0);
+                return response.getFirst();
             } else {
                 return null;
             }

--- a/apps/synt-vedtakshistorikk-service/src/main/java/no/nav/testnav/apps/syntvedtakshistorikkservice/consumer/SyntVedtakshistorikkConsumer.java
+++ b/apps/synt-vedtakshistorikk-service/src/main/java/no/nav/testnav/apps/syntvedtakshistorikkservice/consumer/SyntVedtakshistorikkConsumer.java
@@ -32,11 +32,12 @@ public class SyntVedtakshistorikkConsumer {
 
     public SyntVedtakshistorikkConsumer(
             Consumers consumers,
-            TokenExchange tokenExchange) {
+            TokenExchange tokenExchange,
+            WebClient.Builder webClientBuilder) {
+
         serverProperties = consumers.getSyntVedtakshistorikk();
         this.tokenExchange = tokenExchange;
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .exchangeStrategies(ExchangeStrategies
                         .builder()
                         .codecs(configurer -> configurer

--- a/apps/tenor-search-service/src/main/java/no/nav/testnav/apps/tenorsearchservice/consumers/DollyBackendConsumer.java
+++ b/apps/tenor-search-service/src/main/java/no/nav/testnav/apps/tenorsearchservice/consumers/DollyBackendConsumer.java
@@ -23,11 +23,12 @@ public class DollyBackendConsumer {
     private final ServerProperties dollyBackendProperties;
     private final ServerProperties dollyBackendPropertiesDev;
 
-    public DollyBackendConsumer(TokenExchange tokenExchange, Consumers serverProperties) {
-        this.webClient = WebClient.builder()
+    public DollyBackendConsumer(TokenExchange tokenExchange, Consumers serverProperties,
+                                WebClient.Builder webClientBuilder) {
+        this.webClient = webClientBuilder
                 .baseUrl(serverProperties.getDollyBackend().getUrl())
                 .build();
-        this.webClientDev = WebClient.builder()
+        this.webClientDev = webClientBuilder
                 .baseUrl(serverProperties.getDollyBackendDev().getUrl())
                 .build();
         this.tokenExchange = tokenExchange;

--- a/apps/tenor-search-service/src/main/java/no/nav/testnav/apps/tenorsearchservice/consumers/MaskinportenConsumer.java
+++ b/apps/tenor-search-service/src/main/java/no/nav/testnav/apps/tenorsearchservice/consumers/MaskinportenConsumer.java
@@ -35,8 +35,8 @@ public class MaskinportenConsumer {
     private final MaskinportenConfig maskinportenConfig;
     private final Mono<AccessToken> accessToken;
 
-    public MaskinportenConsumer(MaskinportenConfig maskinportenConfig) {
-        this.webClient = WebClient.builder().build();
+    public MaskinportenConsumer(MaskinportenConfig maskinportenConfig, WebClient.Builder webClientBuilder) {
+        this.webClient = webClientBuilder.build();
         this.maskinportenConfig = maskinportenConfig;
         var wellKnownMono = cache(
                 new GetWellKnownCommand(webClient, maskinportenConfig).call(),

--- a/apps/tenor-search-service/src/main/java/no/nav/testnav/apps/tenorsearchservice/consumers/PdlDataConsumer.java
+++ b/apps/tenor-search-service/src/main/java/no/nav/testnav/apps/tenorsearchservice/consumers/PdlDataConsumer.java
@@ -18,8 +18,9 @@ public class PdlDataConsumer {
     private final TokenExchange tokenExchange;
     private final ServerProperties serverProperties;
 
-    public PdlDataConsumer(TokenExchange tokenExchange, Consumers serverProperties) {
-        this.webClient = WebClient.builder()
+    public PdlDataConsumer(TokenExchange tokenExchange, Consumers serverProperties,
+                           WebClient.Builder webClientBuilder) {
+        this.webClient = webClientBuilder
                 .baseUrl(serverProperties.getPdlTestdata().getUrl())
                 .build();
         this.tokenExchange = tokenExchange;

--- a/apps/tenor-search-service/src/main/java/no/nav/testnav/apps/tenorsearchservice/consumers/TenorConsumer.java
+++ b/apps/tenor-search-service/src/main/java/no/nav/testnav/apps/tenorsearchservice/consumers/TenorConsumer.java
@@ -15,10 +15,10 @@ public class TenorConsumer {
     private final WebClient webClient;
     private final MaskinportenConsumer maskinportenConsumer;
 
-    public TenorConsumer(Consumers consumers, MaskinportenConsumer maskinportenConsumer) {
+    public TenorConsumer(Consumers consumers, MaskinportenConsumer maskinportenConsumer,
+                         WebClient.Builder webClientBuilder) {
 
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .baseUrl(consumers.getTenorSearchService().getUrl())
                 .codecs(configurer -> configurer.defaultCodecs()
                         .maxInMemorySize(32 * 1024 * 1024))

--- a/apps/tenor-search-service/src/main/java/no/nav/testnav/apps/tenorsearchservice/consumers/TenorOrganisasjonConsumer.java
+++ b/apps/tenor-search-service/src/main/java/no/nav/testnav/apps/tenorsearchservice/consumers/TenorOrganisasjonConsumer.java
@@ -15,10 +15,10 @@ public class TenorOrganisasjonConsumer {
     private final WebClient webClient;
     private final MaskinportenConsumer maskinportenConsumer;
 
-    public TenorOrganisasjonConsumer(Consumers consumers, MaskinportenConsumer maskinportenConsumer) {
+    public TenorOrganisasjonConsumer(Consumers consumers, MaskinportenConsumer maskinportenConsumer,
+                                     WebClient.Builder webClientBuilder) {
 
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .baseUrl(consumers.getTenorSearchService().getUrl())
                 .codecs(configurer -> configurer.defaultCodecs()
                         .maxInMemorySize(32 * 1024 * 1024))

--- a/apps/testnav-ident-pool/src/main/java/no/nav/testnav/identpool/consumers/TpsMessagingConsumer.java
+++ b/apps/testnav-ident-pool/src/main/java/no/nav/testnav/identpool/consumers/TpsMessagingConsumer.java
@@ -29,11 +29,12 @@ public class TpsMessagingConsumer {
 
     public TpsMessagingConsumer(
             Consumers consumers,
-            TokenExchange tokenExchange
+            TokenExchange tokenExchange,
+            WebClient.Builder webClientBuilder
     ) {
+
         serverProperties = consumers.getTpsMessagingService();
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .baseUrl(serverProperties.getUrl())
                 .build();
         this.tokenExchange = tokenExchange;

--- a/apps/testnorge-statisk-data-forvalter/src/main/java/no/nav/registre/sdforvalter/consumer/rs/aareg/AaregConsumer.java
+++ b/apps/testnorge-statisk-data-forvalter/src/main/java/no/nav/registre/sdforvalter/consumer/rs/aareg/AaregConsumer.java
@@ -21,11 +21,12 @@ public class AaregConsumer {
 
     public AaregConsumer(
             Consumers consumers,
-            TokenExchange tokenExchange
+            TokenExchange tokenExchange,
+            WebClient.Builder webClientBuilder
     ) {
         serverProperties = consumers.getTestnavAaregProxy();
         this.tokenExchange = tokenExchange;
-        this.webClient = WebClient.builder()
+        this.webClient = webClientBuilder
                 .exchangeStrategies(ExchangeStrategies.builder()
                         .codecs(configurer -> configurer
                                 .defaultCodecs()

--- a/apps/testnorge-statisk-data-forvalter/src/main/java/no/nav/registre/sdforvalter/consumer/rs/kodeverk/KodeverkConsumer.java
+++ b/apps/testnorge-statisk-data-forvalter/src/main/java/no/nav/registre/sdforvalter/consumer/rs/kodeverk/KodeverkConsumer.java
@@ -12,10 +12,10 @@ public class KodeverkConsumer {
     private final WebClient webClient;
 
     public KodeverkConsumer(
-            Consumers consumers
+            Consumers consumers,
+            WebClient.Builder webClientBuilder
     ) {
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .exchangeStrategies(ExchangeStrategies
                         .builder()
                         .codecs(configurer -> configurer

--- a/apps/testnorge-statisk-data-forvalter/src/main/java/no/nav/registre/sdforvalter/consumer/rs/navn/GenererNavnConsumer.java
+++ b/apps/testnorge-statisk-data-forvalter/src/main/java/no/nav/registre/sdforvalter/consumer/rs/navn/GenererNavnConsumer.java
@@ -17,11 +17,12 @@ public class GenererNavnConsumer {
 
     public GenererNavnConsumer(
             Consumers consumers,
-            TokenExchange tokenExchange) {
+            TokenExchange tokenExchange,
+            WebClient.Builder webClientBuilder) {
+
         this.tokenExchange = tokenExchange;
         properties = consumers.getGenererNavnService();
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .baseUrl(properties.getUrl())
                 .build();
     }

--- a/apps/testnorge-statisk-data-forvalter/src/main/java/no/nav/registre/sdforvalter/consumer/rs/organisasjon/OrganisasjonConsumer.java
+++ b/apps/testnorge-statisk-data-forvalter/src/main/java/no/nav/registre/sdforvalter/consumer/rs/organisasjon/OrganisasjonConsumer.java
@@ -25,12 +25,13 @@ public class OrganisasjonConsumer {
 
     public OrganisasjonConsumer(
             Consumers consumers,
-            TokenExchange tokenExchange) {
+            TokenExchange tokenExchange,
+            WebClient.Builder webClientBuilder) {
+
         serverProperties = consumers.getTestnavOrganisasjonService();
         this.tokenExchange = tokenExchange;
         this.executor = Executors.newFixedThreadPool(serverProperties.getThreads());
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .baseUrl(serverProperties.getUrl())
                 .build();
     }

--- a/apps/testnorge-statisk-data-forvalter/src/main/java/no/nav/registre/sdforvalter/consumer/rs/organisasjon/OrganisasjonFasteDataConsumer.java
+++ b/apps/testnorge-statisk-data-forvalter/src/main/java/no/nav/registre/sdforvalter/consumer/rs/organisasjon/OrganisasjonFasteDataConsumer.java
@@ -27,12 +27,12 @@ public class OrganisasjonFasteDataConsumer {
     public OrganisasjonFasteDataConsumer(
             Consumers consumers,
             TokenExchange tokenExchange,
-            GenererNavnConsumer genererNavnConsumer) {
+            GenererNavnConsumer genererNavnConsumer,
+            WebClient.Builder webClientBuilder) {
 
         serverProperties = consumers.getTestnavOrganisasjonFasteDataService();
         this.tokenExchange = tokenExchange;
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .baseUrl(serverProperties.getUrl())
                 .build();
         this.genererNavnConsumer = genererNavnConsumer;

--- a/apps/tilbakemelding-api/src/main/java/no/nav/registre/testnorge/tilbakemeldingapi/config/AppConfig.java
+++ b/apps/tilbakemelding-api/src/main/java/no/nav/registre/testnorge/tilbakemeldingapi/config/AppConfig.java
@@ -1,14 +1,14 @@
 package no.nav.registre.testnorge.tilbakemeldingapi.config;
 
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
-
 import no.nav.testnav.libs.servletcore.config.ApplicationCoreConfig;
 import no.nav.testnav.libs.servletcore.config.ApplicationProperties;
 import no.nav.testnav.libs.servletsecurity.config.SecureOAuth2ServerToServerConfiguration;
 import no.nav.testnav.libs.slack.consumer.SlackConsumer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.web.reactive.function.client.WebClient;
 
 @Configuration
 @Import({
@@ -22,9 +22,10 @@ public class AppConfig {
             @Value("${consumers.slack.token}") String token,
             @Value("${consumers.slack.baseUrl}") String baseUrl,
             @Value("${http.proxy:#{null}}") String proxyHost,
-            ApplicationProperties properties
+            ApplicationProperties properties,
+            WebClient .Builder webClientBuilder
     ) {
-        return new SlackConsumer(token, baseUrl, proxyHost, properties.getName());
+        return new SlackConsumer(token, baseUrl, proxyHost, properties.getName(), webClientBuilder);
     }
 
 

--- a/apps/tilbakemelding-api/src/main/java/no/nav/registre/testnorge/tilbakemeldingapi/consumer/ProfilApiConsumer.java
+++ b/apps/tilbakemelding-api/src/main/java/no/nav/registre/testnorge/tilbakemeldingapi/consumer/ProfilApiConsumer.java
@@ -8,7 +8,6 @@ import no.nav.testnav.libs.securitycore.domain.ServerProperties;
 import no.nav.testnav.libs.servletsecurity.exchange.TokenExchange;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
-
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.util.retry.Retry;
 
@@ -24,12 +23,13 @@ public class ProfilApiConsumer {
 
     public ProfilApiConsumer(
             Consumers consumers,
-            TokenExchange tokenExchange
+            TokenExchange tokenExchange,
+            WebClient.Builder webClientBuilder
     ) {
+
         serverProperties = consumers.getProfilApi();
         this.tokenExchange = tokenExchange;
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .baseUrl(serverProperties.getUrl())
                 .build();
     }

--- a/apps/tps-messaging-service/src/main/java/no/nav/testnav/apps/tpsmessagingservice/consumer/TestmiljoerServiceConsumer.java
+++ b/apps/tps-messaging-service/src/main/java/no/nav/testnav/apps/tpsmessagingservice/consumer/TestmiljoerServiceConsumer.java
@@ -22,11 +22,12 @@ public class TestmiljoerServiceConsumer {
 
     public TestmiljoerServiceConsumer(
             Consumers consumers,
-            TokenExchange tokenExchange
+            TokenExchange tokenExchange,
+            WebClient.Builder webClientBuilder
     ) {
+
         serverProperties = consumers.getTestmiljoerService();
-        this.webClient = WebClient
-                .builder()
+        this.webClient = webClientBuilder
                 .baseUrl(serverProperties.getUrl())
                 .build();
         this.tokenExchange = tokenExchange;

--- a/libs/reactive-core/src/main/java/no/nav/testnav/libs/reactivecore/config/WebClientConfig.java
+++ b/libs/reactive-core/src/main/java/no/nav/testnav/libs/reactivecore/config/WebClientConfig.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.web.reactive.function.client.ClientRequestObservationConvention;
 import org.springframework.web.reactive.function.client.DefaultClientRequestObservationConvention;
@@ -23,6 +24,7 @@ import java.time.Duration;
 public class WebClientConfig {
 
     @Bean
+    @Primary
     public WebClient.Builder webClientBuilder(ApplicationContext context) {
 
         try {
@@ -43,14 +45,14 @@ public class WebClientConfig {
                                             .create(ConnectionProvider.builder("Testnorge connection pool")
                                                     .maxConnections(5)
                                                     .pendingAcquireMaxCount(10000)
-                                                    .pendingAcquireTimeout(Duration.ofMinutes(30))
+                                                    .pendingAcquireTimeout(Duration.ofSeconds(300))
                                                     .build())
                                             .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 10000)
                                             .option(ChannelOption.SO_KEEPALIVE, true)
                                             .option(EpollChannelOption.TCP_KEEPIDLE, 300)
                                             .option(EpollChannelOption.TCP_KEEPINTVL, 60)
                                             .option(EpollChannelOption.TCP_KEEPCNT, 8)
-                                            .responseTimeout(Duration.ofSeconds(30))
+                                            .responseTimeout(Duration.ofSeconds(5))
                             ));
 
         } catch (NoSuchBeanDefinitionException e) {

--- a/libs/slack/src/main/java/no/nav/testnav/libs/slack/consumer/SlackConsumer.java
+++ b/libs/slack/src/main/java/no/nav/testnav/libs/slack/consumer/SlackConsumer.java
@@ -1,17 +1,16 @@
 package no.nav.testnav.libs.slack.consumer;
 
 import lombok.extern.slf4j.Slf4j;
+import no.nav.testnav.libs.slack.command.PublishMessageCommand;
+import no.nav.testnav.libs.slack.command.UploadFileCommand;
+import no.nav.testnav.libs.slack.dto.Message;
+import no.nav.testnav.libs.slack.dto.SlackResponse;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.netty.http.client.HttpClient;
 import reactor.netty.transport.ProxyProvider;
 
 import java.net.URI;
-
-import no.nav.testnav.libs.slack.command.PublishMessageCommand;
-import no.nav.testnav.libs.slack.command.UploadFileCommand;
-import no.nav.testnav.libs.slack.dto.Message;
-import no.nav.testnav.libs.slack.dto.SlackResponse;
 
 @Slf4j
 public class SlackConsumer {
@@ -23,15 +22,15 @@ public class SlackConsumer {
             String token,
             String baseUrl,
             String proxyHost,
-            String applicationName
+            String applicationName,
+            WebClient.Builder webClientBuilder
     ) {
         this.token = token;
         this.applicationName = applicationName;
-        var builder = WebClient.builder();
         if (proxyHost != null) {
             log.info("Setter opp proxy host {} for Slack api", proxyHost);
             var uri = URI.create(proxyHost);
-            builder.clientConnector(new ReactorClientHttpConnector(
+            webClientBuilder.clientConnector(new ReactorClientHttpConnector(
                 HttpClient
                     .create()
                     .proxy(proxy -> proxy
@@ -40,7 +39,7 @@ public class SlackConsumer {
                         .port(uri.getPort()))
             ));
         }
-        webClient = builder
+        this.webClient = webClientBuilder
                 .baseUrl(baseUrl)
                 .build();
     }

--- a/proxies/arbeidsplassencv-proxy/src/main/java/no/nav/testnav/proxies/arbeidsplassencvproxy/consumer/FakedingsConsumer.java
+++ b/proxies/arbeidsplassencv-proxy/src/main/java/no/nav/testnav/proxies/arbeidsplassencvproxy/consumer/FakedingsConsumer.java
@@ -1,8 +1,6 @@
 package no.nav.testnav.proxies.arbeidsplassencvproxy.consumer;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import no.nav.testnav.libs.reactivesecurity.exchange.TokenExchange;
-import no.nav.testnav.libs.securitycore.domain.ServerProperties;
 import no.nav.testnav.proxies.arbeidsplassencvproxy.consumer.command.FakedingsGetCommand;
 import no.nav.testnav.proxies.arbeidsplassencvproxy.util.JacksonExchangeStrategyUtil;
 import org.springframework.stereotype.Service;
@@ -15,9 +13,9 @@ public class FakedingsConsumer {
     private static final String FAKE_TOKENDINGS_URL = "https://fakedings.intern.dev.nav.no";
     private final WebClient webClient;
 
-    public FakedingsConsumer(ObjectMapper objectMapper) {
+    public FakedingsConsumer(ObjectMapper objectMapper, WebClient.Builder webClientBuilder) {
 
-        this.webClient = WebClient.builder()
+        this.webClient = webClientBuilder
                 .baseUrl(FAKE_TOKENDINGS_URL)
                 .exchangeStrategies(JacksonExchangeStrategyUtil.getJacksonStrategy(objectMapper))
                 .build();


### PR DESCRIPTION
Updated the constructors of various consumer classes to accept and use WebClient.Builder for creating WebClient instances. This improves consistency across the codebase and allows easier customization of WebClient configurations.