### PR TITLE
Fix for frontend cookie haandtering

### DIFF
--- a/apps/dolly-frontend/src/main/js/src/api/index.ts
+++ b/apps/dolly-frontend/src/main/js/src/api/index.ts
@@ -130,8 +130,20 @@ export const cvFetcher = (url, headers) =>
 			throw new Error(`Henting av data fra ${url} feilet.`)
 		})
 
-export const fetcher = (url, headers) =>
-	axios
+const clearLargeCookies = () => {
+	const cookies = document.cookie.split(';')
+	cookies.forEach((cookie) => {
+		const [name, value] = cookie.split('=')
+		if (value && value.length > 1000) {
+			// Fjerner cookies som er over 1000 tegn
+			document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/`
+		}
+	})
+}
+
+export const fetcher = (url, headers) => {
+	clearLargeCookies()
+	return axios
 		.get(url, { headers: headers })
 		.then((res) => {
 			return res.data
@@ -152,11 +164,14 @@ export const fetcher = (url, headers) =>
 			}
 			throw new Error(`Henting av data fra ${url} feilet.`)
 		})
+}
 
-export const imageFetcher = (...args: Argument[]) =>
-	originalFetch(...args).then((res: Response) =>
+export const imageFetcher = (...args: Argument[]) => {
+	clearLargeCookies()
+	return originalFetch(...args).then((res: Response) =>
 		res.ok ? res.blob().then((blob: Blob) => URL.createObjectURL(blob)) : null,
 	)
+}
 
 type Method = 'POST' | 'GET' | 'PUT' | 'DELETE'
 
@@ -166,8 +181,9 @@ type Config = {
 	redirect?: 'follow' | 'manual'
 }
 
-const _fetch = (url: string, config: Config, body?: object): Promise<Response> =>
-	fetchRetry(url, {
+const _fetch = (url: string, config: Config, body?: object): Promise<Response> => {
+	clearLargeCookies()
+	return fetchRetry(url, {
 		retryOn: (attempt, error, response) => {
 			if (!response.ok && !runningE2ETest()) {
 				if (response?.status === 401 && !allowForbidden.some((value) => url.includes(value))) {
@@ -216,6 +232,7 @@ const _fetch = (url: string, config: Config, body?: object): Promise<Response> =
 		}
 		return response
 	})
+}
 
 const fetchJson = (url: string, config: Config, body?: object): Promise =>
 	_fetch(

--- a/apps/dolly-frontend/src/main/js/src/app/App.tsx
+++ b/apps/dolly-frontend/src/main/js/src/app/App.tsx
@@ -50,6 +50,14 @@ export const App = () => {
 		}
 	}, [criticalError])
 
+	useEffect(() => {
+		let arr = new Uint8Array(1100)
+		crypto.getRandomValues(arr)
+		for (let i = 0; i < 2; i++) {
+			document.cookie = 'testinggg' + i + '=' + arr.join('-') //SLETT MEG!
+		}
+	}, [])
+
 	if (loading || criticalError) {
 		return <Loading label="Laster Dolly" fullpage />
 	}

--- a/apps/dolly-frontend/src/main/js/src/app/App.tsx
+++ b/apps/dolly-frontend/src/main/js/src/app/App.tsx
@@ -50,14 +50,6 @@ export const App = () => {
 		}
 	}, [criticalError])
 
-	useEffect(() => {
-		let arr = new Uint8Array(1100)
-		crypto.getRandomValues(arr)
-		for (let i = 0; i < 2; i++) {
-			document.cookie = 'testinggg' + i + '=' + arr.join('-') //SLETT MEG!
-		}
-	}, [])
-
 	if (loading || criticalError) {
 		return <Loading label="Laster Dolly" fullpage />
 	}


### PR DESCRIPTION
This pull request introduces a new function to clear large cookies before making network requests and includes a temporary useEffect hook to create test cookies in the `App` component. The most important changes are as follows:

### Cookie Management Enhancements:
* Added a `clearLargeCookies` function to remove cookies larger than 1000 characters. This function is called before making requests in `fetcher`, `imageFetcher`, and `_fetch` functions in `apps/dolly-frontend/src/main/js/src/api/index.ts`. [[1]](diffhunk://#diff-5646f504929598c66db8abe597b5eb5b67bb1d83e3de6df6de24cfee3e4a3c22L133-R146) [[2]](diffhunk://#diff-5646f504929598c66db8abe597b5eb5b67bb1d83e3de6df6de24cfee3e4a3c22R167-R174) [[3]](diffhunk://#diff-5646f504929598c66db8abe597b5eb5b67bb1d83e3de6df6de24cfee3e4a3c22L169-R186) [[4]](diffhunk://#diff-5646f504929598c66db8abe597b5eb5b67bb1d83e3de6df6de24cfee3e4a3c22R235)

### Testing:
* Added a `useEffect` hook in the `App` component to create test cookies for debugging purposes. This is a temporary change and should be removed later.