### PR TITLE
Refaktorert datoaritmetikk for personstatus 

### DIFF
--- a/apps/pdl-forvalter/src/test/java/no/nav/pdl/forvalter/service/FolkeregisterPersonstatusServiceTest.java
+++ b/apps/pdl-forvalter/src/test/java/no/nav/pdl/forvalter/service/FolkeregisterPersonstatusServiceTest.java
@@ -1,5 +1,6 @@
 package no.nav.pdl.forvalter.service;
 
+import no.nav.testnav.libs.data.pdlforvalter.v1.AdressebeskyttelseDTO;
 import no.nav.testnav.libs.data.pdlforvalter.v1.BostedadresseDTO;
 import no.nav.testnav.libs.data.pdlforvalter.v1.DoedsfallDTO;
 import no.nav.testnav.libs.data.pdlforvalter.v1.FolkeregisterPersonstatusDTO;
@@ -27,11 +28,13 @@ import static no.nav.testnav.libs.data.pdlforvalter.v1.FolkeregisterPersonstatus
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 
 @ExtendWith(MockitoExtension.class)
 class FolkeregisterPersonstatusServiceTest {
 
     private static final String FNR_IDENT = "12044512345";
+    private static final LocalDateTime GYLDIG_FRA_OG_MED = LocalDateTime.of(1970, 1, 1, 0, 0);
 
     @InjectMocks
     private FolkeregisterPersonstatusService folkeregisterPersonstatusService;
@@ -173,5 +176,95 @@ class FolkeregisterPersonstatusServiceTest {
                         .build()).getFirst();
 
         assertThat(target.getStatus(), is(equalTo(FOEDSELSREGISTRERT)));
+    }
+
+    @Test
+    void whenFraDatoIsIdenticalOnTwoStatuses_FixIt() {
+
+        var target = folkeregisterPersonstatusService.convert(
+                PersonDTO.builder()
+                        .ident(FNR_IDENT)
+                        .adressebeskyttelse(List.of(AdressebeskyttelseDTO.builder()
+                                .isNew(true)
+                                .build()))
+                        .folkeregisterPersonstatus(
+                                List.of(FolkeregisterPersonstatusDTO.builder()
+                                                .status(FOEDSELSREGISTRERT)
+                                                .gyldigFraOgMed(GYLDIG_FRA_OG_MED)
+                                                .id(2)
+                                                .build(),
+                                        FolkeregisterPersonstatusDTO.builder()
+                                                .status(BOSATT)
+                                                .gyldigFraOgMed(GYLDIG_FRA_OG_MED)
+                                                .id(1)
+                                                .build()))
+                        .build());
+
+        assertThat(target.getFirst().getStatus(), is(equalTo(FOEDSELSREGISTRERT)));
+        assertThat(target.getFirst().getGyldigFraOgMed(), is(equalTo(GYLDIG_FRA_OG_MED.plusDays(2))));
+        assertThat(target.getFirst().getGyldigTilOgMed(), is((nullValue())));
+        assertThat(target.getLast().getStatus(), is(equalTo(BOSATT)));
+        assertThat(target.getLast().getGyldigFraOgMed(), is(equalTo(GYLDIG_FRA_OG_MED)));
+        assertThat(target.getLast().getGyldigTilOgMed(), is(equalTo(GYLDIG_FRA_OG_MED.plusDays(1))));
+    }
+
+    @Test
+    void whenFraDatoIsArrangedProperly_DoNothing() {
+
+        var target = folkeregisterPersonstatusService.convert(
+                PersonDTO.builder()
+                        .ident(FNR_IDENT)
+                        .adressebeskyttelse(List.of(AdressebeskyttelseDTO.builder()
+                                .isNew(true)
+                                .build()))
+                        .folkeregisterPersonstatus(
+                                List.of(FolkeregisterPersonstatusDTO.builder()
+                                                .status(FOEDSELSREGISTRERT)
+                                                .gyldigFraOgMed(GYLDIG_FRA_OG_MED.plusYears(10))
+                                                .id(2)
+                                                .build(),
+                                        FolkeregisterPersonstatusDTO.builder()
+                                                .status(BOSATT)
+                                                .gyldigFraOgMed(GYLDIG_FRA_OG_MED)
+                                                .id(1)
+                                                .build()))
+                        .build());
+
+        assertThat(target.getFirst().getStatus(), is(equalTo(FOEDSELSREGISTRERT)));
+        assertThat(target.getFirst().getGyldigFraOgMed(), is(equalTo(GYLDIG_FRA_OG_MED.plusYears(10))));
+        assertThat(target.getFirst().getGyldigTilOgMed(), is((nullValue())));
+        assertThat(target.getLast().getStatus(), is(equalTo(BOSATT)));
+        assertThat(target.getLast().getGyldigFraOgMed(), is(equalTo(GYLDIG_FRA_OG_MED)));
+        assertThat(target.getLast().getGyldigTilOgMed(), is(equalTo(GYLDIG_FRA_OG_MED.plusYears(10).minusDays(1))));
+    }
+
+    @Test
+    void whenFraDatoDiffersByOneDay_Fixit() {
+
+        var target = folkeregisterPersonstatusService.convert(
+                PersonDTO.builder()
+                        .ident(FNR_IDENT)
+                        .adressebeskyttelse(List.of(AdressebeskyttelseDTO.builder()
+                                .isNew(true)
+                                .build()))
+                        .folkeregisterPersonstatus(
+                                List.of(FolkeregisterPersonstatusDTO.builder()
+                                                .status(FOEDSELSREGISTRERT)
+                                                .gyldigFraOgMed(GYLDIG_FRA_OG_MED.plusDays(1))
+                                                .id(2)
+                                                .build(),
+                                        FolkeregisterPersonstatusDTO.builder()
+                                                .status(BOSATT)
+                                                .gyldigFraOgMed(GYLDIG_FRA_OG_MED)
+                                                .id(1)
+                                                .build()))
+                        .build());
+
+        assertThat(target.getFirst().getStatus(), is(equalTo(FOEDSELSREGISTRERT)));
+        assertThat(target.getFirst().getGyldigFraOgMed(), is(equalTo(GYLDIG_FRA_OG_MED.plusDays(2))));
+        assertThat(target.getFirst().getGyldigTilOgMed(), is((nullValue())));
+        assertThat(target.getLast().getStatus(), is(equalTo(BOSATT)));
+        assertThat(target.getLast().getGyldigFraOgMed(), is(equalTo(GYLDIG_FRA_OG_MED)));
+        assertThat(target.getLast().getGyldigTilOgMed(), is(equalTo(GYLDIG_FRA_OG_MED.plusDays(1))));
     }
 }


### PR DESCRIPTION
Refaktorert datoaritmetikk for personstatus 

Introduced unit tests to verify and fix scenarios where person status dates overlap or coincide. Refactored `setGyldigTilOgMed` method by splitting logic into `fixGyldigTilOgMed` and `fixGyldigFraOgMed` helper functions for clarity and maintainability.