### PR TITLE
Pensjon nytt endepunkt for AP søknad + sletting av POPP-inntekt

### DIFF
--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/pensjonforvalter/PensjonforvalterClient.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/pensjonforvalter/PensjonforvalterClient.java
@@ -96,11 +96,12 @@ public class PensjonforvalterClient implements ClientRegister {
     @Override
     public void release(List<String> identer) {
 
-        // Pensjonforvalter / POPP, AP, UT støtter pt ikke sletting
+        // Pensjonforvalter AP, UT støtter pt ikke sletting
 
         pensjonforvalterConsumer.sletteTpForhold(identer);
         pensjonforvalterConsumer.slettePensjonsavtale(identer);
         pensjonforvalterConsumer.sletteAfpOffentlig(identer);
+        pensjonforvalterConsumer.slettePoppinntekt(identer);
     }
 
     private String prepInitStatus(Set<String> miljoer) {

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/pensjonforvalter/PensjonforvalterConsumer.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/pensjonforvalter/PensjonforvalterConsumer.java
@@ -1,6 +1,7 @@
 package no.nav.dolly.bestilling.pensjonforvalter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sun.jna.Function;
 import lombok.extern.slf4j.Slf4j;
 import no.nav.dolly.bestilling.ConsumerStatus;
 import no.nav.dolly.bestilling.pensjonforvalter.command.AnnullerSamboerCommand;
@@ -19,6 +20,7 @@ import no.nav.dolly.bestilling.pensjonforvalter.command.OpprettPersonCommand;
 import no.nav.dolly.bestilling.pensjonforvalter.command.PensjonHentVedtakCommand;
 import no.nav.dolly.bestilling.pensjonforvalter.command.SletteAfpOffentligCommand;
 import no.nav.dolly.bestilling.pensjonforvalter.command.SlettePensjonsavtaleCommand;
+import no.nav.dolly.bestilling.pensjonforvalter.command.SlettePoppInntektCommand;
 import no.nav.dolly.bestilling.pensjonforvalter.command.SletteTpForholdCommand;
 import no.nav.dolly.bestilling.pensjonforvalter.domain.AfpOffentligRequest;
 import no.nav.dolly.bestilling.pensjonforvalter.domain.AlderspensjonRequest;
@@ -69,14 +71,14 @@ public class PensjonforvalterConsumer implements ConsumerStatus {
                 .build();
     }
 
-    @Timed(name = "providers", tags = { "operation", "pen_getMiljoer" })
+    @Timed(name = "providers", tags = {"operation", "pen_getMiljoer"})
     public Mono<Set<String>> getMiljoer() {
 
         return tokenService.exchange(serverProperties)
                 .flatMap(token -> new HentMiljoerCommand(webClient, token.getTokenValue()).call());
     }
 
-    @Timed(name = "providers", tags = { "operation", "popp_lagreInntekt" })
+    @Timed(name = "providers", tags = {"operation", "popp_lagreInntekt"})
     public Flux<PensjonforvalterResponse> lagreInntekter(PensjonPoppInntektRequest pensjonPoppInntektRequest) {
 
         return tokenService.exchange(serverProperties)
@@ -84,7 +86,7 @@ public class PensjonforvalterConsumer implements ConsumerStatus {
                         pensjonPoppInntektRequest).call());
     }
 
-    @Timed(name = "providers", tags = { "operation", "popp_lagreGenerertInntekt" })
+    @Timed(name = "providers", tags = {"operation", "popp_lagreGenerertInntekt"})
     public Flux<PensjonforvalterResponse> lagreGenererteInntekter(PensjonPoppGenerertInntektRequest pensjonPoppGenerertInntektRequest) {
 
         return tokenService.exchange(serverProperties)
@@ -92,7 +94,7 @@ public class PensjonforvalterConsumer implements ConsumerStatus {
                         pensjonPoppGenerertInntektRequest).call());
     }
 
-    @Timed(name = "providers", tags = { "operation", "pen_opprettPerson" })
+    @Timed(name = "providers", tags = {"operation", "pen_opprettPerson"})
     public Flux<PensjonforvalterResponse> opprettPerson(PensjonPersonRequest pensjonPersonRequest,
                                                         Set<String> miljoer) {
 
@@ -102,7 +104,7 @@ public class PensjonforvalterConsumer implements ConsumerStatus {
                 .doOnNext(response -> log.info("Opprettet person for {}: {}", pensjonPersonRequest.getFnr(), response));
     }
 
-    @Timed(name = "providers", tags = { "operation", "pen_hentSamboer" })
+    @Timed(name = "providers", tags = {"operation", "pen_hentSamboer"})
     public Flux<PensjonSamboerResponse> hentSamboer(String ident, String miljoe) {
 
         return tokenService.exchange(serverProperties)
@@ -110,7 +112,7 @@ public class PensjonforvalterConsumer implements ConsumerStatus {
                 .doOnNext(response -> log.info("Pensjon samboer for {} i {} hentet {}", ident, miljoe, response));
     }
 
-    @Timed(name = "providers", tags = { "operation", "pen_opprettSamboer" })
+    @Timed(name = "providers", tags = {"operation", "pen_opprettSamboer"})
     public Flux<PensjonforvalterResponse> lagreSamboer(PensjonSamboerRequest pensjonSamboerRequest,
                                                        String miljoe) {
         log.info("Oppretter samboerskap i pensjon: {}", pensjonSamboerRequest);
@@ -119,14 +121,14 @@ public class PensjonforvalterConsumer implements ConsumerStatus {
                 .flatMapMany(token -> new LagreSamboerCommand(webClient, pensjonSamboerRequest, miljoe, token.getTokenValue()).call());
     }
 
-    @Timed(name = "providers", tags = { "operation", "pen_opprettSamboer" })
+    @Timed(name = "providers", tags = {"operation", "pen_opprettSamboer"})
     public Flux<PensjonforvalterResponse> annullerSamboer(String periodeId, String miljoe) {
 
         return tokenService.exchange(serverProperties)
                 .flatMapMany(token -> new AnnullerSamboerCommand(webClient, periodeId, miljoe, token.getTokenValue()).call());
     }
 
-    @Timed(name = "providers", tags = { "operation", "pen_lagreAlderspensjon" })
+    @Timed(name = "providers", tags = {"operation", "pen_lagreAlderspensjon"})
     public Flux<PensjonforvalterResponse> lagreAlderspensjon(AlderspensjonRequest request) {
 
         return tokenService.exchange(serverProperties)
@@ -134,21 +136,21 @@ public class PensjonforvalterConsumer implements ConsumerStatus {
                         new LagreAlderspensjonCommand(webClient, token.getTokenValue(), request).call());
     }
 
-    @Timed(name = "providers", tags = { "operation", "pen_lagreUforetrygd" })
+    @Timed(name = "providers", tags = {"operation", "pen_lagreUforetrygd"})
     public Flux<PensjonforvalterResponse> lagreUforetrygd(PensjonUforetrygdRequest request) {
 
         return tokenService.exchange(serverProperties)
                 .flatMapMany(token -> new LagreUforetrygdCommand(webClient, token.getTokenValue(), request).call());
     }
 
-    @Timed(name = "providers", tags = { "operation", "pen_lagreTpForhold" })
+    @Timed(name = "providers", tags = {"operation", "pen_lagreTpForhold"})
     public Flux<PensjonforvalterResponse> lagreTpForhold(PensjonTpForholdRequest pensjonTpForholdRequest) {
 
         return tokenService.exchange(serverProperties)
                 .flatMapMany(token -> new LagreTpForholdCommand(webClient, token.getTokenValue(), pensjonTpForholdRequest).call());
     }
 
-    @Timed(name = "providers", tags = { "operation", "pen_sletteTpForhold" })
+    @Timed(name = "providers", tags = {"operation", "pen_sletteTpForhold"})
     public void sletteTpForhold(List<String> identer) {
 
         tokenService.exchange(serverProperties)
@@ -160,21 +162,21 @@ public class PensjonforvalterConsumer implements ConsumerStatus {
                 .subscribe(response -> log.info("Slettet mot PESYS (tp) i alle miljoer"));
     }
 
-    @Timed(name = "providers", tags = { "operation", "pen_lagreTpYtelse" })
+    @Timed(name = "providers", tags = {"operation", "pen_lagreTpYtelse"})
     public Flux<PensjonforvalterResponse> lagreTpYtelse(PensjonTpYtelseRequest pensjonTpYtelseRequest) {
 
         return tokenService.exchange(serverProperties)
                 .flatMapMany(token -> new LagreTpYtelseCommand(webClient, token.getTokenValue(), pensjonTpYtelseRequest).call());
     }
 
-    @Timed(name = "providers", tags = { "operation", "pen_lagrePensjpnsavtale" })
+    @Timed(name = "providers", tags = {"operation", "pen_lagrePensjpnsavtale"})
     public Flux<PensjonforvalterResponse> lagrePensjonsavtale(PensjonsavtaleRequest pensjonsavtaleRequest) {
 
         return tokenService.exchange(serverProperties)
                 .flatMapMany(token -> new LagrePensjonsavtaleCommand(webClient, pensjonsavtaleRequest, token.getTokenValue()).call());
     }
 
-    @Timed(name = "providers", tags = { "operation", "pen_slettePensjpnsavtale" })
+    @Timed(name = "providers", tags = {"operation", "pen_slettePensjpnsavtale"})
     public void slettePensjonsavtale(List<String> identer) {
 
         tokenService.exchange(serverProperties)
@@ -184,7 +186,18 @@ public class PensjonforvalterConsumer implements ConsumerStatus {
                 .subscribe(resultat -> log.info("Slettet pensjonsavtaler (PEN), alle miljøer"));
     }
 
-    @Timed(name = "providers", tags = { "operation", "pen_hentVedtak" })
+    @Timed(name = "providers", tags = {"operation", "pen_slettePoppinntekt"})
+    public void slettePoppinntekt(List<String> identer) {
+
+        tokenService.exchange(serverProperties)
+                .flatMap(token -> Flux.from(new HentMiljoerCommand(webClient, token.getTokenValue()).call())
+                        .flatMap(miljoer -> Flux.fromIterable(identer)
+                                .flatMap(ident -> new SlettePoppInntektCommand(webClient, ident, miljoer, token.getTokenValue()).call()))
+                        .collectList())
+                .subscribe(resultat -> log.info("Slettet POPP-inntekt, alle miljøer"));
+    }
+
+    @Timed(name = "providers", tags = {"operation", "pen_hentVedtak"})
     public Flux<PensjonVedtakResponse> hentVedtak(String ident, String miljoe) {
 
         return tokenService.exchange(serverProperties)
@@ -193,14 +206,14 @@ public class PensjonforvalterConsumer implements ConsumerStatus {
                         ident, miljoe, response));
     }
 
-    @Timed(name = "providers", tags = { "operation", "pen_lagreAfpOffentlig" })
+    @Timed(name = "providers", tags = {"operation", "pen_lagreAfpOffentlig"})
     public Flux<PensjonforvalterResponse> lagreAfpOffentlig(AfpOffentligRequest afpOffentligRequest, String ident, String miljoe) {
 
         return tokenService.exchange(serverProperties)
                 .flatMapMany(token -> new LagreAfpOffentligCommand(webClient, afpOffentligRequest, ident, miljoe, token.getTokenValue()).call());
     }
 
-    @Timed(name = "providers", tags = { "operation", "pen_sletteAfpOffentlig" })
+    @Timed(name = "providers", tags = {"operation", "pen_sletteAfpOffentlig"})
     public void sletteAfpOffentlig(List<String> identer) {
 
         tokenService.exchange(serverProperties)

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/pensjonforvalter/command/LagreAlderspensjonCommand.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/pensjonforvalter/command/LagreAlderspensjonCommand.java
@@ -27,7 +27,7 @@ import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 public class LagreAlderspensjonCommand implements Callable<Flux<PensjonforvalterResponse>> {
 
     private static final String PENSJON_AP_VEDTAK_URL = "/api/v4/vedtak/ap";
-    private static final String PENSJON_AP_SOKNAD_URL = "/api/v3/vedtak/ap/soknad";
+    private static final String PENSJON_AP_SOKNAD_URL = "/api/v4/vedtak/ap/soknad";
 
     private final WebClient webClient;
 

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/pensjonforvalter/command/SlettePoppInntektCommand.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/pensjonforvalter/command/SlettePoppInntektCommand.java
@@ -1,0 +1,52 @@
+package no.nav.dolly.bestilling.pensjonforvalter.command;
+
+import lombok.RequiredArgsConstructor;
+import no.nav.dolly.bestilling.pensjonforvalter.domain.PensjonforvalterResponse;
+import no.nav.testnav.libs.reactivecore.utils.WebClientFilter;
+import no.nav.testnav.libs.securitycore.config.UserConstant;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Callable;
+
+import static no.nav.dolly.domain.CommonKeysAndUtils.CONSUMER;
+import static no.nav.dolly.domain.CommonKeysAndUtils.HEADER_NAV_CALL_ID;
+import static no.nav.dolly.domain.CommonKeysAndUtils.HEADER_NAV_CONSUMER_ID;
+import static no.nav.dolly.util.CallIdUtil.generateCallId;
+import static no.nav.dolly.util.TokenXUtil.getUserJwt;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+@RequiredArgsConstructor
+public class SlettePoppInntektCommand implements Callable<Flux<PensjonforvalterResponse>> {
+
+    private static final String POPP_DELETE_URL = "/api/v1/popp/person";
+
+    private final WebClient webClient;
+    private final String ident;
+    private final Set<String> miljoer;
+    private final String token;
+
+    public Flux<PensjonforvalterResponse> call() {
+
+        return webClient
+                .delete()
+                .uri(uriBuilder -> uriBuilder
+                        .path(POPP_DELETE_URL)
+                        .queryParam("miljoer", miljoer)
+                        .build())
+                .header("pid", ident)
+                .header(AUTHORIZATION, "Bearer " + token)
+                .header(UserConstant.USER_HEADER_JWT, getUserJwt())
+                .header(HEADER_NAV_CALL_ID, generateCallId())
+                .header(HEADER_NAV_CONSUMER_ID, CONSUMER)
+                .retrieve()
+                .bodyToFlux(PensjonforvalterResponse.class)
+                .doOnError(WebClientFilter::logErrorMessage)
+                .onErrorResume(Exception.class, error -> Mono.empty());
+    }
+}


### PR DESCRIPTION
This pull request includes several changes to the `pensjonforvalter` module in the `dolly-backend` application, mainly focusing on adding support for deleting POPP income data and updating existing endpoints.

### Key changes:

#### Addition of POPP income deletion support:
* Added a new method `slettePoppinntekt` in `PensjonforvalterConsumer` to handle the deletion of POPP income data.
* Introduced a new command class `SlettePoppInntektCommand` to execute the deletion of POPP income data.
* Updated the `release` method in `PensjonforvalterClient` to include the deletion of POPP income data.

#### Dependency and endpoint updates:
* Added `com.sun.jna.Function` import in `PensjonforvalterConsumer`.
* Updated the endpoint URL for saving alderspensjon applications in `LagreAlderspensjonCommand`.…-test-dolly-backend