### PR TITLE
Fikset sletting av skjerming og oppdatert brukte dependencies

### DIFF
--- a/apps/dolly-frontend/src/main/js/package-lock.json
+++ b/apps/dolly-frontend/src/main/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dolly",
-  "version": "3.0.40",
+  "version": "3.0.41",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dolly",
-      "version": "3.0.40",
+      "version": "3.0.41",
       "license": "ISC",
       "dependencies": {
         "@grafana/faro-react": "^1.1.2",
@@ -1528,14 +1528,14 @@
       }
     },
     "node_modules/@inquirer/confirm": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-3.2.0.tgz",
-      "integrity": "sha512-oOIwPs0Dvq5220Z8lGL/6LHRTEr9TgLHmiI99Rj1PJ1p1czTys+olrgBqZk4E2qC0YTzeHprxSQmoHioVdJ7Lw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-4.0.1.tgz",
+      "integrity": "sha512-46yL28o2NJ9doViqOy0VDcoTzng7rAb6yPQKU7VDLqkmbCaH4JqK4yk4XqlzNWy9PVC5pG1ZUXPBQv+VqnYs2w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^9.1.0",
-        "@inquirer/type": "^1.5.3"
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/type": "^2.0.0"
       },
       "engines": {
         "node": ">=18"
@@ -1565,19 +1565,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@inquirer/core/node_modules/@inquirer/type": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-2.0.0.tgz",
-      "integrity": "sha512-XvJRx+2KR3YXyYtPUUy+qd9i7p+GO9Ko6VIIpWlBrpWwXDv8WLFeHTxz35CfQFUiBMLXlGHhGzys7lqit9gWag==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mute-stream": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@inquirer/figures": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.7.tgz",
@@ -1589,9 +1576,9 @@
       }
     },
     "node_modules/@inquirer/type": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-1.5.5.tgz",
-      "integrity": "sha512-MzICLu4yS7V8AA61sANROZ9vT1H3ooca5dSmI1FjZkzq7o/koMsRfQSzRtFo+F3Ao4Sf1C0bpLKejpKB/+j6MA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-2.0.0.tgz",
+      "integrity": "sha512-XvJRx+2KR3YXyYtPUUy+qd9i7p+GO9Ko6VIIpWlBrpWwXDv8WLFeHTxz35CfQFUiBMLXlGHhGzys7lqit9gWag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1729,9 +1716,9 @@
       }
     },
     "node_modules/@mswjs/interceptors": {
-      "version": "0.35.9",
-      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.35.9.tgz",
-      "integrity": "sha512-SSnyl/4ni/2ViHKkiZb8eajA/eN1DNFaHjhGiLUdZvDz6PKF4COSf/17xqSz64nOo2Ia29SA6B2KNCsyCbVmaQ==",
+      "version": "0.36.5",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.36.5.tgz",
+      "integrity": "sha512-aQ8WF5zQwOdcxLsxSEk9Jd01GgGb80xxqCaiDDlewhtwqpSm8MOvUHslwPydVirasdW09++NxDNNftm1vLY8yA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1747,16 +1734,16 @@
       }
     },
     "node_modules/@navikt/aksel-icons": {
-      "version": "7.3.0",
-      "resolved": "https://npm.pkg.github.com/download/@navikt/aksel-icons/7.3.0/50af8f46f221d92be1475249e8930c00b5417a72",
-      "integrity": "sha512-wQWdKZwY13hAVvurdwheFMOAc0Evl/RJde0KdIM49ZrKA3mpdKh2EQC4MbxkxIZPz071KC8fFdAuDKmKQ+hxvw==",
+      "version": "7.3.1",
+      "resolved": "https://npm.pkg.github.com/download/@navikt/aksel-icons/7.3.1/579d009ffc9063af4afd5000a9e73dfba39a1f1c",
+      "integrity": "sha512-FqARFTIvjOVyyYQ2BFS8ba3GEu/M53d7MUle5/NP838ZG4CY3O+Ea453dxPGuGCu2EIG8CX8sQ3VFmVqCYu9mQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@navikt/ds-css": {
-      "version": "7.3.0",
-      "resolved": "https://npm.pkg.github.com/download/@navikt/ds-css/7.3.0/149d6e5c64ae6a19a56e070d63bc97522fe54f3a",
-      "integrity": "sha512-kLuq7lJFYuvmQzd9IjkthUFTzQN7hYwSX+oXuQjN4KoBJNqMTwJVnwJUdVY+2xwUirmwXrt2ZRAe0dp7e8+NrQ==",
+      "version": "7.3.1",
+      "resolved": "https://npm.pkg.github.com/download/@navikt/ds-css/7.3.1/ed21257bbfa4a5615ce55bfe7f5175b20bf42d8f",
+      "integrity": "sha512-Q/vzLpPvtzUEmrK2s6dH/gtPTcj11AlEBFxG6tMzLUcynB7R0olXgYBfdD7kTPy3F2Y6PWr5ihQvV4tXPIgpww==",
       "dev": true,
       "license": "MIT"
     },
@@ -1778,16 +1765,16 @@
       }
     },
     "node_modules/@navikt/ds-react": {
-      "version": "7.3.0",
-      "resolved": "https://npm.pkg.github.com/download/@navikt/ds-react/7.3.0/f78f7e92e1a244843746d6f746ddc970b5c47106",
-      "integrity": "sha512-3jZPqOopOCTxl07IRGsnbOae2GZvUsUPYXg0X1A0RGRATZDEPseUd76miI06H2HLH8iqKGr8/I1lACJP70yY6A==",
+      "version": "7.3.1",
+      "resolved": "https://npm.pkg.github.com/download/@navikt/ds-react/7.3.1/0aa76367ae5294f4ed2f598218240efa7a51e136",
+      "integrity": "sha512-5HetHrvZHwjTr/CfOy9fES018vYgU5Jgb+VE+P+U0SuLU2k+86+mJ5fhsXQn6ipSqBDPGOB0IMw0LY8n/eVkFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@floating-ui/react": "0.25.4",
         "@floating-ui/react-dom": "^2.0.9",
-        "@navikt/aksel-icons": "^7.3.0",
-        "@navikt/ds-tokens": "^7.3.0",
+        "@navikt/aksel-icons": "^7.3.1",
+        "@navikt/ds-tokens": "^7.3.1",
         "clsx": "^2.1.0",
         "date-fns": "^3.0.0",
         "react-day-picker": "8.10.0"
@@ -1937,9 +1924,9 @@
       }
     },
     "node_modules/@navikt/ds-tokens": {
-      "version": "7.3.0",
-      "resolved": "https://npm.pkg.github.com/download/@navikt/ds-tokens/7.3.0/7b08f7cb6ecc23773ded1d655d8e75af80316c3a",
-      "integrity": "sha512-2VeG4C6D6yF4BGKlL9RuSi2scbFVZjXnEOjUYiFeePywS4c56xVvoFTFSWDxn5bHSg59QAuHdnxp7MUwsucYJQ==",
+      "version": "7.3.1",
+      "resolved": "https://npm.pkg.github.com/download/@navikt/ds-tokens/7.3.1/806b85e70ee44c469422bf5b415a4e9c026d981d",
+      "integrity": "sha512-zYoEz4YMfKiyi2CwYFWRjPTkzmeNZqE5XRb8CL0xkZMj3ESkn0M7XSEk2AKfe7BIN7q3kItD4bMsmCruTmr1pQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -3414,9 +3401,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.7.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.7.tgz",
-      "integrity": "sha512-SRxCrrg9CL/y54aiMCG3edPKdprgMVGDXjA3gB8UmmBW5TcXzRUYAh8EWzTnSJFAd1rgImPELza+A3bJ+qxz8Q==",
+      "version": "22.7.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.8.tgz",
+      "integrity": "sha512-a922jJy31vqR5sk+kAdIENJjHblqcZ4RmERviFsER4WJcEONqxKcjNOlk0q7OUfrF5sddT+vng070cdfMlrPLg==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
@@ -3639,17 +3626,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.10.0.tgz",
-      "integrity": "sha512-phuB3hoP7FFKbRXxjl+DRlQDuJqhpOnm5MmtROXyWi3uS/Xg2ZXqiQfcG2BJHiN4QKyzdOJi3NEn/qTnjUlkmQ==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.11.0.tgz",
+      "integrity": "sha512-KhGn2LjW1PJT2A/GfDpiyOfS4a8xHQv2myUagTM5+zsormOmBlYsnQ6pobJ8XxJmh6hnHwa2Mbe3fPrDJoDhbA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.10.0",
-        "@typescript-eslint/type-utils": "8.10.0",
-        "@typescript-eslint/utils": "8.10.0",
-        "@typescript-eslint/visitor-keys": "8.10.0",
+        "@typescript-eslint/scope-manager": "8.11.0",
+        "@typescript-eslint/type-utils": "8.11.0",
+        "@typescript-eslint/utils": "8.11.0",
+        "@typescript-eslint/visitor-keys": "8.11.0",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
@@ -3673,16 +3660,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.10.0.tgz",
-      "integrity": "sha512-E24l90SxuJhytWJ0pTQydFT46Nk0Z+bsLKo/L8rtQSL93rQ6byd1V/QbDpHUTdLPOMsBCcYXZweADNCfOCmOAg==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.11.0.tgz",
+      "integrity": "sha512-lmt73NeHdy1Q/2ul295Qy3uninSqi6wQI18XwSpm8w0ZbQXUpjCAWP1Vlv/obudoBiIjJVjlztjQ+d/Md98Yxg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.10.0",
-        "@typescript-eslint/types": "8.10.0",
-        "@typescript-eslint/typescript-estree": "8.10.0",
-        "@typescript-eslint/visitor-keys": "8.10.0",
+        "@typescript-eslint/scope-manager": "8.11.0",
+        "@typescript-eslint/types": "8.11.0",
+        "@typescript-eslint/typescript-estree": "8.11.0",
+        "@typescript-eslint/visitor-keys": "8.11.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -3702,14 +3689,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.10.0.tgz",
-      "integrity": "sha512-AgCaEjhfql9MDKjMUxWvH7HjLeBqMCBfIaBbzzIcBbQPZE7CPh1m6FF+L75NUMJFMLYhCywJXIDEMa3//1A0dw==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.11.0.tgz",
+      "integrity": "sha512-Uholz7tWhXmA4r6epo+vaeV7yjdKy5QFCERMjs1kMVsLRKIrSdM6o21W2He9ftp5PP6aWOVpD5zvrvuHZC0bMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.10.0",
-        "@typescript-eslint/visitor-keys": "8.10.0"
+        "@typescript-eslint/types": "8.11.0",
+        "@typescript-eslint/visitor-keys": "8.11.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3720,14 +3707,14 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.10.0.tgz",
-      "integrity": "sha512-PCpUOpyQSpxBn230yIcK+LeCQaXuxrgCm2Zk1S+PTIRJsEfU6nJ0TtwyH8pIwPK/vJoA+7TZtzyAJSGBz+s/dg==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.11.0.tgz",
+      "integrity": "sha512-ItiMfJS6pQU0NIKAaybBKkuVzo6IdnAhPFZA/2Mba/uBjuPQPet/8+zh5GtLHwmuFRShZx+8lhIs7/QeDHflOg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.10.0",
-        "@typescript-eslint/utils": "8.10.0",
+        "@typescript-eslint/typescript-estree": "8.11.0",
+        "@typescript-eslint/utils": "8.11.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.3.0"
       },
@@ -3745,9 +3732,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.10.0.tgz",
-      "integrity": "sha512-k/E48uzsfJCRRbGLapdZgrX52csmWJ2rcowwPvOZ8lwPUv3xW6CcFeJAXgx4uJm+Ge4+a4tFOkdYvSpxhRhg1w==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.11.0.tgz",
+      "integrity": "sha512-tn6sNMHf6EBAYMvmPUaKaVeYvhUsrE6x+bXQTxjQRp360h1giATU0WvgeEys1spbvb5R+VpNOZ+XJmjD8wOUHw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3759,14 +3746,14 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.10.0.tgz",
-      "integrity": "sha512-3OE0nlcOHaMvQ8Xu5gAfME3/tWVDpb/HxtpUZ1WeOAksZ/h/gwrBzCklaGzwZT97/lBbbxJ16dMA98JMEngW4w==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.11.0.tgz",
+      "integrity": "sha512-yHC3s1z1RCHoCz5t06gf7jH24rr3vns08XXhfEqzYpd6Hll3z/3g23JRi0jM8A47UFKNc3u/y5KIMx8Ynbjohg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@typescript-eslint/types": "8.10.0",
-        "@typescript-eslint/visitor-keys": "8.10.0",
+        "@typescript-eslint/types": "8.11.0",
+        "@typescript-eslint/visitor-keys": "8.11.0",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -3788,16 +3775,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.10.0.tgz",
-      "integrity": "sha512-Oq4uZ7JFr9d1ZunE/QKy5egcDRXT/FrS2z/nlxzPua2VHFtmMvFNDvpq1m/hq0ra+T52aUezfcjGRIB7vNJF9w==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.11.0.tgz",
+      "integrity": "sha512-CYiX6WZcbXNJV7UNB4PLDIBtSdRmRI/nb0FMyqHPTQD1rMjA0foPLaPUV39C/MxkTd/QKSeX+Gb34PPsDVC35g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.10.0",
-        "@typescript-eslint/types": "8.10.0",
-        "@typescript-eslint/typescript-estree": "8.10.0"
+        "@typescript-eslint/scope-manager": "8.11.0",
+        "@typescript-eslint/types": "8.11.0",
+        "@typescript-eslint/typescript-estree": "8.11.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3811,13 +3798,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.10.0.tgz",
-      "integrity": "sha512-k8nekgqwr7FadWk548Lfph6V3r9OVqjzAIVskE7orMZR23cGJjAOVazsZSJW+ElyjfTM4wx/1g88Mi70DDtG9A==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.11.0.tgz",
+      "integrity": "sha512-EaewX6lxSjRJnc+99+dqzTeoDZUfyrA52d2/HRrkI830kgovWsmIiTfmr0NZorzqic7ga+1bS60lRBUgR3n/Bw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.10.0",
+        "@typescript-eslint/types": "8.11.0",
         "eslint-visitor-keys": "^3.4.3"
       },
       "engines": {
@@ -4458,9 +4445,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.0.tgz",
-      "integrity": "sha512-Rmb62sR1Zpjql25eSanFGEhAxcFwfA1K0GuQcLoaJBAcENegrQut3hYdhXFF1obQfiDyqIW/cLM5HSJ/9k884A==",
+      "version": "4.24.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.2.tgz",
+      "integrity": "sha512-ZIc+Q62revdMcqC6aChtW4jz3My3klmCO1fEmINZY/8J3EpBg5/A/D0AKmBveUh6pgoeycoMkVMko84tuYS+Gg==",
       "dev": true,
       "funding": [
         {
@@ -4478,10 +4465,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001663",
-        "electron-to-chromium": "^1.5.28",
+        "caniuse-lite": "^1.0.30001669",
+        "electron-to-chromium": "^1.5.41",
         "node-releases": "^2.0.18",
-        "update-browserslist-db": "^1.1.0"
+        "update-browserslist-db": "^1.1.1"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -5255,9 +5242,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.41",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.41.tgz",
-      "integrity": "sha512-dfdv/2xNjX0P8Vzme4cfzHqnPm5xsZXwsolTYr0eyW18IUmNyG08vL+fttvinTfhKfIKdRoqkDIC9e9iWQCNYQ==",
+      "version": "1.5.42",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.42.tgz",
+      "integrity": "sha512-gIfKavKDw1mhvic9nbzA5lZw8QSHpdMwLwXc0cWidQz9B15pDoDdDH4boIatuFfeoCatb3a/NGL6CYRVFxGZ9g==",
       "dev": true,
       "license": "ISC"
     },
@@ -7957,9 +7944,9 @@
       "license": "MIT"
     },
     "node_modules/msw": {
-      "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/msw/-/msw-2.4.11.tgz",
-      "integrity": "sha512-TVEw9NOPTc6ufOQLJ53234S9NBRxQbu7xFMxs+OCP43JQcNEIOKiZHxEm2nDzYIrwccoIhUxUf8wr99SukD76A==",
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.4.13.tgz",
+      "integrity": "sha512-EDA7ls/twh3XG5QEYv0LvAnnFs3wYL6GFNMSqG4hh2+1rq7h78iDbh5jB2iaO8hKi1JVmZLO6ItssXmP1A7nxQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -7967,8 +7954,8 @@
         "@bundled-es-modules/cookie": "^2.0.0",
         "@bundled-es-modules/statuses": "^1.0.1",
         "@bundled-es-modules/tough-cookie": "^0.1.6",
-        "@inquirer/confirm": "^3.0.0",
-        "@mswjs/interceptors": "^0.35.8",
+        "@inquirer/confirm": "^4.0.0",
+        "@mswjs/interceptors": "^0.36.5",
         "@open-draft/until": "^2.1.0",
         "@types/cookie": "^0.6.0",
         "@types/statuses": "^2.0.4",
@@ -9046,12 +9033,12 @@
       }
     },
     "node_modules/react-inlinesvg": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/react-inlinesvg/-/react-inlinesvg-4.1.3.tgz",
-      "integrity": "sha512-p1+wkr1UQZyLw/3bdpnHO3v3tMNVWyxWnAEY6ML/Ql9ldDYTBTy6HqAyNl7u3au925XPffLMiXKnQrqZeJAldw==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/react-inlinesvg/-/react-inlinesvg-4.1.4.tgz",
+      "integrity": "sha512-V7x3YGqG7LNeHpsIx90HDa2qhYCOPkzjIMToPWALyvOTI3kzicKF2O2PNZDaVqAVhwRbijLIUoQN5STleTO2rg==",
       "license": "MIT",
       "dependencies": {
-        "react-from-dom": "^0.7.2"
+        "react-from-dom": "^0.7.3"
       },
       "peerDependencies": {
         "react": "16.8 - 18"
@@ -10547,22 +10534,22 @@
       }
     },
     "node_modules/tldts": {
-      "version": "6.1.52",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.52.tgz",
-      "integrity": "sha512-fgrDJXDjbAverY6XnIt0lNfv8A0cf7maTEaZxNykLGsLG7XP+5xhjBTrt/ieAsFjAlZ+G5nmXomLcZDkxXnDzw==",
+      "version": "6.1.53",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.53.tgz",
+      "integrity": "sha512-4uCStuOjPFaY2/LUjTSwdnJTC82W/gvSFL6FoTC9ehNOHboA9cyO3wX1erh2yGofVls37OdXr5sQLEfL5hS1TA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^6.1.52"
+        "tldts-core": "^6.1.53"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "6.1.52",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.52.tgz",
-      "integrity": "sha512-j4OxQI5rc1Ve/4m/9o2WhWSC4jGc4uVbCINdOEJRAraCi0YqTqgMcxUx7DbmuP0G3PCixoof/RZB0Q5Kh9tagw==",
+      "version": "6.1.53",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.53.tgz",
+      "integrity": "sha512-IleS872aGdTB/UtocD2dSZBnQi/nqMIZxxezVgfcKKjw6+G2hJGzFw9buIDJO2MVJyEJe3rCAdyMTl2yvGMMrQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/apps/dolly-frontend/src/main/js/package.json
+++ b/apps/dolly-frontend/src/main/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dolly",
-  "version": "3.0.40",
+  "version": "3.0.41",
   "type": "module",
   "description": "",
   "main": "index.js",

--- a/apps/dolly-frontend/src/main/js/src/api/index.ts
+++ b/apps/dolly-frontend/src/main/js/src/api/index.ts
@@ -169,7 +169,7 @@ type Config = {
 const _fetch = (url: string, config: Config, body?: object): Promise<Response> =>
 	fetchRetry(url, {
 		retryOn: (attempt, error, response) => {
-			if (!response.ok && !runningE2ETest()) {
+			if (!response.ok && response?.status !== 404 && !runningE2ETest()) {
 				if (response?.status === 401 && !allowForbidden.some((value) => url.includes(value))) {
 					console.error('Auth feilet, navigerer til login')
 					navigateToLogin()

--- a/apps/dolly-frontend/src/main/js/src/service/services/skjerming/SkjermingService.tsx
+++ b/apps/dolly-frontend/src/main/js/src/service/services/skjerming/SkjermingService.tsx
@@ -1,10 +1,17 @@
 import Request from '@/service/services/Request'
+import { subDays } from 'date-fns'
 
 const skjermingUrl = '/testnav-skjermingsregister-proxy/api/v1/skjerming/dolly'
 
 export default {
-	deleteSkjerming(ident: string) {
-		return Request.put(skjermingUrl, { personident: ident, skjermetTil: new Date() })
+	deleteSkjerming(ident: string, fornavn: string, etternavn: string) {
+		return Request.put(skjermingUrl, {
+			personident: ident,
+			fornavn: fornavn,
+			etternavn: etternavn,
+			skjermetFra: subDays(new Date(), 1),
+			skjermetTil: new Date(),
+		})
 	},
 
 	getSkjerming(ident: string) {


### PR DESCRIPTION
This pull request updates several dependencies in the `package-lock.json` file to their latest versions. The changes primarily focus on updating versions to improve security, performance, and compatibility.

Code refactor/Bug fixes:
* Fixed faulty deletion of skjerming in personVisningRedigering
* Changed fetch_retry to skip retrying if endpoint returns a 404 status

Dependency updates:

* Updated the project version to `3.0.41` (`apps/dolly-frontend/src/main/js/package-lock.json`).

Major dependency updates:

* Updated `@inquirer/confirm` from `3.2.0` to `4.0.1`, along with its dependencies (`@inquirer/core` and `@inquirer/type`) to newer versions (`apps/dolly-frontend/src/main/js/package-lock.json`) [[1]](diffhunk://#diff-f927473d3cafe422c5ebd1b4ac3667070f49100c00f35f5054faadf3433a6434L1531-R1538) [[2]](diffhunk://#diff-f927473d3cafe422c5ebd1b4ac3667070f49100c00f35f5054faadf3433a6434L1592-R1581).
* Updated `@mswjs/interceptors` from `0.35.9` to `0.36.5` (`apps/dolly-frontend/src/main/js/package-lock.json`).
* Updated `@navikt` packages (`aksel-icons`, `ds-css`, `ds-react`, `ds-tokens`) from `7.3.0` to `7.3.1` (`apps/dolly-frontend/src/main/js/package-lock.json`) [[1]](diffhunk://#diff-f927473d3cafe422c5ebd1b4ac3667070f49100c00f35f5054faadf3433a6434L1750-R1746) [[2]](diffhunk://#diff-f927473d3cafe422c5ebd1b4ac3667070f49100c00f35f5054faadf3433a6434L1781-R1777) [[3]](diffhunk://#diff-f927473d3cafe422c5ebd1b4ac3667070f49100c00f35f5054faadf3433a6434L1940-R1929).
* Updated `@typescript-eslint` packages (`eslint-plugin`, `parser`, `scope-manager`, `type-utils`, `types`, `typescript-estree`, `visitor-keys`) from `8.10.0` to `8.11.0` (`apps/dolly-frontend/src/main/js/package-lock.json`) [[1]](diffhunk://#diff-f927473d3cafe422c5ebd1b4ac3667070f49100c00f35f5054faadf3433a6434L3642-R3639) [[2]](diffhunk://#diff-f927473d3cafe422c5ebd1b4ac3667070f49100c00f35f5054faadf3433a6434L3676-R3672) [[3]](diffhunk://#diff-f927473d3cafe422c5ebd1b4ac3667070f49100c00f35f5054faadf3433a6434L3705-R3699) [[4]](diffhunk://#diff-f927473d3cafe422c5ebd1b4ac3667070f49100c00f35f5054faadf3433a6434L3723-R3717) [[5]](diffhunk://#diff-f927473d3cafe422c5ebd1b4ac3667070f49100c00f35f5054faadf3433a6434L3748-R3737) [[6]](diffhunk://#diff-f927473d3cafe422c5ebd1b4ac3667070f49100c00f35f5054faadf3433a6434L3762-R3756) [[7]](diffhunk://#diff-f927473d3cafe422c5ebd1b4ac3667070f49100c00f35f5054faadf3433a6434L3791-R3787) [[8]](diffhunk://#diff-f927473d3cafe422c5ebd1b4ac3667070f49100c00f35f5054faadf3433a6434L3814-R3807).

Other dependency updates:

* Updated `browserslist` from `4.24.0` to `4.24.2` (`apps/dolly-frontend/src/main/js/package-lock.json`).
* Updated `electron-to-chromium` from `1.5.41` to `1.5.42` (`apps/dolly-frontend/src/main/js/package-lock.json`).
* Updated `msw` from `2.4.11` to `2.4.13` (`apps/dolly-frontend/src/main/js/package-lock.json`).
* Updated `react-inlinesvg` from `4.1.3` to `4.1.4` (`apps/dolly-frontend/src/main/js/package-lock.json`).