### PR TITLE
Removes deprecated identity_provider and project_id from docker-build-push.

### DIFF
--- a/.github/workflows/common.workflow.backend.yml
+++ b/.github/workflows/common.workflow.backend.yml
@@ -108,8 +108,6 @@ jobs:
         uses: nais/docker-build-push@v0
         with:
           team: dolly
-          identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
-          project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
           docker_context: ${{ inputs.working-directory }}
           image_suffix: ${{ inputs.image-suffix }}
     outputs:

--- a/.github/workflows/common.workflow.frontend.yml
+++ b/.github/workflows/common.workflow.frontend.yml
@@ -145,8 +145,6 @@ jobs:
         uses: nais/docker-build-push@v0
         with:
           team: dolly
-          identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
-          project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
           docker_context: ${{ inputs.working-directory }}
           image_suffix: ${{ inputs.image-suffix }}
     outputs:


### PR DESCRIPTION
Mindre endringer, ref. https://nav-it.slack.com/archives/C01DE3M9YBV/p1737982464376109.