### PR TITLE
Refactored default localhost test data initialization as a Flyway (minor) migration, to avoid a chicken-and-egg situation on starting a clean DB.

### DIFF
--- a/apps/levende-arbeidsforhold-ansettelse/src/main/resources/application-local.yml
+++ b/apps/levende-arbeidsforhold-ansettelse/src/main/resources/application-local.yml
@@ -9,14 +9,11 @@ spring:
     url: jdbc:postgresql://localhost:5432/testnav-levende-arbeidsforhold
     user: postgres
     password:
+    locations: classpath:db/migration,classpath:db/local
   r2dbc:
     url: r2dbc:postgresql://localhost:5432/testnav-levende-arbeidsforhold
     username: postgres
     password:
-  sql:
-    init:
-      mode: always
-      data-locations: classpath:/db/local/default-config.sql
 
 consumers:
   testnav-kodeverk-service:

--- a/apps/levende-arbeidsforhold-ansettelse/src/main/resources/db/local/V1.0.1__AddLocalTestData.sql
+++ b/apps/levende-arbeidsforhold-ansettelse/src/main/resources/db/local/V1.0.1__AddLocalTestData.sql
@@ -1,0 +1,5 @@
+INSERT INTO jobb_parameter(navn, tekst, verdi, verdier) VALUES ('stillingsprosent','Stillingsprosent','80','20,30,40,50,60,70,80,90,100');
+INSERT INTO jobb_parameter(navn, tekst, verdi, verdier) VALUES ('intervall','Intervall for neste kjøring (timer)','1','1,5,12,24,168');
+INSERT INTO jobb_parameter(navn, tekst, verdi, verdier) VALUES ('antallOrganisasjoner','Antall Organisasjoner','1','1,5,10,15,20,25,30,35,40,45,50');
+INSERT INTO jobb_parameter(navn, tekst, verdi, verdier) VALUES ('antallPersoner','Antall Personer','1','1,10,15,20,25,30,35,40,45,50,1001');
+INSERT INTO jobb_parameter(navn, tekst, verdi, verdier) VALUES ('arbeidsforholdType','Arbeidsforhold Type','ordinaertArbeidsforhold','forenkletOppgjoersordning,frilanserOppdragstakerHonorarPersonerMm,maritimtArbeidsforhold,ordinaertArbeidsforhold');

--- a/apps/levende-arbeidsforhold-ansettelse/src/main/resources/db/local/default-config.sql
+++ b/apps/levende-arbeidsforhold-ansettelse/src/main/resources/db/local/default-config.sql
@@ -1,9 +1,0 @@
--- Default verdier for kjøring med H2
-
-insert into jobb_parameter(navn, tekst, verdi, verdier) values('stillingsprosent','Stillingsprosent','80','20,30,40,50,60,70,80,90,100');
-insert into jobb_parameter(navn, tekst, verdi, verdier) values('intervall','Intervall for neste kjøring (timer)','1','1,5,12,24,168');
-insert into jobb_parameter(navn, tekst, verdi, verdier) values('antallOrganisasjoner','Antall Organisasjoner','1','1,5,10,15,20,25,30,35,40,45,50');
-insert into jobb_parameter(navn, tekst, verdi, verdier) values('antallPersoner','Antall Personer','1','1,10,15,20,25,30,35,40,45,50,1001');
-insert into jobb_parameter(navn, tekst, verdi, verdier) values('arbeidsforholdType','Arbeidsforhold Type','ordinaertArbeidsforhold','forenkletOppgjoersordning,frilanserOppdragstakerHonorarPersonerMm,maritimtArbeidsforhold,ordinaertArbeidsforhold');
-
-commit;


### PR DESCRIPTION
Fikser oppstart lokalt med tom DB, ref. `docker-compose.yml`.