### PR TITLE
Bugfix/brreg stub

### DIFF
--- a/apps/brreg-stub/build.gradle
+++ b/apps/brreg-stub/build.gradle
@@ -55,8 +55,9 @@ dependencies {
     implementation "no.nav.common:cxf:3.2023.10.17_06.55-4e30d96bba05"
 
     implementation "com.sun.xml.ws:jaxws-rt:$versions.jaxws"
+    implementation "jakarta.jws:jakarta.jws-api:3.0.0"
+
     testImplementation "org.testcontainers:junit-jupiter"
     testImplementation "org.testcontainers:postgresql"
-    implementation "jakarta.jws:jakarta.jws-api:3.0.0"
     testImplementation "org.springframework.cloud:spring-cloud-contract-wiremock"
 }

--- a/apps/brreg-stub/build.gradle
+++ b/apps/brreg-stub/build.gradle
@@ -18,7 +18,10 @@ wsimport {
 }
 
 dependencies {
-    implementation("io.dropwizard:dropwizard-jackson:4.0.7") {
+
+    runtimeOnly 'org.jetbrains.kotlin:kotlin-reflect:2.1.10'
+
+    implementation("io.dropwizard:dropwizard-jackson:4.0.12") {
         exclude group: "com.google.code.findbugs"
     }
 

--- a/apps/brreg-stub/src/main/java/no/nav/brregstub/config/OpenApiConfig.java
+++ b/apps/brreg-stub/src/main/java/no/nav/brregstub/config/OpenApiConfig.java
@@ -14,13 +14,12 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import java.util.Arrays;
 
-import no.nav.testnav.libs.servletcore.config.ApplicationProperties;
-
 @Configuration
 public class OpenApiConfig implements WebMvcConfigurer {
 
     @Bean
-    public OpenAPI openApi(ApplicationProperties applicationProperties) {
+    public OpenAPI openApi() {
+
         return new OpenAPI()
                 .components(new Components().addSecuritySchemes("bearer-jwt", new SecurityScheme()
                         .type(SecurityScheme.Type.HTTP)
@@ -32,9 +31,9 @@ public class OpenApiConfig implements WebMvcConfigurer {
                 .addSecurityItem(
                         new SecurityRequirement().addList("bearer-jwt", Arrays.asList("read", "write")))
                 .info(new Info()
-                        .title(applicationProperties.getName())
-                        .version(applicationProperties.getVersion())
-                        .description(applicationProperties.getDescription())
+                        .title("Adresse Service API")
+                        .version("Versjon 1")
+                        .description("Adresseservice har operasjoner for uthenting av tilfeldige adresser fra PDL.")
                         .termsOfService("https://nav.no")
                         .contact(new Contact()
                                 .url("https://nav-it.slack.com/archives/CA3P9NGA2")
@@ -44,8 +43,7 @@ public class OpenApiConfig implements WebMvcConfigurer {
                         .license(new License()
                                 .name("MIT License")
                                 .url("https://opensource.org/licenses/MIT")
-                        )
-                );
+                        ));
     }
 
     @Override

--- a/apps/brreg-stub/src/main/java/no/nav/brregstub/config/OpenApiConfig.java
+++ b/apps/brreg-stub/src/main/java/no/nav/brregstub/config/OpenApiConfig.java
@@ -31,9 +31,9 @@ public class OpenApiConfig implements WebMvcConfigurer {
                 .addSecurityItem(
                         new SecurityRequirement().addList("bearer-jwt", Arrays.asList("read", "write")))
                 .info(new Info()
-                        .title("Adresse Service API")
+                        .title("Brreg-stub API")
                         .version("Versjon 1")
-                        .description("Adresseservice har operasjoner for uthenting av tilfeldige adresser fra PDL.")
+                        .description("Brreg-stub har operasjoner for testdata av brønnøysundregisteret.")
                         .termsOfService("https://nav.no")
                         .contact(new Contact()
                                 .url("https://nav-it.slack.com/archives/CA3P9NGA2")

--- a/apps/brreg-stub/src/main/resources/application.yml
+++ b/apps/brreg-stub/src/main/resources/application.yml
@@ -9,16 +9,17 @@ springdoc:
 
 management:
   endpoints:
-    enabled-by-default: true
     web:
       base-path: /internal
       exposure:
         include: prometheus,health
       path-mapping:
         prometheus: metrics
+    access:
+      default: read_only
   endpoint:
     prometheus:
-      enabled: true
+      access: read_only
   prometheus:
     metrics:
       export:


### PR DESCRIPTION
This pull request includes changes to the `apps/brreg-stub` project to update dependencies, remove unused properties, and improve the OpenAPI configuration. The most important changes include updating dependencies in the `build.gradle` file, modifying the OpenAPI configuration to remove the use of `ApplicationProperties`, and adjusting the `application.yml` file for better management endpoint access control.

Dependency Updates:
* [`apps/brreg-stub/build.gradle`](diffhunk://#diff-6ee325a73655486464ce6ed7ed6d6afe4a9c8d4980169407d408a2a8535d95b8L21-R24): Added `runtimeOnly` dependency for `kotlin-reflect` and updated `dropwizard-jackson` to version 4.0.12.
* [`apps/brreg-stub/build.gradle`](diffhunk://#diff-6ee325a73655486464ce6ed7ed6d6afe4a9c8d4980169407d408a2a8535d95b8R61-L60): Added `jakarta.jws-api` implementation dependency.

OpenAPI Configuration:
* [`apps/brreg-stub/src/main/java/no/nav/brregstub/config/OpenApiConfig.java`](diffhunk://#diff-6a067e669363fe65e8062fe995f4dcb871dfeda3980d6ad84477171328dc16b1L17-R22): Removed `ApplicationProperties` from the `openApi` method and updated the API title, version, and description. [[1]](diffhunk://#diff-6a067e669363fe65e8062fe995f4dcb871dfeda3980d6ad84477171328dc16b1L17-R22) [[2]](diffhunk://#diff-6a067e669363fe65e8062fe995f4dcb871dfeda3980d6ad84477171328dc16b1L35-R36) [[3]](diffhunk://#diff-6a067e669363fe65e8062fe995f4dcb871dfeda3980d6ad84477171328dc16b1L47-R46)

Configuration Adjustments:
* [`apps/brreg-stub/src/main/resources/application.yml`](diffhunk://#diff-2a529c97ae50ea49f2f8d476a4253690e9924e1be91759a70dfac99c57c43206L12-R22): Adjusted management endpoint access control to set default access to read-only.