### PR TITLE
change/azure-app-client-deprecated

### DIFF
--- a/apps/endringsmelding-frontend/src/test/resources/application-test.yml
+++ b/apps/endringsmelding-frontend/src/test/resources/application-test.yml
@@ -3,3 +3,10 @@ spring:
     gcp:
       secretmanager:
         enabled: false
+  security:
+    oauth2:
+      client:
+        registration:
+          aad:
+            client-id: dummy
+            client-secret: dummy

--- a/apps/faste-data-frontend/src/test/resources/application-test.yml
+++ b/apps/faste-data-frontend/src/test/resources/application-test.yml
@@ -3,3 +3,10 @@ spring:
     gcp:
       secretmanager:
         enabled: false
+  security:
+    oauth2:
+      client:
+        registration:
+          aad:
+            client-id: dummy
+            client-secret: dummy

--- a/apps/testnorge-statisk-data-forvalter/src/test/resources/application-test.yml
+++ b/apps/testnorge-statisk-data-forvalter/src/test/resources/application-test.yml
@@ -61,7 +61,6 @@ aareg:
   pageSize: 2
 
 controller.staticdata.cache.hours: 24
-azure.app.client.id: dummy
 
 KAFKA_SCHEMA_REGISTRY: http://localhost:9009
 kafka.groupid: organisasjon-forvalter-v1

--- a/libs/security-core/src/main/java/no/nav/testnav/libs/securitycore/domain/azuread/AzureNavClientCredential.java
+++ b/libs/security-core/src/main/java/no/nav/testnav/libs/securitycore/domain/azuread/AzureNavClientCredential.java
@@ -7,9 +7,10 @@ import org.springframework.context.annotation.Configuration;
 public class AzureNavClientCredential extends ClientCredential {
 
     public AzureNavClientCredential(
-            @Value("${azure.app.client.id:#{null}}") String clientId,
-            @Value("${azure.app.client.secret:#{null}}") String clientSecret
+            @Value("${spring.security.oauth2.client.registration.aad.client-id:#{null}}") String clientId,
+            @Value("${spring.security.oauth2.client.registration.aad.client-secret:#{null}}") String clientSecret
     ) {
         super(clientId, clientSecret);
     }
+
 }

--- a/proxies/fullmakt-proxy/src/main/resources/application.yml
+++ b/proxies/fullmakt-proxy/src/main/resources/application.yml
@@ -10,7 +10,7 @@ spring:
         aad:
           issuer-uri: ${AAD_ISSUER_URI}/v2.0
           jwk-set-uri: ${AAD_ISSUER_URI}/discovery/v2.0/keys
-          accepted-audience: ${azure.app.client.id}, api://${azure.app.client.id}
+          accepted-audience: ${AZURE_APP_CLIENT_ID}, api://${AZURE_APP_CLIENT_ID}
         tokenx:
           issuer-uri: ${TOKEN_X_ISSUER}
           jwk-set-uri: ${TOKEN_X_JWKS_URI}

--- a/proxies/sykemelding-proxy/src/main/resources/application.yml
+++ b/proxies/sykemelding-proxy/src/main/resources/application.yml
@@ -10,7 +10,7 @@ spring:
         aad:
           issuer-uri: ${AAD_ISSUER_URI}/v2.0
           jwk-set-uri: ${AAD_ISSUER_URI}/discovery/v2.0/keys
-          accepted-audience: ${azure.app.client.id}, api://${azure.app.client.id}
+          accepted-audience: ${AZURE_APP_CLIENT_ID}, api://${AZURE_APP_CLIENT_ID}
         tokenx:
           issuer-uri: ${TOKEN_X_ISSUER}
           jwk-set-uri: ${TOKEN_X_JWKS_URI}

--- a/proxies/synthdata-meldekort-proxy/src/main/resources/application-dev.yml
+++ b/proxies/synthdata-meldekort-proxy/src/main/resources/application-dev.yml
@@ -6,16 +6,6 @@ spring:
   config:
     import: "sm://"
 
-azure:
-  nav:
-    app:
-      client:
-        id: ${sm://azure-app-client-id}
-        secret: ${sm://azure-app-client-secret}
-  openid:
-    config:
-      issuer: https://login.microsoftonline.com/62366534-1ec3-4962-8869-9b5535279d0b
-
 consumers:
   synt-meldekort:
     url: https://synthdata-arena-meldekort.intern.dev.nav.no

--- a/proxies/synthdata-meldekort-proxy/src/main/resources/application.yml
+++ b/proxies/synthdata-meldekort-proxy/src/main/resources/application.yml
@@ -1,13 +1,12 @@
 spring:
   application:
     name: testnav-synthdata-meldekort-proxy
-    desciption: Proxy for synthdata-arena-meldekort som legger på sikkerhet.
   security:
     oauth2:
       resourceserver:
         trygdeetaten:
-          issuer-uri: ${azure.openid.config.issuer}
-          jwk-set-uri: ${azure.openid.config.jwks.uri}
+          issuer-uri: ${AZURE_OPENID_CONFIG_ISSUER}
+          jwk-set-uri: ${AZURE_OPENID_CONFIG_JWKS_URI}
           accepted-audience:  ${AZURE_APP_CLIENT_ID}, api:// ${AZURE_APP_CLIENT_ID}
   codec:
     max-in-memory-size: 15MB

--- a/proxies/synthdata-meldekort-proxy/src/test/resources/application-test.yml
+++ b/proxies/synthdata-meldekort-proxy/src/test/resources/application-test.yml
@@ -1,4 +1,6 @@
-azure:
-  openid:
-    config:
-      issuer: dummy
+spring:
+  security:
+    oauth2:
+      resourceserver:
+        trygdeetaten:
+          issuer-uri: # Intentionally left blank.


### PR DESCRIPTION
Endrer fra å bruke gamle `azure.app.client.[id|secret]` til de samme verdiene som allikevel settes i ordinær Spring config.

Følger opp med å se litt på om `AzureNavClientCredential` kan forenkles eller ikke.