### PR TITLE
* Logger ut bruker ved feil under henting av bruker/org i dolly-idporten

### DIFF
--- a/apps/dolly-frontend/src/main/js/src/components/utlogging/logoutBruker.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/utlogging/logoutBruker.tsx
@@ -2,21 +2,7 @@ const logoutBruker = (feilmelding?: string) => {
 	const runningLocalOrIdporten =
 		window.location.hostname.includes('localhost') || window.location.hostname.includes('idporten')
 
-	const extractFeilmelding = (stackTrace: string) => {
-		if (stackTrace?.includes('miljoer')) {
-			return 'miljoe_error'
-		} else if (stackTrace?.includes('current')) {
-			return 'azure_error'
-		} else if (stackTrace?.includes('person_org')) {
-			return 'person_org_error'
-		} else {
-			return 'unknown_error'
-		}
-	}
-
-	window.location.href = runningLocalOrIdporten
-		? '/logout' + (feilmelding ? '?state=' + extractFeilmelding(feilmelding) : '')
-		: '/oauth2/logout'
+	window.location.href = runningLocalOrIdporten ? '/logout' : '/oauth2/logout'
 	console.error(feilmelding)
 }
 export default logoutBruker

--- a/apps/dolly-frontend/src/main/js/src/pages/brukerPage/BrukerModel.tsx
+++ b/apps/dolly-frontend/src/main/js/src/pages/brukerPage/BrukerModel.tsx
@@ -6,8 +6,8 @@ import { Bruker, Organisasjon, OrgResponse } from '@/pages/brukerPage/types'
 import { BrukerApi, PersonOrgTilgangApi, SessionApi } from '@/service/Api'
 import { NotFoundError } from '@/error'
 import { Navigate } from 'react-router-dom'
-import { navigateToLogin } from '@/components/utlogging/navigateToLogin'
 import { Logger } from '@/logger/Logger'
+import logoutBruker from '@/components/utlogging/logoutBruker'
 
 const ORG_ERROR = 'organisation_error'
 const UNKNOWN_ERROR = 'unknown_error'
@@ -28,7 +28,7 @@ export default () => {
 						message: 'Ukjent feil ved henting av organisasjoner for bankid bruker',
 						uuid: window.uuid,
 					})
-					navigateToLogin(UNKNOWN_ERROR)
+					logoutBruker(UNKNOWN_ERROR)
 				}
 				setOrganisasjoner(response.data)
 				setModalHeight(310 + 55 * response.data.length)
@@ -40,7 +40,7 @@ export default () => {
 					message: 'Fant ingen organisasjoner for bankid bruker',
 					uuid: window.uuid,
 				})
-				navigateToLogin(ORG_ERROR)
+				logoutBruker(ORG_ERROR)
 			})
 			.catch((e: Error) => {
 				Logger.error({
@@ -48,7 +48,7 @@ export default () => {
 					message: e.message,
 					uuid: window.uuid,
 				})
-				navigateToLogin(UNKNOWN_ERROR)
+				logoutBruker(UNKNOWN_ERROR)
 			})
 	}, [])
 
@@ -66,7 +66,7 @@ export default () => {
 						message: 'Ukjent feil ved henting av bankid bruker fra bruker-service',
 						uuid: window.uuid,
 					})
-					navigateToLogin(UNKNOWN_ERROR)
+					logoutBruker(UNKNOWN_ERROR)
 				}
 			})
 			.catch((_e: NotFoundError) => {
@@ -78,7 +78,7 @@ export default () => {
 					message: e.message,
 					uuid: window.uuid,
 				})
-				navigateToLogin(UNKNOWN_ERROR)
+				logoutBruker(UNKNOWN_ERROR)
 			})
 	}
 


### PR DESCRIPTION
This pull request includes changes to streamline error handling by replacing the `navigateToLogin` function with the `logoutBruker` function and simplifying the logout process.

Error handling improvements:

* [`apps/dolly-frontend/src/main/js/src/pages/brukerPage/BrukerModel.tsx`](diffhunk://#diff-469b306882c8805d3e5e670a7e00bd58bf26553dec918e7d7648e8c722cd129aL31-R31): Replaced multiple calls to `navigateToLogin` with `logoutBruker` for more consistent error handling. [[1]](diffhunk://#diff-469b306882c8805d3e5e670a7e00bd58bf26553dec918e7d7648e8c722cd129aL31-R31) [[2]](diffhunk://#diff-469b306882c8805d3e5e670a7e00bd58bf26553dec918e7d7648e8c722cd129aL43-R51) [[3]](diffhunk://#diff-469b306882c8805d3e5e670a7e00bd58bf26553dec918e7d7648e8c722cd129aL69-R69) [[4]](diffhunk://#diff-469b306882c8805d3e5e670a7e00bd58bf26553dec918e7d7648e8c722cd129aL81-R81)

Code simplification:

* [`apps/dolly-frontend/src/main/js/src/components/utlogging/logoutBruker.tsx`](diffhunk://#diff-94e1549216f52cd44d95f69bfc9ae6eb7eece147c17ebbc12ee3425a8cba57c6L5-R5): Removed the `extractFeilmelding` function and simplified the `window.location.href` assignment in the `logoutBruker` function.