### PR TITLE
Bugfix/manglende pensjonforvalter

### DIFF
--- a/apps/dolly-frontend/src/main/js/src/components/bestillingsveileder/stegVelger/steg/steg2/Steg2.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/bestillingsveileder/stegVelger/steg/steg2/Steg2.tsx
@@ -12,16 +12,19 @@ import { PensjonForm } from '@/components/fagsystem/pensjon/form/Form'
 import { MedlForm } from '@/components/fagsystem/medl/form/MedlForm'
 import { SykdomForm } from '@/components/fagsystem/sykdom/form/Form'
 import { OrganisasjonForm } from '@/components/fagsystem/organisasjoner/form/Form'
-import { TjenestepensjonForm } from '@/components/fagsystem/tjenestepensjon/form/Form'
-import { AlderspensjonForm } from '@/components/fagsystem/alderspensjon/form/Form'
+import { TjenestepensjonForm, tpPath } from '@/components/fagsystem/tjenestepensjon/form/Form'
+import {
+	AlderspensjonForm,
+	alderspensjonPath,
+} from '@/components/fagsystem/alderspensjon/form/Form'
 import { ArbeidsplassenForm } from '@/components/fagsystem/arbeidsplassen/form/Form'
-import { UforetrygdForm } from '@/components/fagsystem/uforetrygd/form/Form'
+import { UforetrygdForm, uforetrygdPath } from '@/components/fagsystem/uforetrygd/form/Form'
 import { SigrunstubPensjonsgivendeForm } from '@/components/fagsystem/sigrunstubPensjonsgivende/form/Form'
 import { KrrstubForm } from '@/components/fagsystem/krrstub/form/KrrForm'
 import { SkattekortForm } from '@/components/fagsystem/skattekort/form/Form'
-import { PensjonsavtaleForm } from '@/components/fagsystem/pensjonsavtale/form/Form'
+import { avtalePath, PensjonsavtaleForm } from '@/components/fagsystem/pensjonsavtale/form/Form'
 import { FullmaktForm } from '@/components/fagsystem/fullmakt/form/FullmaktForm'
-import { AfpOffentligForm } from '@/components/fagsystem/afpOffentlig/form/Form'
+import { AfpOffentligForm, afpOffentligPath } from '@/components/fagsystem/afpOffentlig/form/Form'
 import { YrkesskaderForm } from '@/components/fagsystem/yrkesskader/form/Form'
 import Loading from '@/components/ui/loading/Loading'
 import { PdlfForm } from '@/components/fagsystem/pdlf/form/Form'
@@ -80,11 +83,11 @@ const Steg2: React.FC = () => {
 			{getValues('arbeidssoekerregisteret') && <ArbeidssoekerregisteretForm />}
 			{getValues('arbeidsplassenCV') && <ArbeidsplassenForm />}
 			{getValues('pensjonforvalter') && <PensjonForm />}
-			{getValues('pensjonsavtale') && <PensjonsavtaleForm />}
-			{getValues('tjenestepensjon') && <TjenestepensjonForm />}
-			{getValues('alderspensjon') && <AlderspensjonForm />}
-			{getValues('uforetrygd') && <UforetrygdForm />}
-			{getValues('afpOffentlig') && <AfpOffentligForm />}
+			{getValues(avtalePath) && <PensjonsavtaleForm />}
+			{getValues(tpPath) && <TjenestepensjonForm />}
+			{getValues(alderspensjonPath) && <AlderspensjonForm />}
+			{getValues(uforetrygdPath) && <UforetrygdForm />}
+			{getValues(afpOffentligPath) && <AfpOffentligForm />}
 			{getValues('arenaforvalter') && <ArenaForm />}
 			{getValues('sykemelding') && <SykdomForm />}
 			{getValues('yrkesskader') && <YrkesskaderForm />}

--- a/apps/dolly-frontend/src/main/js/src/components/ui/button/Tags/TagsButton.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/ui/button/Tags/TagsButton.tsx
@@ -58,9 +58,9 @@ export const TagsButton = ({ gruppeId, eksisterendeTags, isSending }: Props) => 
 						<DollySelect
 							name={'tags'}
 							options={tagOptions}
-							// options={tagOptions}
 							isMulti
-							value={tags?.map((t) => ({ value: t, label: t }))}
+							value={tags}
+							size={'large'}
 							onChange={(selected: any) => {
 								setTags(selected.map((s: any) => s.value))
 							}}


### PR DESCRIPTION
This pull request includes several changes to the `apps/dolly-frontend/src/main/js/src/components` directory, focusing on improving the import structure and updating the usage of path constants in the `Steg2` component. Additionally, there is a minor update to the `TagsButton` component.

### Import structure improvements:

* [`apps/dolly-frontend/src/main/js/src/components/bestillingsveileder/stegVelger/steg/steg2/Steg2.tsx`](diffhunk://#diff-1464a345f5624d30305c4046cbdd6c82f437427e74b36340019e90dd097d56faL15-R27): Updated imports to include path constants for `TjenestepensjonForm`, `AlderspensjonForm`, `UforetrygdForm`, `PensjonsavtaleForm`, and `AfpOffentligForm`.

### Path constants usage:

* [`apps/dolly-frontend/src/main/js/src/components/bestillingsveileder/stegVelger/steg/steg2/Steg2.tsx`](diffhunk://#diff-1464a345f5624d30305c4046cbdd6c82f437427e74b36340019e90dd097d56faL83-R90): Replaced hard-coded string values with path constants for `PensjonsavtaleForm`, `TjenestepensjonForm`, `AlderspensjonForm`, `UforetrygdForm`, and `AfpOffentligForm` in the `Steg2` component.

### Minor component update:

* [`apps/dolly-frontend/src/main/js/src/components/ui/button/Tags/TagsButton.tsx`](diffhunk://#diff-b272bd9ac3b92976c3c82318395f0a1dc630755ba8f753cf3f6b65ad9e042b65L61-R63): Simplified the `value` prop and added a `size` prop to the `DollySelect` component.