### PR TITLE
Bugfix/set default start date for contract and improve WebClient time…

### DIFF
--- a/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/consumer/PdlTestdataConsumer.java
+++ b/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/consumer/PdlTestdataConsumer.java
@@ -14,12 +14,15 @@ import no.nav.testnav.libs.data.pdlforvalter.v1.PdlStatus;
 import no.nav.testnav.libs.securitycore.domain.AccessToken;
 import no.nav.testnav.libs.securitycore.domain.ServerProperties;
 import no.nav.testnav.libs.standalone.servletsecurity.exchange.TokenExchange;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.netty.http.client.HttpClient;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Set;
 
@@ -51,6 +54,8 @@ public class PdlTestdataConsumer {
         serverProperties = consumers.getPdlProxy();
         this.webClient = webClient
                 .mutate()
+                .clientConnector(new ReactorClientHttpConnector(HttpClient.create()
+                        .responseTimeout(Duration.ofSeconds(10))))
                 .baseUrl(serverProperties.getUrl())
                 .filters(exchangeFilterFunctions -> exchangeFilterFunctions.add(logRequest()))
                 .build();

--- a/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/service/DeltBostedService.java
+++ b/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/service/DeltBostedService.java
@@ -67,6 +67,10 @@ public class DeltBostedService implements BiValidation<DeltBostedDTO, PersonDTO>
 
     public void handle(DeltBostedDTO deltBosted, PersonDTO hovedperson) {
 
+        if (isNull(deltBosted.getStartdatoForKontrakt())) {
+            deltBosted.setStartdatoForKontrakt(LocalDateTime.now());
+        }
+
         if (LocalDateTime.now().isAfter(FoedselsdatoUtility.getMyndighetsdato(hovedperson))) {
 
             // DeltBosted for forelder, settes på barnet
@@ -146,10 +150,10 @@ public class DeltBostedService implements BiValidation<DeltBostedDTO, PersonDTO>
                     .toList();
     }
 
-
     private void setAdresse(DeltBostedDTO deltBosted, BostedadresseDTO boadresse) {
 
         deltBosted.setMaster(DbVersjonDTO.Master.FREG);
+        deltBosted.setKilde(getKilde(deltBosted));
         deltBosted.setAdresseIdentifikatorFraMatrikkelen(boadresse.getAdresseIdentifikatorFraMatrikkelen());
 
         if (nonNull(boadresse.getVegadresse())) {
@@ -162,7 +166,6 @@ public class DeltBostedService implements BiValidation<DeltBostedDTO, PersonDTO>
             deltBosted.setUkjentBosted(mapperFacade.map(boadresse.getUkjentBosted(), UkjentBostedDTO.class));
         }
     }
-
 
     private static boolean isEqualAdresse(BostedadresseDTO adresse1, BostedadresseDTO adresse2) {
 


### PR DESCRIPTION
This pull request introduces several changes to improve the functionality and reliability of the `PdlTestdataConsumer` and `DeltBostedService` classes in the `apps/pdl-forvalter` project. The most important changes include adding a timeout configuration for HTTP client connections and ensuring default values for certain fields.

### Improvements to `PdlTestdataConsumer`:

* Added `ReactorClientHttpConnector` to configure the HTTP client with a response timeout of 10 seconds. This change ensures that the HTTP client does not hang indefinitely. [[1]](diffhunk://#diff-4f4fc77d24dd7acb836d97e68af728e499bb85dac1c0a3f1b068c83efb763975R17-R25) [[2]](diffhunk://#diff-4f4fc77d24dd7acb836d97e68af728e499bb85dac1c0a3f1b068c83efb763975R57-R58)

### Enhancements to `DeltBostedService`:

* Added a check to set the `startdatoForKontrakt` field to the current date and time if it is null. This ensures that the `startdatoForKontrakt` field always has a valid value.
* Added a call to `setKilde` method to set the source for the `DeltBostedDTO` object. This provides more accurate tracking of data origins.

### Codebase cleanup:

* Removed unnecessary blank lines for better code readability. [[1]](diffhunk://#diff-3533a1802a518a71998a3053b9f854c959f090b8b149ca58ebfd1f8cc116eb71L149-R156) [[2]](diffhunk://#diff-3533a1802a518a71998a3053b9f854c959f090b8b149ca58ebfd1f8cc116eb71L166)…out #deploy-test-pdl-forvalter #deploy-pdl-forvalter