### PR TITLE
Refactor ElasticTyper descriptions and add Type endpoint

### DIFF
--- a/apps/dolly-backend/README.md
+++ b/apps/dolly-backend/README.md
@@ -24,7 +24,7 @@ https://dolly-backend.intern.dev.nav.no/swagger-ui.html
 ## Kjør lokalt
 * Se [generell informasjon](../../docs/local_general.md).
 * Applikasjonen er avhengig av en database i GCP, se [egen dokumentasjon](../../docs/gcp_db.md).
-* Applikasjonen er avhengig av Elasticsearch:
+* Applikasjonen er avhengig av OpenSearch:
 ```aiexclude
 > docker run -p 9200:9200 -p 9600:9600 -e "discovery.type=single-node" -e "plugins.security.disabled=true" -e "OPENSEARCH_INITIAL_ADMIN_PASSWORD=YLAgOm}rz#o6#Aq" --name opensearch -d opensearchproject/opensearch:latest
 ```

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/pensjonforvalter/PensjonforvalterClient.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/pensjonforvalter/PensjonforvalterClient.java
@@ -553,7 +553,7 @@ public class PensjonforvalterClient implements ClientRegister {
                             var context = MappingContextUtils.getMappingContext();
                             context.setProperty(IDENT, ident);
                             var request = mapperFacade.map(pensjon, AfpOffentligRequest.class, context);
-                            return pensjonforvalterConsumer.lagreAfpOffentlig(request, miljoe);
+                            return pensjonforvalterConsumer.lagreAfpOffentlig(request, ident, miljoe);
                         }));
     }
 

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/pensjonforvalter/PensjonforvalterConsumer.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/pensjonforvalter/PensjonforvalterConsumer.java
@@ -193,10 +193,10 @@ public class PensjonforvalterConsumer implements ConsumerStatus {
     }
 
     @Timed(name = "providers", tags = {"operation", "pen_lagreAfpOffentlig"})
-    public Flux<PensjonforvalterResponse> lagreAfpOffentlig(AfpOffentligRequest afpOffentligRequest, String miljoe) {
+    public Flux<PensjonforvalterResponse> lagreAfpOffentlig(AfpOffentligRequest afpOffentligRequest, String ident, String miljoe) {
 
         return tokenService.exchange(serverProperties)
-                .flatMapMany(token -> new LagreAfpOffentligCommand(webClient, afpOffentligRequest, miljoe, token.getTokenValue()).call());
+                .flatMapMany(token -> new LagreAfpOffentligCommand(webClient, afpOffentligRequest, ident, miljoe, token.getTokenValue()).call());
     }
 
     @Timed(name = "providers", tags = {"operation", "pen_sletteAfpOffentlig"})

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/pensjonforvalter/command/LagreAfpOffentligCommand.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/pensjonforvalter/command/LagreAfpOffentligCommand.java
@@ -25,15 +25,11 @@ public class LagreAfpOffentligCommand implements Callable<Mono<PensjonforvalterR
 
     private final WebClient webClient;
     private final AfpOffentligRequest afpOffentligRequest;
+    private final String ident;
     private final String miljoe;
     private final String token;
 
     public Mono<PensjonforvalterResponse> call() {
-
-        var ident = afpOffentligRequest
-                .getMocksvar().stream()
-                .map(AfpOffentligRequest.AfpOffentligStub::getFnr)
-                .findFirst().orElse(null);
 
         var callId = generateCallId();
         log.info("Pensjon afp-offentlig {} {}, callId: {}", miljoe, afpOffentligRequest, callId);

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/elastic/ElasticTyper.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/elastic/ElasticTyper.java
@@ -5,9 +5,6 @@ import lombok.Getter;
 @Getter
 public enum ElasticTyper {
 
-    // Forklaring i parantes er det som vises i frontend
-    // For at alfabetisk rekkefølge skal beholdes setter dette føring på forkalringen
-
     AAREG("Arbeidsgiver/arbeidstaker-register (AAREG)"),
     ARBEIDSPLASSENCV("Arbeidsplassen CV"),
     ARENA_AAP("Arena AAP ytelse"),

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/elastic/ElasticTyper.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/elastic/ElasticTyper.java
@@ -1,36 +1,42 @@
 package no.nav.dolly.elastic;
 
+import lombok.Getter;
+
+@Getter
 public enum ElasticTyper {
 
-    AAREG("Arbeidsregister (AAREG)"),
-    INST("Institusjonsopphold (INST2)"),
-    KRRSTUB("Digital kontaktinformasjon (DKIF)"),
-    SIGRUN_LIGNET("Lignet skatteinntekt (Sigrunstub)"),
-    SIGRUN_PENSJONSGIVENDE("Pensjonsgivende inntekt (Sigrunstub)"),
+    // Forklaring i parantes er det som vises i frontend
+    // For at alfabetisk rekkefølge skal beholdes setter dette føring på forkalringen
+
+    AAREG("Arbeidsgiver/arbeidstaker-register (AAREG)"),
+    ARBEIDSPLASSENCV("Arbeidsplassen CV"),
     ARENA_AAP("Arena AAP ytelse"),
     ARENA_AAP115("Arena AAP115 rettighet"),
     ARENA_DAGP("Arena dagpenger"),
-    UDISTUB("Utlendingsdirektoratet (UDI)"),
-    INNTK("Inntektskomponenten (INNTK)"),
-    PEN_INNTEKT("Pensjonsopptjening (POPP)"),
-    PEN_TP("Tjenestepensjon (TP)"),
-    PEN_AP("Alderspensjon (AP)"),
-    PEN_UT("Uføretrygd (UT)"),
-    PEN_AFP_OFFENTLIG("AFP offentlig (PEN"),
-    PEN_PENSJONSAVTALE("Pensjonsavtaler (PEN)"),
-    INNTKMELD("Inntektsmelding (ALTINN/JOARK)"),
+    BANKKONTO("Bankkontoregister"),
+    BANKKONTO_NORGE("Bankkonto i Norge"),
+    BANKKONTO_UTLAND("Bankkonto i utlandet"),
     BRREGSTUB("Brønnøysundregistrene (BRREGSTUB)"),
     DOKARKIV("Dokumentarkiv (JOARK)"),
     FULLMAKT("Fullmakt (Representasjon)"),
+    HISTARK("Historisk arkiv (HISTARK)"),
+    INNTK("Inntektskomponenten/stub (INNTK)"),
+    INNTKMELD("Inntektsmelding (ALTINN/JOARK)"),
+    INST("Institusjonsopphold (INST2)"),
+    KRRSTUB("Kontakt- og reservasjonsregister-stub"),
     MEDL("Medlemskap (MEDL)"),
-    HISTARK("Saksmappearkiv (HISTARK)"),
-    SYKEMELDING("NAV sykemelding"),
+    PEN_AFP_OFFENTLIG("Pensjon - AFP offentlig"),
+    PEN_AP("Pensjon - Alderspensjon (AP)"),
+    PEN_INNTEKT("Pensjon - Pensjonsinntekt/opptjening"),
+    PEN_PENSJONSAVTALE("Pensjon - Pensjonsavtaler"),
+    PEN_TP("Pensjon - Tjenestepensjon (TP)"),
+    PEN_UT("Pensjon - Uføretrygd (UT)"),
+    SIGRUN_LIGNET("Sigrunstub - Lignet skatteinntekt"),
+    SIGRUN_PENSJONSGIVENDE("Sigrunstub - Pensjonsgivende inntekt"),
+    SKATTEKORT("Skattekort (SOKOS)"),
     SKJERMING("Skjermingsregisteret"),
-    BANKKONTO("Bankkontoregister"),
-    BANKKONTO_NORGE("Norsk bankkonto"),
-    BANKKONTO_UTLAND("Utenlandsk bankkonto"),
-    ARBEIDSPLASSENCV("Arbeidsplassen CV"),
-    SKATTEKORT("SOKOS"),
+    SYKEMELDING("Sykemelding"),
+    UDISTUB("Udistub - Utlendingsdirektoratet"),
     YRKESSKADE("Yrkesskade");
 
     private final String beskrivelse;

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/elastic/dto/Kategori.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/elastic/dto/Kategori.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class Type {
+public class Kategori {
 
     private String type;
     private String beskrivelse;

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/elastic/dto/Type.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/elastic/dto/Type.java
@@ -1,0 +1,16 @@
+package no.nav.dolly.elastic.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Type {
+
+    private String type;
+    private String beskrivelse;
+}

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/elastic/service/OpenSearchService.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/elastic/service/OpenSearchService.java
@@ -9,7 +9,7 @@ import no.nav.dolly.elastic.ElasticTyper;
 import no.nav.dolly.elastic.consumer.ElasticParamsConsumer;
 import no.nav.dolly.elastic.dto.SearchRequest;
 import no.nav.dolly.elastic.dto.SearchResponse;
-import no.nav.dolly.elastic.dto.Type;
+import no.nav.dolly.elastic.dto.Kategori;
 import org.opensearch.client.RequestOptions;
 import org.opensearch.client.RestHighLevelClient;
 import org.opensearch.index.query.BoolQueryBuilder;
@@ -63,14 +63,14 @@ public class OpenSearchService {
         return elasticParamsConsumer.deleteIndex();
     }
 
-    public List<Type> getTyper() {
+    public List<Kategori> getTyper() {
 
         return Stream.of(ElasticTyper.values())
-                .map(entry -> Type.builder()
+                .map(entry -> Kategori.builder()
                         .type(entry.name())
                         .beskrivelse(entry.getBeskrivelse())
                         .build())
-                .sorted(Comparator.comparing(Type::getBeskrivelse))
+                .sorted(Comparator.comparing(Kategori::getBeskrivelse))
                 .toList();
     }
 

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/elastic/service/OpenSearchService.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/elastic/service/OpenSearchService.java
@@ -9,6 +9,7 @@ import no.nav.dolly.elastic.ElasticTyper;
 import no.nav.dolly.elastic.consumer.ElasticParamsConsumer;
 import no.nav.dolly.elastic.dto.SearchRequest;
 import no.nav.dolly.elastic.dto.SearchResponse;
+import no.nav.dolly.elastic.dto.Type;
 import org.opensearch.client.RequestOptions;
 import org.opensearch.client.RestHighLevelClient;
 import org.opensearch.index.query.BoolQueryBuilder;
@@ -23,7 +24,10 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static java.util.Objects.nonNull;
 
@@ -59,6 +63,17 @@ public class OpenSearchService {
     public Mono<JsonNode> deleteIndex() {
 
         return elasticParamsConsumer.deleteIndex();
+    }
+
+    public List<Type> getTyper() {
+
+        return Stream.of(ElasticTyper.values())
+                .map(entry -> Type.builder()
+                        .type(entry.name())
+                        .beskrivelse(entry.getBeskrivelse())
+                        .build())
+                .sorted(Comparator.comparing(Type::getType))
+                .toList();
     }
 
     private SearchResponse execQuery(BoolQueryBuilder query) {

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/elastic/service/OpenSearchService.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/elastic/service/OpenSearchService.java
@@ -23,10 +23,8 @@ import reactor.core.publisher.Mono;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.util.Objects.nonNull;
@@ -72,7 +70,7 @@ public class OpenSearchService {
                         .type(entry.name())
                         .beskrivelse(entry.getBeskrivelse())
                         .build())
-                .sorted(Comparator.comparing(Type::getType))
+                .sorted(Comparator.comparing(Type::getBeskrivelse))
                 .toList();
     }
 

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/provider/api/OpensearchController.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/provider/api/OpensearchController.java
@@ -8,8 +8,10 @@ import no.nav.dolly.elastic.ElasticBestilling;
 import no.nav.dolly.elastic.ElasticTyper;
 import no.nav.dolly.elastic.dto.SearchRequest;
 import no.nav.dolly.elastic.dto.SearchResponse;
+import no.nav.dolly.elastic.dto.Type;
 import no.nav.dolly.elastic.service.OpenSearchService;
 import no.nav.dolly.exceptions.NotFoundException;
+import org.bouncycastle.util.Arrays;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -21,6 +23,9 @@ import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static java.lang.String.format;
 
@@ -37,6 +42,13 @@ public class OpensearchController {
     public List<ElasticBestilling> getAll(@PathVariable String ident) {
 
         return openSearchService.search(ident);
+    }
+
+    @GetMapping("/typer")
+    @Operation(description = "Henter alle typer som kan søkes på")
+    public List<Type> getKategorier() {
+
+        return openSearchService.getTyper();
     }
 
     @GetMapping("/identer")

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/provider/api/OpensearchController.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/provider/api/OpensearchController.java
@@ -8,10 +8,9 @@ import no.nav.dolly.elastic.ElasticBestilling;
 import no.nav.dolly.elastic.ElasticTyper;
 import no.nav.dolly.elastic.dto.SearchRequest;
 import no.nav.dolly.elastic.dto.SearchResponse;
-import no.nav.dolly.elastic.dto.Type;
+import no.nav.dolly.elastic.dto.Kategori;
 import no.nav.dolly.elastic.service.OpenSearchService;
 import no.nav.dolly.exceptions.NotFoundException;
-import org.bouncycastle.util.Arrays;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -23,9 +22,6 @@ import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static java.lang.String.format;
 
@@ -46,7 +42,7 @@ public class OpensearchController {
 
     @GetMapping("/typer")
     @Operation(description = "Henter alle typer som kan søkes på")
-    public List<Type> getKategorier() {
+    public List<Kategori> getKategorier() {
 
         return openSearchService.getTyper();
     }


### PR DESCRIPTION
#deploy-test-dolly-backend

Updated `ElasticTyper` with more intuitive descriptions and alphabetical order. Added a new `Type` class and corresponding `/typer` endpoint for fetching all searchable types. Improved indexing and mapping strategies in `ElasticBestillingStrategyMapping` and adjusted `PensjonforvalterConsumer` methods to pass `ident` parameter directly.