### PR TITLE
test/cloud-profiler-agent

### DIFF
--- a/apps/budpro-service/Dockerfile
+++ b/apps/budpro-service/Dockerfile
@@ -5,6 +5,6 @@ COPY build/libs/app.jar /app/app.jar
 
 RUN wget -q https://storage.googleapis.com/cloud-profiler/java/latest/profiler_java_agent.tar.gz -P /app/agent && tar xzf /app/agent/profiler_java_agent.tar.gz -C /app/agent && rm /app/agent/profiler_java_agent.tar.gz
 
-ENV JAVA_OPTS="-Dspring.profiles.active=prod -agentpath:/app/agent/profiler_java_agent.so=-cprof_project_id=dolly-dev-ff83,-cprof_service=testnav-budpro-service,-cprof_enable_heap_sampling=true,-logtostderr,-minloglevel=0"
+ENV JAVA_OPTS="-Dspring.profiles.active=prod -agentpath:/app/agent/profiler_java_agent.so=-cprof_project_id=dolly-dev-ff83,-cprof_service=testnav-budpro-service,-cprof_enable_heap_sampling=true,-logtostderr,-minloglevel=1"
 
 EXPOSE 8080

--- a/apps/budpro-service/Dockerfile
+++ b/apps/budpro-service/Dockerfile
@@ -3,9 +3,8 @@ LABEL maintainer="Team Dolly"
 
 COPY build/libs/app.jar /app/app.jar
 
-RUN wget -q https://storage.googleapis.com/cloud-profiler/java/latest/profiler_java_agent.tar.gz -P /app/agent && \
-    tar xzf /app/agent/profiler_java_agent.tar.gz -C /app/agent
+RUN wget -q https://storage.googleapis.com/cloud-profiler/java/latest/profiler_java_agent.tar.gz -P /app/agent && tar xzf /app/agent/profiler_java_agent.tar.gz -C /app/agent
 
-ENV JAVA_OPTS="-Dspring.profiles.active=prod --agentpath:/app/agent/profiler_java_agent.so=-cprof_project_id=dolly-dev-ff83,-cprof_service=testnav-budpro-service,-cprof_enable_heap_sampling=true,-logtostderr,-minloglevel=0"
+ENV JAVA_OPTS="-Dspring.profiles.active=prod -agentpath:/app/agent/profiler_java_agent.so=-cprof_project_id=dolly-dev-ff83,-cprof_service=testnav-budpro-service,-cprof_enable_heap_sampling=true,-logtostderr,-minloglevel=0"
 
 EXPOSE 8080

--- a/apps/budpro-service/Dockerfile
+++ b/apps/budpro-service/Dockerfile
@@ -3,7 +3,7 @@ LABEL maintainer="Team Dolly"
 
 COPY build/libs/app.jar /app/app.jar
 
-RUN wget -q https://storage.googleapis.com/cloud-profiler/java/latest/profiler_java_agent.tar.gz -P /app/agent && tar xzf /app/agent/profiler_java_agent.tar.gz -C /app/agent
+RUN wget -q https://storage.googleapis.com/cloud-profiler/java/latest/profiler_java_agent.tar.gz -P /app/agent && tar xzf /app/agent/profiler_java_agent.tar.gz -C /app/agent && rm /app/agent/profiler_java_agent.tar.gz
 
 ENV JAVA_OPTS="-Dspring.profiles.active=prod -agentpath:/app/agent/profiler_java_agent.so=-cprof_project_id=dolly-dev-ff83,-cprof_service=testnav-budpro-service,-cprof_enable_heap_sampling=true,-logtostderr,-minloglevel=0"
 

--- a/apps/budpro-service/config.yml
+++ b/apps/budpro-service/config.yml
@@ -41,3 +41,9 @@ spec:
   replicas:
     min: 1
     max: 1
+  gcp:
+    permissions:
+      - resource:
+          apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+          kind: Project
+        role: roles/cloudprofiler.agent


### PR DESCRIPTION
Legger til profiler agent i Dockerfile og gir tillatelser i NAIS-manifest.

Foreløpig tenkt som et eksempel på hvordan vi evt. kan slå på profiling for flere applikasjoner, ved behov.

Burde kanskje brukt ADD i stedet for wget, men ADD ga masse trøbbel med rettigheter for tar. Kan være verdt å se på hvis man *virkelig* vil optimalisere Docker build.

Kan også vurdere å pipe .tar.gz (~6MB) til tar, beholdt den slik under testing (se ADD over).