### PR TITLE
cleanup/mute_imagenotfoundexception

### DIFF
--- a/apps/profil-api/src/main/java/no/nav/registre/testnorge/profil/consumer/command/GetProfileImageCommand.java
+++ b/apps/profil-api/src/main/java/no/nav/registre/testnorge/profil/consumer/command/GetProfileImageCommand.java
@@ -31,7 +31,7 @@ public class GetProfileImageCommand implements Callable<Mono<byte[]>> {
                                 .map(IllegalStateException::new)
                 )
                 .bodyToMono(byte[].class)
-                .doOnError(e -> e
+                .doOnError(e -> !e
                                 .getMessage()
                                 .contains("Microsoft.Fast.Profile.Core.Exception.ImageNotFoundException"),
                         WebClientError.logTo(log))

--- a/apps/profil-api/src/main/java/no/nav/registre/testnorge/profil/consumer/command/GetProfileImageCommand.java
+++ b/apps/profil-api/src/main/java/no/nav/registre/testnorge/profil/consumer/command/GetProfileImageCommand.java
@@ -31,7 +31,10 @@ public class GetProfileImageCommand implements Callable<Mono<byte[]>> {
                                 .map(IllegalStateException::new)
                 )
                 .bodyToMono(byte[].class)
-                .doOnError(WebClientError.logTo(log))
+                .doOnError(e -> e
+                                .getMessage()
+                                .contains("Microsoft.Fast.Profile.Core.Exception.ImageNotFoundException"),
+                        WebClientError.logTo(log))
                 .retryWhen(WebClientError.is5xxException());
     }
 


### PR DESCRIPTION
Added a conditional on logging to avoid all those errors on 404 NOT_FOUND from GET https://graph.microsoft.com/v1.0/me/photos/240x240/$value.