### PR TITLE
feature/noop-userinfo

### DIFF
--- a/apps/dolly-frontend/src/main/resources/application-local.yml
+++ b/apps/dolly-frontend/src/main/resources/application-local.yml
@@ -22,9 +22,7 @@ spring:
             client-secret: ${AZURE_APP_CLIENT_SECRET}
         provider:
           aad:
-            authorization-uri: ${AAD_ISSUER_URI}/oauth2/v2.0/authorize
-            token-uri: ${AAD_ISSUER_URI}/oauth2/v2.0/token
-            jwk-set-uri: ${AAD_ISSUER_URI}/discovery/v2.0/keys
+            issuer-uri: ${sm\://azure-openid-config-issuer}
 
 consumers:
   testnav-altinn3-tilgang-service:

--- a/apps/endringsmelding-frontend/src/main/java/no/nav/testnav/apps/endringsmeldingfrontend/EndringsmeldingFrontendApplicationStarter.java
+++ b/apps/endringsmelding-frontend/src/main/java/no/nav/testnav/apps/endringsmeldingfrontend/EndringsmeldingFrontendApplicationStarter.java
@@ -19,6 +19,7 @@ import org.springframework.cloud.gateway.route.builder.PredicateSpec;
 import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
 
 import java.util.function.Function;
 
@@ -28,6 +29,7 @@ import java.util.function.Function;
         FrontendConfig.class
 })
 @SpringBootApplication
+@EnableWebFluxSecurity
 @RequiredArgsConstructor
 public class EndringsmeldingFrontendApplicationStarter {
 

--- a/apps/endringsmelding-frontend/src/main/java/no/nav/testnav/apps/endringsmeldingfrontend/config/SecurityConfig.java
+++ b/apps/endringsmelding-frontend/src/main/java/no/nav/testnav/apps/endringsmeldingfrontend/config/SecurityConfig.java
@@ -2,24 +2,29 @@ package no.nav.testnav.apps.endringsmeldingfrontend.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
 import org.springframework.security.config.web.server.ServerHttpSecurity;
 import org.springframework.security.web.server.SecurityWebFilterChain;
 
+import static org.springframework.security.config.Customizer.withDefaults;
 
 @Configuration
-@EnableWebFluxSecurity
-public class SecurityConfig {
+class SecurityConfig {
 
     @Bean
-    public SecurityWebFilterChain springSecurityFilterChain(ServerHttpSecurity http) {
-        return http.cors(ServerHttpSecurity.CorsSpec::disable)
+    SecurityWebFilterChain springSecurityFilterChain(ServerHttpSecurity http) {
+        return http
+                .cors(ServerHttpSecurity.CorsSpec::disable)
                 .csrf(ServerHttpSecurity.CsrfSpec::disable)
-                .authorizeExchange(authorizeExchangeSpec -> authorizeExchangeSpec
-                        .pathMatchers("/internal/isReady", "/internal/isAlive", "/internal/metrics").permitAll()
-                        .anyExchange().authenticated())
-                .oauth2Login(oAuth2LoginSpec -> {
-                })
+                .authorizeExchange(spec -> spec
+                        .pathMatchers(
+                                "/internal/isReady",
+                                "/internal/isAlive",
+                                "/internal/metrics")
+                        .permitAll()
+                        .anyExchange()
+                        .authenticated())
+                .oauth2Login(withDefaults())
                 .build();
     }
+
 }

--- a/apps/endringsmelding-frontend/src/main/resources/application.yml
+++ b/apps/endringsmelding-frontend/src/main/resources/application.yml
@@ -18,9 +18,7 @@ spring:
             scope: openid,  ${AZURE_APP_CLIENT_ID}/.default
         provider:
           aad:
-            authorization-uri: ${AAD_ISSUER_URI}/oauth2/v2.0/authorize
-            token-uri: ${AAD_ISSUER_URI}/oauth2/v2.0/token
-            jwk-set-uri: ${AAD_ISSUER_URI}/discovery/v2.0/keys
+            issuer-uri: ${AZURE_OPENID_CONFIG_ISSUER}
 
 consumers:
   endringsmelding-service:

--- a/apps/faste-data-frontend/src/main/resources/application.yml
+++ b/apps/faste-data-frontend/src/main/resources/application.yml
@@ -21,9 +21,7 @@ spring:
             scope: openid,  ${AZURE_APP_CLIENT_ID}/.default
         provider:
           aad:
-            authorization-uri: ${AAD_ISSUER_URI}/oauth2/v2.0/authorize
-            token-uri: ${AAD_ISSUER_URI}/oauth2/v2.0/token
-            jwk-set-uri: ${AAD_ISSUER_URI}/discovery/v2.0/keys
+            issuer-uri: ${AZURE_OPENID_CONFIG_ISSUER}
 
 consumers:
   testnorge-profil-api:

--- a/libs/security-core/src/main/java/no/nav/testnav/libs/securitycore/oauth2/client/userinfo/NoopOidcReactiveOAuth2UserService.java
+++ b/libs/security-core/src/main/java/no/nav/testnav/libs/securitycore/oauth2/client/userinfo/NoopOidcReactiveOAuth2UserService.java
@@ -1,0 +1,55 @@
+package no.nav.testnav.libs.securitycore.oauth2.client.userinfo;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcReactiveOAuth2UserService;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.oidc.OidcUserInfo;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.security.oauth2.core.oidc.user.OidcUserAuthority;
+import org.springframework.util.StringUtils;
+import reactor.core.publisher.Mono;
+
+import java.util.LinkedHashSet;
+
+import static lombok.AccessLevel.PACKAGE;
+
+@RequiredArgsConstructor(access = PACKAGE)
+class NoopOidcReactiveOAuth2UserService extends OidcReactiveOAuth2UserService {
+
+    /**
+     * Stripped from {@code org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequestUtils#getUser(OidcUserRequest, OidcUserInfo)}.
+     *
+     * @param userRequest OIDC user request.
+     * @return OIDC user.
+     */
+    private static OidcUser getUser(OidcUserRequest userRequest) {
+
+        var authorities = new LinkedHashSet<GrantedAuthority>();
+        authorities.add(new OidcUserAuthority(userRequest.getIdToken(), null));
+        userRequest
+                .getAccessToken()
+                .getScopes()
+                .forEach(scope -> authorities.add(new SimpleGrantedAuthority("SCOPE_" + scope)));
+        var providerDetails = userRequest
+                .getClientRegistration()
+                .getProviderDetails();
+        var userNameAttributeName = providerDetails
+                .getUserInfoEndpoint()
+                .getUserNameAttributeName();
+        if (StringUtils.hasText(userNameAttributeName)) {
+            return new DefaultOidcUser(authorities, userRequest.getIdToken(), null, userNameAttributeName);
+        }
+        return new DefaultOidcUser(authorities, userRequest.getIdToken(), (OidcUserInfo) null);
+
+    }
+
+    @Override
+    public Mono<OidcUser> loadUser(OidcUserRequest userRequest) throws OAuth2AuthenticationException {
+        return Mono.just(getUser(userRequest));
+    }
+
+}

--- a/libs/security-core/src/main/java/no/nav/testnav/libs/securitycore/oauth2/client/userinfo/NoopOidcReactiveOAuth2UserService.java
+++ b/libs/security-core/src/main/java/no/nav/testnav/libs/securitycore/oauth2/client/userinfo/NoopOidcReactiveOAuth2UserService.java
@@ -1,6 +1,5 @@
 package no.nav.testnav.libs.securitycore.oauth2.client.userinfo;
 
-import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcReactiveOAuth2UserService;
@@ -15,9 +14,6 @@ import reactor.core.publisher.Mono;
 
 import java.util.LinkedHashSet;
 
-import static lombok.AccessLevel.PACKAGE;
-
-@RequiredArgsConstructor(access = PACKAGE)
 class NoopOidcReactiveOAuth2UserService extends OidcReactiveOAuth2UserService {
 
     /**

--- a/libs/security-core/src/main/java/no/nav/testnav/libs/securitycore/oauth2/client/userinfo/NoopReactiveClientRegistrationRepository.java
+++ b/libs/security-core/src/main/java/no/nav/testnav/libs/securitycore/oauth2/client/userinfo/NoopReactiveClientRegistrationRepository.java
@@ -1,0 +1,14 @@
+package no.nav.testnav.libs.securitycore.oauth2.client.userinfo;
+
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ReactiveClientRegistrationRepository;
+import reactor.core.publisher.Mono;
+
+class NoopReactiveClientRegistrationRepository implements ReactiveClientRegistrationRepository {
+
+    @Override
+    public Mono<ClientRegistration> findByRegistrationId(String registrationId) {
+        return Mono.empty();
+    }
+
+}

--- a/libs/security-core/src/main/java/no/nav/testnav/libs/securitycore/oauth2/client/userinfo/NoopReactiveOAuth2UserService.java
+++ b/libs/security-core/src/main/java/no/nav/testnav/libs/securitycore/oauth2/client/userinfo/NoopReactiveOAuth2UserService.java
@@ -1,15 +1,11 @@
 package no.nav.testnav.libs.securitycore.oauth2.client.userinfo;
 
-import lombok.RequiredArgsConstructor;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.client.userinfo.ReactiveOAuth2UserService;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import reactor.core.publisher.Mono;
 
-import static lombok.AccessLevel.PACKAGE;
-
-@RequiredArgsConstructor(access = PACKAGE)
 class NoopReactiveOAuth2UserService implements ReactiveOAuth2UserService<OAuth2UserRequest, OAuth2User> {
 
     @Override

--- a/libs/security-core/src/main/java/no/nav/testnav/libs/securitycore/oauth2/client/userinfo/NoopReactiveOAuth2UserService.java
+++ b/libs/security-core/src/main/java/no/nav/testnav/libs/securitycore/oauth2/client/userinfo/NoopReactiveOAuth2UserService.java
@@ -1,0 +1,20 @@
+package no.nav.testnav.libs.securitycore.oauth2.client.userinfo;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.ReactiveOAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import reactor.core.publisher.Mono;
+
+import static lombok.AccessLevel.PACKAGE;
+
+@RequiredArgsConstructor(access = PACKAGE)
+class NoopReactiveOAuth2UserService implements ReactiveOAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+    @Override
+    public Mono<OAuth2User> loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        return Mono.empty();
+    }
+
+}

--- a/libs/security-core/src/main/java/no/nav/testnav/libs/securitycore/oauth2/client/userinfo/NoopReactiveOauth2AutoConfiguration.java
+++ b/libs/security-core/src/main/java/no/nav/testnav/libs/securitycore/oauth2/client/userinfo/NoopReactiveOauth2AutoConfiguration.java
@@ -2,7 +2,9 @@ package no.nav.testnav.libs.securitycore.oauth2.client.userinfo;
 
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcReactiveOAuth2UserService;
+import org.springframework.security.oauth2.client.registration.ReactiveClientRegistrationRepository;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.client.userinfo.ReactiveOAuth2UserService;
 import org.springframework.security.oauth2.core.user.OAuth2User;
@@ -18,6 +20,19 @@ public class NoopReactiveOauth2AutoConfiguration {
     @Bean
     public OidcReactiveOAuth2UserService oidcReactiveOAuth2UserService() {
         return new NoopOidcReactiveOAuth2UserService();
+    }
+
+    /**
+     * When testing, just use an empty repository so we don't trigger the full behaviour of
+     * {@code InMemoryReactiveClientRegistrationRepository} - which is not needed for tests.
+     * @return An instance of {@code NoopReactiveClientRegistrationRepository}.
+     * @see org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository
+     * @see no.nav.testnav.libs.securitycore.oauth2.client.userinfo.NoopReactiveClientRegistrationRepository
+     */
+    @Bean
+    @Profile("test")
+    ReactiveClientRegistrationRepository reactiveClientRegistrationRepositoryForTesting() {
+        return new NoopReactiveClientRegistrationRepository();
     }
 
 }

--- a/libs/security-core/src/main/java/no/nav/testnav/libs/securitycore/oauth2/client/userinfo/NoopReactiveOauth2AutoConfiguration.java
+++ b/libs/security-core/src/main/java/no/nav/testnav/libs/securitycore/oauth2/client/userinfo/NoopReactiveOauth2AutoConfiguration.java
@@ -13,12 +13,12 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 public class NoopReactiveOauth2AutoConfiguration {
 
     @Bean
-    public ReactiveOAuth2UserService<OAuth2UserRequest, OAuth2User> reactiveOAuth2UserService() {
+    ReactiveOAuth2UserService<OAuth2UserRequest, OAuth2User> reactiveOAuth2UserService() {
         return new NoopReactiveOAuth2UserService();
     }
 
     @Bean
-    public OidcReactiveOAuth2UserService oidcReactiveOAuth2UserService() {
+    OidcReactiveOAuth2UserService oidcReactiveOAuth2UserService() {
         return new NoopOidcReactiveOAuth2UserService();
     }
 

--- a/libs/security-core/src/main/java/no/nav/testnav/libs/securitycore/oauth2/client/userinfo/NoopReactiveOauth2AutoConfiguration.java
+++ b/libs/security-core/src/main/java/no/nav/testnav/libs/securitycore/oauth2/client/userinfo/NoopReactiveOauth2AutoConfiguration.java
@@ -1,0 +1,23 @@
+package no.nav.testnav.libs.securitycore.oauth2.client.userinfo;
+
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcReactiveOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.ReactiveOAuth2UserService;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+@AutoConfiguration
+public class NoopReactiveOauth2AutoConfiguration {
+
+    @Bean
+    public ReactiveOAuth2UserService<OAuth2UserRequest, OAuth2User> reactiveOAuth2UserService() {
+        return new NoopReactiveOAuth2UserService();
+    }
+
+    @Bean
+    public OidcReactiveOAuth2UserService oidcReactiveOAuth2UserService() {
+        return new NoopOidcReactiveOAuth2UserService();
+    }
+
+}

--- a/libs/security-core/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/libs/security-core/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,1 +1,2 @@
 no.nav.testnav.libs.securitycore.domain.azuread.ClientCredentialAutoConfiguration
+no.nav.testnav.libs.securitycore.oauth2.client.userinfo.NoopReactiveOauth2AutoConfiguration


### PR DESCRIPTION
Forenkler konfigurasjon av typen `spring.security.oauth2.client.provider.*` ved å basere seg på kun `issuer-uri`. Dette gjøres ved å legge til et autokonfigurert ikke-oppslag av userinfo, som a) er ikke-standard fra Microsoft, og b) ikke behøves, da vi har info i token allerede.

Ref. tråd i [Slack](https://nav-it.slack.com/archives/C5KUST8N6/p1734694606570669).