### PR TITLE
Refactor: Rename hentKodeverk method and add fallback logic for kodev…

### DIFF
--- a/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/consumer/KodeverkConsumer.java
+++ b/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/consumer/KodeverkConsumer.java
@@ -71,11 +71,17 @@ public class KodeverkConsumer {
                 .block();
     }
 
-    private Mono<Map<String, String>> hentKodeverk(String kodeverk) {
+    private Mono<Map<String, String>> hentKodeverkInner(String kodeverk) {
 
         return tokenExchange
                 .exchange(serverProperties)
                 .flatMap(token -> new KodeverkCommand(webClient, kodeverk, token.getTokenValue()).call())
                 .map(KodeverkDTO::getKodeverk);
+    }
+
+    private Mono<Map<String, String>> hentKodeverk(String kodeverk) {
+
+        return hentKodeverkInner(kodeverk)
+                .switchIfEmpty(hentKodeverkInner(kodeverk));
     }
 }

--- a/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/consumer/command/KodeverkCommand.java
+++ b/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/consumer/command/KodeverkCommand.java
@@ -40,6 +40,6 @@ public class KodeverkCommand implements Callable<Mono<KodeverkDTO>> {
                 .doFinally(value -> log.info("Kodeverk {} hentet", kodeverknavn))
                 .retryWhen(Retry.backoff(3, Duration.ofSeconds(5))
                         .filter(WebClientFilter::is5xxException))
-                .cache(Duration.ofHours(8));
+                .cache(Duration.ofMinutes(30));
     }
 }


### PR DESCRIPTION
This pull request includes changes to the `KodeverkConsumer` and `KodeverkCommand` classes in the `apps/pdl-forvalter` module. The changes aim to improve the reliability and performance of the code.

Improvements to reliability:

* [`apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/consumer/KodeverkConsumer.java`](diffhunk://#diff-d62e1cd33636968e312f820298414709777259f2f44416074c19b7a376c035ecL74-R86): Added a new method `hentKodeverkInner` to encapsulate the existing logic and updated the `hentKodeverk` method to call `hentKodeverkInner` with a fallback mechanism using `switchIfEmpty`.

Performance improvements:

* [`apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/consumer/command/KodeverkCommand.java`](diffhunk://#diff-3d7ca53365b8f7a277527b944cddb8671c1c5ca1d2116e19553a462331deec31L43-R43): Reduced the cache duration for the `call` method from 8 hours to 30 minutes to ensure fresher data.…erk retrieval