### PR TITLE
Remove 'fullmakt' from GraphQL queries

### DIFF
--- a/apps/person-service/src/main/resources/pdl/pdlPerson2Query.graphql
+++ b/apps/person-service/src/main/resources/pdl/pdlPerson2Query.graphql
@@ -442,16 +442,6 @@ query($ident: ID!, $historikk: Boolean!) {
                 ...metadataDetails
             }
         },
-        fullmakt(historikk: $historikk) {
-            motpartsPersonident,
-            motpartsRolle,
-            omraader,
-            gyldigFraOgMed,
-            gyldigTilOgMed,
-            metadata {
-                ...metadataDetails
-            }
-        },
         folkeregisteridentifikator(historikk: $historikk) {
             identifikasjonsnummer,
             status,

--- a/apps/person-service/src/main/resources/pdl/pdlPersonQuery.graphql
+++ b/apps/person-service/src/main/resources/pdl/pdlPersonQuery.graphql
@@ -141,11 +141,6 @@ query($ident1: ID!) {
                 opplysningsId
             }
         }
-        fullmakt {
-            metadata {
-                opplysningsId
-            }
-        }
     },
     hentIdenter(ident: $ident1, historikk: true, grupper: [AKTORID, FOLKEREGISTERIDENT, NPID]) {
         identer {

--- a/apps/person-service/src/main/resources/pdl/pdlbolkquery.graphql
+++ b/apps/person-service/src/main/resources/pdl/pdlbolkquery.graphql
@@ -449,16 +449,6 @@ query($identer: [ID!]!) {
                     ...metadataDetails
                 }
             },
-            fullmakt(historikk: true) {
-                motpartsPersonident,
-                motpartsRolle,
-                omraader,
-                gyldigFraOgMed,
-                gyldigTilOgMed,
-                metadata {
-                    ...metadataDetails
-                }
-            },
             folkeregisteridentifikator(historikk: true) {
                 identifikasjonsnummer,
                 status,


### PR DESCRIPTION
Removed 'fullmakt' field from pdlbolkquery.graphql, pdlPerson2Query.graphql, and pdlPersonQuery.graphql. This exclusion simplifies the query structure and eliminates redundant data retrieval related to fullmakt details.