### PR TITLE
Fix: Add null check for sivilstand before setting opphoerstidspunkt i…

### DIFF
--- a/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/service/MetadataTidspunkterService.java
+++ b/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/service/MetadataTidspunkterService.java
@@ -260,7 +260,9 @@ public class MetadataTidspunkterService {
                 .findFirst()
                 .orElse(null);
 
-        person.getSivilstand().getFirst().getFolkeregistermetadata().setOpphoerstidspunkt(doedsdato);
+        if (!person.getSivilstand().isEmpty()) {
+            person.getSivilstand().getFirst().getFolkeregistermetadata().setOpphoerstidspunkt(doedsdato);
+        }
     }
 
     private static void fixStatsborgerskap(StatsborgerskapDTO statsborgerskapDTO) {


### PR DESCRIPTION
This pull request includes a small change to the `MetadataTidspunkterService.java` file. The change adds a check to ensure that the `sivilstand` list is not empty before attempting to set the `opphoerstidspunkt` on the first item in the list.

* [`apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/service/MetadataTidspunkterService.java`](diffhunk://#diff-b99c99abe520efd27e8f120dfecc35cbedc81ac6ae5bcf0ed9f56cb46cf9ab3dR263-R266): Added a check to ensure `sivilstand` list is not empty before setting `opphoerstidspunkt` on the first item.…n MetadataTidspunkterService