### PR TITLE
Bugfix/auth header log fix

### DIFF
--- a/libs/reactive-core/src/main/java/no/nav/testnav/libs/reactivecore/logging/TestnavLogbackEncoder.java
+++ b/libs/reactive-core/src/main/java/no/nav/testnav/libs/reactivecore/logging/TestnavLogbackEncoder.java
@@ -120,7 +120,7 @@ public class TestnavLogbackEncoder extends LogstashEncoder {
             return match.group();
         });
 
-        message = bearer.matcher(message).replaceAll("REDACTED_AUTH_HEADER");
+        message = bearer.matcher(message).replaceAll("REDACTED_BEARER");
 
         return message;
     }

--- a/libs/reactive-core/src/main/java/no/nav/testnav/libs/reactivecore/logging/TestnavLogbackEncoder.java
+++ b/libs/reactive-core/src/main/java/no/nav/testnav/libs/reactivecore/logging/TestnavLogbackEncoder.java
@@ -33,8 +33,8 @@ import static org.springframework.util.StringUtils.truncate;
 public class TestnavLogbackEncoder extends LogstashEncoder {
 
     // matches exactly 11 digits (\\d{11}) that are not immediately preceded ((?<!\\d)) or followed ((?!\\d)) by another digit.
-    private final Pattern pattern = Pattern.compile("(?<!\\d)\\d{11}(?!\\d)");
-
+    private final Pattern identNummer = Pattern.compile("(?<!\\d)\\d{11}(?!\\d)");
+    private final Pattern bearer = Pattern.compile("Bearer [a-zA-Z0-9\\-_.]+");
     @Setter
     private int maxStackTraceLength = 480;
 
@@ -113,24 +113,15 @@ public class TestnavLogbackEncoder extends LogstashEncoder {
     }
 
     private String formatMessage(String message) {
-        var matcher = pattern.matcher(message);
-
-        if (!matcher.find()) {
-            return message;
-        }
-
-        matcher.reset();
-        var result = new StringBuilder();
-
-        while (matcher.find()) {
-            var match = matcher.group();
-            if (match.charAt(2) == '0' || match.charAt(2) == '1') {
-                var replacement = match.substring(0, 6) + "xxxxx";
-                matcher.appendReplacement(result, replacement);
+        message = identNummer.matcher(message).replaceAll(match -> {
+            if (match.group().charAt(2) == '0' || match.group().charAt(2) == '1') {
+                return match.group().substring(0, 6) + "xxxxx";
             }
-        }
-        matcher.appendTail(result);
+            return match.group();
+        });
 
-        return result.toString();
+        message = bearer.matcher(message).replaceAll("REDACTED_AUTH_HEADER");
+
+        return message;
     }
 }


### PR DESCRIPTION
This pull request includes changes to the `TestnavLogbackEncoder` class in the `reactive-core` library to improve the redaction of sensitive information in log messages. The most important changes include the addition of a new pattern to identify bearer tokens and the refactoring of the `formatMessage` method to use the new patterns for redaction.

Improvements to sensitive information redaction:

* [`libs/reactive-core/src/main/java/no/nav/testnav/libs/reactivecore/logging/TestnavLogbackEncoder.java`](diffhunk://#diff-747b490ea69acb6cf72cea075614abb8b6f49c1ca9f74096a5ac1a3015548338L36-R37): Added a new `Pattern` named `bearer` to identify bearer tokens.
* [`libs/reactive-core/src/main/java/no/nav/testnav/libs/reactivecore/logging/TestnavLogbackEncoder.java`](diffhunk://#diff-747b490ea69acb6cf72cea075614abb8b6f49c1ca9f74096a5ac1a3015548338L116-R125): Refactored the `formatMessage` method to use the `identNummer` pattern for redacting identification numbers and the `bearer` pattern for redacting bearer tokens.