### PR TITLE
Refactor SivilstandService to calculate birth dates based on hovedper…

### DIFF
--- a/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/service/SivilstandService.java
+++ b/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/service/SivilstandService.java
@@ -101,9 +101,9 @@ public class SivilstandService implements BiValidation<SivilstandDTO, PersonDTO>
                 if (isNull(sivilstand.getNyRelatertPerson().getAlder()) &&
                         isNull(sivilstand.getNyRelatertPerson().getFoedtEtter()) &&
                         isNull(sivilstand.getNyRelatertPerson().getFoedtFoer())) {
-
-                    sivilstand.getNyRelatertPerson().setFoedtFoer(now().minusYears(30));
-                    sivilstand.getNyRelatertPerson().setFoedtEtter(now().minusYears(60));
+                    var foedselsdato = FoedselsdatoUtility.getFoedselsdato(hovedperson);
+                    sivilstand.getNyRelatertPerson().setFoedtFoer(foedselsdato.plusYears(2));
+                    sivilstand.getNyRelatertPerson().setFoedtEtter(foedselsdato.minusYears(2));
                 }
                 if (isNull(sivilstand.getNyRelatertPerson().getKjoenn())) {
                     KjoennDTO.Kjoenn kjoenn = hovedperson.getKjoenn().stream().findFirst()


### PR DESCRIPTION
This pull request includes a modification to the `SivilstandService` class in the `apps/pdl-forvalter` module. The change aims to improve the handling of the birth date for a new related person in the `handle` method.

### Changes to birth date handling:

* [`apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/service/SivilstandService.java`](diffhunk://#diff-35898d8fe8d73278056eda87993ef25784f50a8ee451ba6538fd2b36b15c74ecL104-R106): Updated the logic to set the `FoedtFoer` and `FoedtEtter` fields of `NyRelatertPerson` using a birth date derived from the `hovedperson` via the `FoedselsdatoUtility` class. The `FoedtFoer` is now set to two years after the derived birth date, and `FoedtEtter` is set to two years before the derived birth date.…son's date for improved accuracy #deploy-test-pdl-forvalter #deploy-pdl-forvalter