### PR TITLE
Viser form values i "prod" dersom man er dollyAdmin

### DIFF
--- a/apps/dolly-frontend/src/main/js/src/components/bestillingsveileder/stegVelger/StegVelger.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/bestillingsveileder/stegVelger/StegVelger.tsx
@@ -30,6 +30,7 @@ import Steg0 from './steg/steg0/Steg0'
 import Steg1 from './steg/steg1/Steg1'
 import Steg2 from './steg/steg2/Steg2'
 import Steg3 from './steg/steg3/Steg3'
+import { erDollyAdmin } from '@/utils/DollyAdmin'
 
 Steg0.label = 'Velg gruppe/mal'
 Steg1.label = 'Velg egenskaper'
@@ -161,7 +162,7 @@ export const StegVelger = ({ initialValues, onSubmit }) => {
 				<Suspense fallback={<Loading label="Laster komponenter" />}>
 					<CurrentStepComponent stateModifier={stateModifier} loadingBestilling={loading} />
 				</Suspense>
-				{devEnabled && (
+				{(devEnabled || erDollyAdmin()) && (
 					<Suspense fallback={<Loading label="Laster komponenter" />}>
 						<DisplayFormState />
 						<DisplayFormErrors errors={formMethods.formState.errors} label={'Vis errors'} />

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/visning/visningRedigerbar/VisningRedigerbar.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/visning/visningRedigerbar/VisningRedigerbar.tsx
@@ -43,6 +43,7 @@ import { FoedselsdatoForm } from '@/components/fagsystem/pdlf/form/partials/foed
 import { devEnabled } from '@/components/bestillingsveileder/stegVelger/StegVelger'
 import { PersonstatusForm } from '@/components/fagsystem/pdlf/form/partials/personstatus/Personstatus'
 import Loading from '@/components/ui/loading/Loading'
+import { erDollyAdmin } from '@/utils/DollyAdmin'
 
 type VisningTypes = {
 	getPdlForvalter: Function
@@ -401,7 +402,7 @@ export const VisningRedigerbar = ({
 				{visningModus === Modus.Skriv && (
 					<Form onSubmit={(data) => handleSubmit(data)}>
 						<>
-							{devEnabled && (
+							{(devEnabled || erDollyAdmin()) && (
 								<>
 									<Suspense fallback={<Loading label="Laster komponenter" />}>
 										<DisplayFormState />

--- a/apps/dolly-frontend/src/main/js/src/pages/organisasjoner/OrganisasjonTenorSoek/SoekFormOrg.tsx
+++ b/apps/dolly-frontend/src/main/js/src/pages/organisasjoner/OrganisasjonTenorSoek/SoekFormOrg.tsx
@@ -12,6 +12,7 @@ import { SamletReskontroinnsyn } from '@/pages/organisasjoner/OrganisasjonTenorS
 import { Tjenestepensjonsavtale } from '@/pages/organisasjoner/OrganisasjonTenorSoek/soekFormPartials/Tjenestepensjonsavtale'
 import { TestComponentSelectors } from '#/mocks/Selectors'
 import Loading from '@/components/ui/loading/Loading'
+import { erDollyAdmin } from '@/utils/DollyAdmin'
 
 const SoekefeltWrapper = styled.div`
 	display: flex;
@@ -209,7 +210,7 @@ export const SoekFormOrg = ({ setRequest, mutate }: any) => {
 								</Accordion.Item>
 							</Accordion>
 						</Form>
-						{devEnabled && (
+						{(devEnabled || erDollyAdmin()) && (
 							<Suspense fallback={<Loading label="Laster komponenter" />}>
 								<DisplayFormState />
 							</Suspense>

--- a/apps/dolly-frontend/src/main/js/src/pages/tenorSoek/SoekForm.tsx
+++ b/apps/dolly-frontend/src/main/js/src/pages/tenorSoek/SoekForm.tsx
@@ -16,6 +16,7 @@ import { Tjenestepensjonsavtale } from '@/pages/tenorSoek/soekFormPartials/Tjene
 import { Skattemelding } from '@/pages/tenorSoek/soekFormPartials/Skattemelding'
 import { InntektAordningen } from '@/pages/tenorSoek/soekFormPartials/InntektAordningen'
 import DisplayFormState from '@/utils/DisplayFormState'
+import { erDollyAdmin } from '@/utils/DollyAdmin'
 
 const SoekefeltWrapper = styled.div`
 	display: flex;
@@ -290,7 +291,7 @@ export const SoekForm = ({ setRequest, setMarkertePersoner, mutate }: any) => {
 								</Accordion.Item>
 							</Accordion>
 						</Form>
-						{devEnabled && <DisplayFormState />}
+						{(devEnabled || erDollyAdmin()) && <DisplayFormState />}
 					</>
 				</FormProvider>
 			</Soekefelt>


### PR DESCRIPTION
This pull request includes changes to the `apps/dolly-frontend` project, primarily focusing on enhancing the visibility of form state and errors for administrators. The main changes involve importing a new utility function and updating conditional rendering logic to include checks for admin status.

Enhancements for admin visibility:

* [`apps/dolly-frontend/src/main/js/src/components/bestillingsveileder/stegVelger/StegVelger.tsx`](diffhunk://#diff-e1870d3da9228c44262d963cbb671e54a8850ad5160eb6d38a0a0d2c6f18da6bR33): Added import for `erDollyAdmin` utility function and updated conditional rendering to display form state and errors if the user is an admin. [[1]](diffhunk://#diff-e1870d3da9228c44262d963cbb671e54a8850ad5160eb6d38a0a0d2c6f18da6bR33) [[2]](diffhunk://#diff-e1870d3da9228c44262d963cbb671e54a8850ad5160eb6d38a0a0d2c6f18da6bL164-R165)
* [`apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/visning/visningRedigerbar/VisningRedigerbar.tsx`](diffhunk://#diff-da6f4643e4c70afa4e4dc8d4bc21f50b796c6e4c5696e0453f8ca40a729493b6R46): Added import for `erDollyAdmin` utility function and updated conditional rendering to display form state and errors if the user is an admin. [[1]](diffhunk://#diff-da6f4643e4c70afa4e4dc8d4bc21f50b796c6e4c5696e0453f8ca40a729493b6R46) [[2]](diffhunk://#diff-da6f4643e4c70afa4e4dc8d4bc21f50b796c6e4c5696e0453f8ca40a729493b6L404-R405)
* [`apps/dolly-frontend/src/main/js/src/pages/organisasjoner/OrganisasjonTenorSoek/SoekFormOrg.tsx`](diffhunk://#diff-57fe60e5d4653b34abd675a9ba5789a6f08a524b6e9692a4da842b39115c2d89R15): Added import for `erDollyAdmin` utility function and updated conditional rendering to display form state and errors if the user is an admin. [[1]](diffhunk://#diff-57fe60e5d4653b34abd675a9ba5789a6f08a524b6e9692a4da842b39115c2d89R15) [[2]](diffhunk://#diff-57fe60e5d4653b34abd675a9ba5789a6f08a524b6e9692a4da842b39115c2d89L212-R213)
* [`apps/dolly-frontend/src/main/js/src/pages/tenorSoek/SoekForm.tsx`](diffhunk://#diff-1f80d40d90574ce2f3bf9a1945d19083d768cd11078942cf92d7aef1604f800aR19): Added import for `erDollyAdmin` utility function and updated conditional rendering to display form state and errors if the user is an admin. [[1]](diffhunk://#diff-1f80d40d90574ce2f3bf9a1945d19083d768cd11078942cf92d7aef1604f800aR19) [[2]](diffhunk://#diff-1f80d40d90574ce2f3bf9a1945d19083d768cd11078942cf92d7aef1604f800aL293-R294)