### PR TITLE
disable SSO for ID-porten

### DIFF
--- a/.nais/idporten.yml
+++ b/.nais/idporten.yml
@@ -15,3 +15,4 @@ spec:
     - https://dolly.ekstern.dev.nav.no/login/oauth2/code/idporten
     - https://dolly-idporten.ekstern.dev.nav.no/login/oauth2/code/idporten
   secretName: idporten-dolly-prod # deployes til prod. secret kopieres manuelt til dev.
+  ssoDisabled: true


### PR DESCRIPTION
Dolly shouldn't be a part of the SSO circle-of-trust with many other public services.

See https://docs.digdir.no/docs/idporten/oidc/oidc_func_nosso.html.