### PR TITLE
cleanup/dollyserverhttpsecurity

### DIFF
--- a/apps/altinn3-tilgang-service/src/main/java/no/nav/testnav/altinn3tilgangservice/config/SecurityConfig.java
+++ b/apps/altinn3-tilgang-service/src/main/java/no/nav/testnav/altinn3tilgangservice/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package no.nav.testnav.altinn3tilgangservice.config;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import no.nav.dolly.libs.security.config.DollyServerHttpSecurity;
 import no.nav.testnav.libs.reactivesecurity.manager.JwtReactiveAuthenticationManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -16,24 +17,15 @@ import org.springframework.security.web.server.SecurityWebFilterChain;
 @EnableWebFluxSecurity
 @EnableReactiveMethodSecurity
 @RequiredArgsConstructor
-public class SecurityConfig {
+class SecurityConfig {
 
     private final JwtReactiveAuthenticationManager jwtReactiveAuthenticationManager;
 
     @Bean
-    public SecurityWebFilterChain springSecurityFilterChain(ServerHttpSecurity httpSecurity) {
+    SecurityWebFilterChain springSecurityFilterChain(ServerHttpSecurity httpSecurity) {
         return httpSecurity
                 .csrf(ServerHttpSecurity.CsrfSpec::disable)
-                .authorizeExchange(authorizeConfig -> authorizeConfig.pathMatchers(
-                        "/internal/**",
-                        "/webjars/**",
-                        "/swagger-resources/**",
-                        "/v3/api-docs/**",
-                        "/swagger-ui/**",
-                        "/swagger",
-                        "/error",
-                        "/swagger-ui.html"
-                ).permitAll().anyExchange().authenticated())
+                .authorizeExchange(DollyServerHttpSecurity.withDefaultHttpRequests())
                 .oauth2ResourceServer(oauth2RSConfig -> oauth2RSConfig.jwt(jwtSpec -> jwtSpec.authenticationManager(jwtReactiveAuthenticationManager))).build();
     }
 

--- a/apps/app-tilgang-analyse-service/src/main/java/no/nav/testnav/apps/apptilganganalyseservice/config/SecurityConfig.java
+++ b/apps/app-tilgang-analyse-service/src/main/java/no/nav/testnav/apps/apptilganganalyseservice/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package no.nav.testnav.apps.apptilganganalyseservice.config;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import no.nav.dolly.libs.security.config.DollyServerHttpSecurity;
 import no.nav.testnav.libs.reactivesecurity.manager.JwtReactiveAuthenticationManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -16,25 +17,18 @@ import org.springframework.security.web.server.SecurityWebFilterChain;
 @EnableWebFluxSecurity
 @EnableReactiveMethodSecurity
 @RequiredArgsConstructor
-public class SecurityConfig {
+class SecurityConfig {
 
     private final JwtReactiveAuthenticationManager jwtReactiveAuthenticationManager;
 
     @Bean
-    public SecurityWebFilterChain springSecurityFilterChain(ServerHttpSecurity httpSecurity) {
+    SecurityWebFilterChain springSecurityFilterChain(ServerHttpSecurity httpSecurity) {
         return httpSecurity
                 .csrf(ServerHttpSecurity.CsrfSpec::disable)
-                .authorizeExchange(authorizeConfig -> authorizeConfig.pathMatchers(
-                        "/internal/**",
-                        "/webjars/**",
-                        "/v3/api-docs/**",
-                        "/swagger-ui/**",
-                        "/swagger",
-                        "/error",
-                        "/swagger-ui.html"
-                ).permitAll().anyExchange().authenticated())
+                .authorizeExchange(DollyServerHttpSecurity.withDefaultHttpRequests())
                 .oauth2ResourceServer(oauth2RSConfig -> oauth2RSConfig.jwt(jwtSpec -> jwtSpec.authenticationManager(jwtReactiveAuthenticationManager)))
                 .build();
     }
+
 }
 

--- a/apps/bruker-service/src/main/java/no/nav/testnav/apps/brukerservice/config/SecurityConfig.java
+++ b/apps/bruker-service/src/main/java/no/nav/testnav/apps/brukerservice/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package no.nav.testnav.apps.brukerservice.config;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import no.nav.dolly.libs.security.config.DollyServerHttpSecurity;
 import no.nav.testnav.libs.reactivesecurity.manager.JwtReactiveAuthenticationManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,29 +11,20 @@ import org.springframework.security.config.annotation.web.reactive.EnableWebFlux
 import org.springframework.security.config.web.server.ServerHttpSecurity;
 import org.springframework.security.web.server.SecurityWebFilterChain;
 
-
 @Slf4j
 @Configuration
 @EnableWebFluxSecurity
 @EnableReactiveMethodSecurity
 @RequiredArgsConstructor
-public class SecurityConfig {
+class SecurityConfig {
 
     private final JwtReactiveAuthenticationManager jwtReactiveAuthenticationManager;
 
     @Bean
-    public SecurityWebFilterChain springSecurityFilterChain(ServerHttpSecurity httpSecurity) {
+    SecurityWebFilterChain springSecurityFilterChain(ServerHttpSecurity httpSecurity) {
         return httpSecurity
                 .csrf(ServerHttpSecurity.CsrfSpec::disable)
-                .authorizeExchange(authorizeConfig -> authorizeConfig.pathMatchers(
-                        "/internal/**",
-                        "/webjars/**",
-                        "/v3/api-docs/**",
-                        "/swagger-ui/**",
-                        "/swagger",
-                        "/error",
-                        "/swagger-ui.html"
-                ).permitAll().anyExchange().authenticated())
+                .authorizeExchange(DollyServerHttpSecurity.withDefaultHttpRequests())
                 .oauth2ResourceServer(oauth2RSConfig -> oauth2RSConfig.jwt(jwtSpec -> jwtSpec.authenticationManager(jwtReactiveAuthenticationManager)))
                 .build();
     }

--- a/apps/dolly-search-service/src/main/java/no/nav/testnav/dollysearchservice/config/SecurityConfig.java
+++ b/apps/dolly-search-service/src/main/java/no/nav/testnav/dollysearchservice/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package no.nav.testnav.dollysearchservice.config;
 
 import lombok.RequiredArgsConstructor;
+import no.nav.dolly.libs.security.config.DollyServerHttpSecurity;
 import no.nav.testnav.libs.reactivesecurity.manager.JwtReactiveAuthenticationManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -15,27 +16,18 @@ import org.springframework.security.web.server.SecurityWebFilterChain;
 @Configuration
 @Profile({"prod", "dev", "local"})
 @RequiredArgsConstructor
-public class SecurityConfig {
+class SecurityConfig {
 
     private final JwtReactiveAuthenticationManager jwtReactiveAuthenticationManager;
 
     @Bean
-    public SecurityWebFilterChain springSecurityFilterChain(ServerHttpSecurity httpSecurity) {
+    SecurityWebFilterChain springSecurityFilterChain(ServerHttpSecurity httpSecurity) {
         return httpSecurity
                 .csrf(ServerHttpSecurity.CsrfSpec::disable)
-                .authorizeExchange(authorizeConfig -> authorizeConfig.pathMatchers(
-                                "/internal/**",
-                                "/webjars/**",
-                                "/v3/api-docs/**",
-                                "/swagger-ui/**",
-                                "/swagger",
-                                "/error",
-                                "/swagger-ui.html"
-                        ).permitAll()
-                        .anyExchange()
-                        .authenticated())
+                .authorizeExchange(DollyServerHttpSecurity.withDefaultHttpRequests())
                 .oauth2ResourceServer(oauth2RSConfig -> oauth2RSConfig.jwt(jwtSpec -> jwtSpec.authenticationManager(jwtReactiveAuthenticationManager)))
                 .build();
     }
+
 }
 

--- a/apps/endringsmelding-service/src/main/java/no/nav/testnav/endringsmeldingservice/config/SecurityConfig.java
+++ b/apps/endringsmelding-service/src/main/java/no/nav/testnav/endringsmeldingservice/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package no.nav.testnav.endringsmeldingservice.config;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import no.nav.dolly.libs.security.config.DollyServerHttpSecurity;
 import no.nav.testnav.libs.reactivesecurity.manager.JwtReactiveAuthenticationManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -15,24 +16,17 @@ import org.springframework.security.web.server.SecurityWebFilterChain;
 @EnableWebFluxSecurity
 @EnableReactiveMethodSecurity
 @RequiredArgsConstructor
-public class SecurityConfig {
+class SecurityConfig {
 
     private final JwtReactiveAuthenticationManager jwtReactiveAuthenticationManager;
 
     @Bean
-    public SecurityWebFilterChain springSecurityFilterChain(ServerHttpSecurity httpSecurity) {
+    SecurityWebFilterChain springSecurityFilterChain(ServerHttpSecurity httpSecurity) {
         return httpSecurity
                 .csrf(ServerHttpSecurity.CsrfSpec::disable)
-                .authorizeExchange(authorizeConfig -> authorizeConfig.pathMatchers(
-                        "/internal/**",
-                        "/webjars/**",
-                        "/v3/api-docs/**",
-                        "/swagger-ui/**",
-                        "/swagger",
-                        "/error",
-                        "/swagger-ui.html"
-                ).permitAll().anyExchange().authenticated())
+                .authorizeExchange(DollyServerHttpSecurity.withDefaultHttpRequests())
                 .oauth2ResourceServer(oauth2RSConfig -> oauth2RSConfig.jwt(jwtSpec -> jwtSpec.authenticationManager(jwtReactiveAuthenticationManager)))
                 .build();
     }
+
 }

--- a/apps/inntektsmelding-service/src/main/java/no/nav/registre/testnav/inntektsmeldingservice/config/SecurityConfig.java
+++ b/apps/inntektsmelding-service/src/main/java/no/nav/registre/testnav/inntektsmeldingservice/config/SecurityConfig.java
@@ -19,12 +19,7 @@ class SecurityConfig {
         return httpSecurity
                 .sessionManagement(configurer -> configurer.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .csrf(AbstractHttpConfigurer::disable)
-                .authorizeHttpRequests(registry -> {
-                    DollyHttpSecurity.allowDefaultHttpRequests().customize(registry);
-                    registry
-                            .requestMatchers("/h2/**").permitAll()
-                            .anyRequest().fullyAuthenticated();
-                })
+                .authorizeHttpRequests(DollyHttpSecurity.withDefaultHttpRequests("/h2/**"))
                 .oauth2ResourceServer(configurer -> configurer.jwt(Customizer.withDefaults()))
                 .build();
     }

--- a/apps/inntektsmelding-service/src/main/java/no/nav/registre/testnav/inntektsmeldingservice/config/SecurityConfig.java
+++ b/apps/inntektsmelding-service/src/main/java/no/nav/registre/testnav/inntektsmeldingservice/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package no.nav.registre.testnav.inntektsmeldingservice.config;
 
+import no.nav.dolly.libs.security.config.DollyHttpSecurity;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
@@ -11,29 +12,21 @@ import org.springframework.security.web.SecurityFilterChain;
 
 @EnableWebSecurity
 @Configuration
-public class SecurityConfig {
+class SecurityConfig {
 
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
-
-        httpSecurity.sessionManagement(managementConfigurer ->
-                        managementConfigurer.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+    SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
+        return httpSecurity
+                .sessionManagement(configurer -> configurer.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .csrf(AbstractHttpConfigurer::disable)
-                .authorizeHttpRequests(matcherRegistry -> matcherRegistry.requestMatchers(
-                                "/internal/**",
-                                "/webjars/**",
-                                "/h2/**",
-                                "/swagger-resources/**",
-                                "/v3/api-docs/**",
-                                "/swagger-ui/**",
-                                "/swagger",
-                                "/error",
-                                "/swagger-ui.html")
-                        .permitAll()
-                        .requestMatchers("/api/**").fullyAuthenticated())
-                .oauth2ResourceServer(httpSecurityOAuth2ResourceServerConfigurer -> httpSecurityOAuth2ResourceServerConfigurer
-                        .jwt(Customizer.withDefaults()));
-
-        return httpSecurity.build();
+                .authorizeHttpRequests(registry -> {
+                    DollyHttpSecurity.allowDefaultHttpRequests().customize(registry);
+                    registry
+                            .requestMatchers("/h2/**").permitAll()
+                            .anyRequest().fullyAuthenticated();
+                })
+                .oauth2ResourceServer(configurer -> configurer.jwt(Customizer.withDefaults()))
+                .build();
     }
+
 }

--- a/apps/levende-arbeidsforhold-ansettelse/src/main/java/no/nav/testnav/levendearbeidsforholdansettelse/config/SecurityConfig.java
+++ b/apps/levende-arbeidsforhold-ansettelse/src/main/java/no/nav/testnav/levendearbeidsforholdansettelse/config/SecurityConfig.java
@@ -25,12 +25,8 @@ class SecurityConfig {
                 .authorizeExchange(spec -> {
                     DollyServerHttpSecurity.allowDefaultHttpRequests().customize(spec);
                     spec
-                            .pathMatchers(
-                                    "/h2/**",
-                                    "/member/**")
-                            .permitAll()
-                            .anyExchange()
-                            .authenticated();
+                            .pathMatchers("/h2/**", "/member/**").permitAll()
+                            .anyExchange().authenticated();
                 })
                 .oauth2ResourceServer(oauth2RSConfig -> oauth2RSConfig.jwt(jwtSpec -> jwtSpec.authenticationManager(jwtReactiveAuthenticationManager)))
                 .build();

--- a/apps/levende-arbeidsforhold-ansettelse/src/main/java/no/nav/testnav/levendearbeidsforholdansettelse/config/SecurityConfig.java
+++ b/apps/levende-arbeidsforhold-ansettelse/src/main/java/no/nav/testnav/levendearbeidsforholdansettelse/config/SecurityConfig.java
@@ -23,7 +23,7 @@ class SecurityConfig {
         return httpSecurity
                 .csrf(ServerHttpSecurity.CsrfSpec::disable)
                 .authorizeExchange(spec -> {
-                    DollyServerHttpSecurity.withDefaultHttpRequests().customize(spec);
+                    DollyServerHttpSecurity.allowDefaultHttpRequests().customize(spec);
                     spec
                             .pathMatchers(
                                     "/h2/**",

--- a/apps/levende-arbeidsforhold-ansettelse/src/main/java/no/nav/testnav/levendearbeidsforholdansettelse/config/SecurityConfig.java
+++ b/apps/levende-arbeidsforhold-ansettelse/src/main/java/no/nav/testnav/levendearbeidsforholdansettelse/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package no.nav.testnav.levendearbeidsforholdansettelse.config;
 
 import lombok.RequiredArgsConstructor;
+import no.nav.dolly.libs.security.config.DollyServerHttpSecurity;
 import no.nav.testnav.libs.reactivesecurity.manager.JwtReactiveAuthenticationManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -13,28 +14,26 @@ import org.springframework.security.web.server.SecurityWebFilterChain;
 @EnableWebFluxSecurity
 @EnableReactiveMethodSecurity
 @RequiredArgsConstructor
-public class SecurityConfig {
+class SecurityConfig {
 
     private final JwtReactiveAuthenticationManager jwtReactiveAuthenticationManager;
 
     @Bean
-    @SuppressWarnings("java:S4502")
-    public SecurityWebFilterChain springSecurityFilterChain(ServerHttpSecurity httpSecurity) {
+    SecurityWebFilterChain springSecurityFilterChain(ServerHttpSecurity httpSecurity) {
         return httpSecurity
                 .csrf(ServerHttpSecurity.CsrfSpec::disable)
-                .authorizeExchange(authorizeConfig -> authorizeConfig.pathMatchers(
-                                "/internal/**",
-                                "/webjars/**",
-                                "/swagger-resources/**",
-                                "/v3/api-docs/**",
-                                "/swagger-ui/**",
-                                "/swagger",
-                                "/error",
-                                "/swagger-ui.html",
-                                "/h2/**",
-                                "/member/**")
-                .permitAll().anyExchange().authenticated())
+                .authorizeExchange(spec -> {
+                    DollyServerHttpSecurity.withDefaultHttpRequests().customize(spec);
+                    spec
+                            .pathMatchers(
+                                    "/h2/**",
+                                    "/member/**")
+                            .permitAll()
+                            .anyExchange()
+                            .authenticated();
+                })
                 .oauth2ResourceServer(oauth2RSConfig -> oauth2RSConfig.jwt(jwtSpec -> jwtSpec.authenticationManager(jwtReactiveAuthenticationManager)))
                 .build();
     }
+
 }

--- a/apps/levende-arbeidsforhold-ansettelse/src/main/java/no/nav/testnav/levendearbeidsforholdansettelse/config/SecurityConfig.java
+++ b/apps/levende-arbeidsforhold-ansettelse/src/main/java/no/nav/testnav/levendearbeidsforholdansettelse/config/SecurityConfig.java
@@ -22,12 +22,7 @@ class SecurityConfig {
     SecurityWebFilterChain springSecurityFilterChain(ServerHttpSecurity httpSecurity) {
         return httpSecurity
                 .csrf(ServerHttpSecurity.CsrfSpec::disable)
-                .authorizeExchange(spec -> {
-                    DollyServerHttpSecurity.allowDefaultHttpRequests().customize(spec);
-                    spec
-                            .pathMatchers("/h2/**", "/member/**").permitAll()
-                            .anyExchange().authenticated();
-                })
+                .authorizeExchange(DollyServerHttpSecurity.withDefaultHttpRequests("/h2/**", "/member/**"))
                 .oauth2ResourceServer(oauth2RSConfig -> oauth2RSConfig.jwt(jwtSpec -> jwtSpec.authenticationManager(jwtReactiveAuthenticationManager)))
                 .build();
     }

--- a/apps/levende-arbeidsforhold-scheduler/src/main/java/no/nav/testnav/levendearbeidsforholdscheduler/config/SecurityConfig.java
+++ b/apps/levende-arbeidsforhold-scheduler/src/main/java/no/nav/testnav/levendearbeidsforholdscheduler/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package no.nav.testnav.levendearbeidsforholdscheduler.config;
 
+import no.nav.dolly.libs.security.config.DollyHttpSecurity;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
@@ -11,29 +12,17 @@ import org.springframework.security.web.SecurityFilterChain;
 
 @EnableWebSecurity
 @Configuration
-public class SecurityConfig {
+class SecurityConfig {
 
     @Bean
-    @SuppressWarnings("java:S4502")
-    public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
-
-        httpSecurity.sessionManagement(sessionConfig -> sessionConfig.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+    SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
+        return httpSecurity
+                .sessionManagement(sessionConfig -> sessionConfig.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .csrf(AbstractHttpConfigurer::disable)
-                .authorizeHttpRequests(authorizeConfig -> authorizeConfig.requestMatchers(
-                                "/internal/**",
-                                "/webjars/**",
-                                "/swagger-resources/**",
-                                "/v3/api-docs/**",
-                                "/swagger-ui/**",
-                                "/swagger",
-                                "/error",
-                                "/swagger-ui.html")
-                        .permitAll()
-                        .requestMatchers("/api/**")
-                        .fullyAuthenticated())
-                .oauth2ResourceServer(oauth2RSConfig -> oauth2RSConfig.jwt(Customizer.withDefaults()));
-
-        return httpSecurity.build();
+                .authorizeHttpRequests(DollyHttpSecurity.withDefaultHttpRequests())
+                .oauth2ResourceServer(oauth2RSConfig -> oauth2RSConfig.jwt(Customizer.withDefaults()))
+                .build();
     }
+
 }
 

--- a/apps/organisasjon-bestilling-service/src/main/java/no/nav/testnav/apps/organisasjonbestillingservice/config/SecurityConfig.java
+++ b/apps/organisasjon-bestilling-service/src/main/java/no/nav/testnav/apps/organisasjonbestillingservice/config/SecurityConfig.java
@@ -22,14 +22,10 @@ class SecurityConfig {
         return httpSecurity
                 .sessionManagement(sessionConfig -> sessionConfig.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .csrf(AbstractHttpConfigurer::disable)
-                .authorizeHttpRequests(registry -> {
-                    DollyHttpSecurity.allowDefaultHttpRequests().customize(registry);
-                    registry
-                            .requestMatchers("/h2/**", "/member/**").permitAll()
-                            .anyRequest().fullyAuthenticated();
-                })
+                .authorizeHttpRequests(DollyHttpSecurity.withDefaultHttpRequests("/h2/**", "/member/**"))
                 .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable))
                 .oauth2ResourceServer(oauth2RSConfig -> oauth2RSConfig.jwt(Customizer.withDefaults()))
                 .build();
     }
+
 }

--- a/apps/organisasjon-bestilling-service/src/main/java/no/nav/testnav/apps/organisasjonbestillingservice/config/SecurityConfig.java
+++ b/apps/organisasjon-bestilling-service/src/main/java/no/nav/testnav/apps/organisasjonbestillingservice/config/SecurityConfig.java
@@ -19,18 +19,17 @@ class SecurityConfig {
 
     @Bean
     SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
-        httpSecurity.sessionManagement(sessionConfig -> sessionConfig.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+        return httpSecurity
+                .sessionManagement(sessionConfig -> sessionConfig.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(registry -> {
-                    DollyHttpSecurity.withDefaultHttpRequests().customize(registry);
+                    DollyHttpSecurity.allowDefaultHttpRequests().customize(registry);
                     registry
-                            .requestMatchers(
-                                    "/h2/**",
-                                    "/member/**")
-                            .permitAll();
+                            .requestMatchers("/h2/**", "/member/**").permitAll()
+                            .anyRequest().fullyAuthenticated();
                 })
                 .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable))
-                .oauth2ResourceServer(oauth2RSConfig -> oauth2RSConfig.jwt(Customizer.withDefaults()));
-        return httpSecurity.build();
+                .oauth2ResourceServer(oauth2RSConfig -> oauth2RSConfig.jwt(Customizer.withDefaults()))
+                .build();
     }
 }

--- a/apps/organisasjon-bestilling-service/src/main/java/no/nav/testnav/apps/organisasjonbestillingservice/config/SecurityConfig.java
+++ b/apps/organisasjon-bestilling-service/src/main/java/no/nav/testnav/apps/organisasjonbestillingservice/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package no.nav.testnav.apps.organisasjonbestillingservice.config;
 
+import no.nav.dolly.libs.security.config.DollyHttpSecurity;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
@@ -17,24 +18,17 @@ import org.springframework.security.web.SecurityFilterChain;
 class SecurityConfig {
 
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
-
+    SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
         httpSecurity.sessionManagement(sessionConfig -> sessionConfig.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .csrf(AbstractHttpConfigurer::disable)
-                .authorizeHttpRequests(authorizeConfig -> authorizeConfig.requestMatchers(
-                                "/internal/**",
-                                "/webjars/**",
-                                "/swagger-resources/**",
-                                "/v3/api-docs/**",
-                                "/swagger-ui/**",
-                                "/swagger",
-                                "/error",
-                                "/swagger-ui.html",
-                                "/h2/**",
-                                "/member/**")
-                        .permitAll()
-                        .requestMatchers("/api/**")
-                        .fullyAuthenticated())
+                .authorizeHttpRequests(registry -> {
+                    DollyHttpSecurity.withDefaultHttpRequests().customize(registry);
+                    registry
+                            .requestMatchers(
+                                    "/h2/**",
+                                    "/member/**")
+                            .permitAll();
+                })
                 .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable))
                 .oauth2ResourceServer(oauth2RSConfig -> oauth2RSConfig.jwt(Customizer.withDefaults()));
         return httpSecurity.build();

--- a/apps/organisasjon-forvalter/src/main/java/no/nav/organisasjonforvalter/config/SecurityConfig.java
+++ b/apps/organisasjon-forvalter/src/main/java/no/nav/organisasjonforvalter/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package no.nav.organisasjonforvalter.config;
 
+import no.nav.dolly.libs.security.config.DollyHttpSecurity;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
@@ -17,26 +18,15 @@ import org.springframework.security.web.SecurityFilterChain;
 class SecurityConfig {
 
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
-
-        httpSecurity.sessionManagement(sessionConfig -> sessionConfig.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+    SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
+        return httpSecurity
+                .sessionManagement(sessionConfig -> sessionConfig.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .csrf(AbstractHttpConfigurer::disable)
-                .authorizeHttpRequests(authorizeConfig -> authorizeConfig.requestMatchers(
-                                "/internal/**",
-                                "/webjars/**",
-                                "/swagger-resources/**",
-                                "/v3/api-docs/**",
-                                "/swagger-ui/**",
-                                "/swagger",
-                                "/error",
-                                "/swagger-ui.html")
-                        .permitAll()
-                        .requestMatchers("/api/**")
-                        .fullyAuthenticated())
+                .authorizeHttpRequests(DollyHttpSecurity.withDefaultHttpRequests())
                 .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable))
-                .oauth2ResourceServer(oauth2RSConfig -> oauth2RSConfig.jwt(Customizer.withDefaults()));
-
-        return httpSecurity.build();
+                .oauth2ResourceServer(oauth2RSConfig -> oauth2RSConfig.jwt(Customizer.withDefaults()))
+                .build();
     }
+
 }
 

--- a/apps/person-faste-data-service/src/main/java/no/nav/testnav/personfastedataservice/config/SecurityConfig.java
+++ b/apps/person-faste-data-service/src/main/java/no/nav/testnav/personfastedataservice/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package no.nav.testnav.personfastedataservice.config;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import no.nav.dolly.libs.security.config.DollyServerHttpSecurity;
 import no.nav.testnav.libs.reactivesecurity.manager.JwtReactiveAuthenticationManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -9,29 +10,21 @@ import org.springframework.security.config.annotation.web.reactive.EnableWebFlux
 import org.springframework.security.config.web.server.ServerHttpSecurity;
 import org.springframework.security.web.server.SecurityWebFilterChain;
 
-
 @Slf4j
 @Configuration
 @EnableWebFluxSecurity
 @RequiredArgsConstructor
-public class SecurityConfig {
+class SecurityConfig {
 
     private final JwtReactiveAuthenticationManager jwtReactiveAuthenticationManager;
 
     @Bean
-    public SecurityWebFilterChain springSecurityFilterChain(ServerHttpSecurity httpSecurity) {
+    SecurityWebFilterChain springSecurityFilterChain(ServerHttpSecurity httpSecurity) {
         return httpSecurity
                 .csrf(ServerHttpSecurity.CsrfSpec::disable)
-                .authorizeExchange(authorizeConfig -> authorizeConfig.pathMatchers(
-                        "/internal/**",
-                        "/webjars/**",
-                        "/v3/api-docs/**",
-                        "/swagger-ui/**",
-                        "/swagger",
-                        "/error",
-                        "/swagger-ui.html"
-                ).permitAll().anyExchange().authenticated())
+                .authorizeExchange(DollyServerHttpSecurity.withDefaultHttpRequests())
                 .oauth2ResourceServer(oauth2RSConfig -> oauth2RSConfig.jwt(jwtSpec -> jwtSpec.authenticationManager(jwtReactiveAuthenticationManager)))
                 .build();
     }
+
 }

--- a/apps/skattekort-service/src/main/java/no/nav/skattekortservice/config/SecurityConfig.java
+++ b/apps/skattekort-service/src/main/java/no/nav/skattekortservice/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package no.nav.skattekortservice.config;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import no.nav.dolly.libs.security.config.DollyServerHttpSecurity;
 import no.nav.testnav.libs.reactivesecurity.manager.JwtReactiveAuthenticationManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -15,24 +16,17 @@ import org.springframework.security.web.server.SecurityWebFilterChain;
 @EnableWebFluxSecurity
 @EnableReactiveMethodSecurity
 @RequiredArgsConstructor
-public class SecurityConfig {
+class SecurityConfig {
 
     private final JwtReactiveAuthenticationManager jwtReactiveAuthenticationManager;
 
     @Bean
-    public SecurityWebFilterChain springSecurityFilterChain(ServerHttpSecurity httpSecurity) {
+    SecurityWebFilterChain springSecurityFilterChain(ServerHttpSecurity httpSecurity) {
         return httpSecurity
                 .csrf(ServerHttpSecurity.CsrfSpec::disable)
-                .authorizeExchange(authorizeConfig -> authorizeConfig.pathMatchers(
-                        "/internal/**",
-                        "/webjars/**",
-                        "/v3/api-docs/**",
-                        "/swagger-ui/**",
-                        "/swagger",
-                        "/error",
-                        "/swagger-ui.html"
-                ).permitAll().anyExchange().authenticated())
+                .authorizeExchange(DollyServerHttpSecurity.withDefaultHttpRequests())
                 .oauth2ResourceServer(oauth2RSConfig -> oauth2RSConfig.jwt(jwtSpec -> jwtSpec.authenticationManager(jwtReactiveAuthenticationManager)))
                 .build();
     }
+
 }

--- a/apps/tenor-search-service/src/main/java/no/nav/testnav/apps/tenorsearchservice/config/SecurityConfig.java
+++ b/apps/tenor-search-service/src/main/java/no/nav/testnav/apps/tenorsearchservice/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package no.nav.testnav.apps.tenorsearchservice.config;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import no.nav.dolly.libs.security.config.DollyServerHttpSecurity;
 import no.nav.testnav.libs.reactivesecurity.manager.JwtReactiveAuthenticationManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,31 +11,22 @@ import org.springframework.security.config.annotation.web.reactive.EnableWebFlux
 import org.springframework.security.config.web.server.ServerHttpSecurity;
 import org.springframework.security.web.server.SecurityWebFilterChain;
 
-
 @Slf4j
 @Configuration
 @EnableWebFluxSecurity
 @EnableReactiveMethodSecurity
 @RequiredArgsConstructor
-public class SecurityConfig {
+class SecurityConfig {
 
     private final JwtReactiveAuthenticationManager jwtReactiveAuthenticationManager;
 
     @Bean
-    public SecurityWebFilterChain springSecurityFilterChain(ServerHttpSecurity httpSecurity) {
+    SecurityWebFilterChain springSecurityFilterChain(ServerHttpSecurity httpSecurity) {
         return httpSecurity
                 .csrf(ServerHttpSecurity.CsrfSpec::disable)
-                .authorizeExchange(authorizeConfig -> authorizeConfig.pathMatchers(
-                        "/internal/**",
-                        "/webjars/**",
-                        "/swagger-resources/**",
-                        "/v3/api-docs/**",
-                        "/swagger-ui/**",
-                        "/swagger",
-                        "/error",
-                        "/swagger-ui.html"
-                ).permitAll().anyExchange().authenticated())
+                .authorizeExchange(DollyServerHttpSecurity.withDefaultHttpRequests())
                 .oauth2ResourceServer(oauth2RSConfig -> oauth2RSConfig.jwt(jwtSpec -> jwtSpec.authenticationManager(jwtReactiveAuthenticationManager)))
                 .build();
     }
+
 }

--- a/apps/testnav-ident-pool/src/main/java/no/nav/testnav/identpool/config/SecurityConfig.java
+++ b/apps/testnav-ident-pool/src/main/java/no/nav/testnav/identpool/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package no.nav.testnav.identpool.config;
 
+import no.nav.dolly.libs.security.config.DollyHttpSecurity;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
@@ -12,30 +13,24 @@ import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
 @EnableWebSecurity
-public class SecurityConfig {
+class SecurityConfig {
 
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
-
-        httpSecurity.sessionManagement(sessionConfig -> sessionConfig.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+    SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
+        return httpSecurity
+                .sessionManagement(sessionConfig -> sessionConfig.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .csrf(AbstractHttpConfigurer::disable)
-                .authorizeHttpRequests(authorizeConfig -> authorizeConfig.requestMatchers(
-                                "/internal/**",
-                                "/webjars/**",
-                                "/swagger-resources/**",
-                                "/v3/api-docs/**",
-                                "/swagger-ui/**",
-                                "/swagger",
-                                "/error",
-                                "/swagger-ui.html",
-                                "/h2/**",
-                                "/member/**")
-                        .permitAll()
-                        .requestMatchers("/api/**")
-                        .fullyAuthenticated())
+                .authorizeHttpRequests(registry -> {
+                    DollyHttpSecurity.withDefaultHttpRequests().customize(registry);
+                    registry
+                            .requestMatchers(
+                                    "/h2/**",
+                                    "/member/**")
+                            .permitAll();
+                })
                 .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable))
-                .oauth2ResourceServer(oauth2RSConfig -> oauth2RSConfig.jwt(Customizer.withDefaults()));
-
-        return httpSecurity.build();
+                .oauth2ResourceServer(oauth2RSConfig -> oauth2RSConfig.jwt(Customizer.withDefaults()))
+                .build();
     }
+
 }

--- a/apps/testnav-ident-pool/src/main/java/no/nav/testnav/identpool/config/SecurityConfig.java
+++ b/apps/testnav-ident-pool/src/main/java/no/nav/testnav/identpool/config/SecurityConfig.java
@@ -20,12 +20,7 @@ class SecurityConfig {
         return httpSecurity
                 .sessionManagement(sessionConfig -> sessionConfig.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .csrf(AbstractHttpConfigurer::disable)
-                .authorizeHttpRequests(registry -> {
-                    DollyHttpSecurity.allowDefaultHttpRequests().customize(registry);
-                    registry
-                            .requestMatchers("/h2/**", "/member/**").permitAll()
-                            .anyRequest().fullyAuthenticated();
-                })
+                .authorizeHttpRequests(DollyHttpSecurity.withDefaultHttpRequests("/h2/**", "/member/**"))
                 .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable))
                 .oauth2ResourceServer(oauth2RSConfig -> oauth2RSConfig.jwt(Customizer.withDefaults()))
                 .build();

--- a/apps/testnav-ident-pool/src/main/java/no/nav/testnav/identpool/config/SecurityConfig.java
+++ b/apps/testnav-ident-pool/src/main/java/no/nav/testnav/identpool/config/SecurityConfig.java
@@ -21,12 +21,10 @@ class SecurityConfig {
                 .sessionManagement(sessionConfig -> sessionConfig.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(registry -> {
-                    DollyHttpSecurity.withDefaultHttpRequests().customize(registry);
+                    DollyHttpSecurity.allowDefaultHttpRequests().customize(registry);
                     registry
-                            .requestMatchers(
-                                    "/h2/**",
-                                    "/member/**")
-                            .permitAll();
+                            .requestMatchers("/h2/**", "/member/**").permitAll()
+                            .anyRequest().fullyAuthenticated();
                 })
                 .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable))
                 .oauth2ResourceServer(oauth2RSConfig -> oauth2RSConfig.jwt(Customizer.withDefaults()))

--- a/apps/testnorge-statisk-data-forvalter/src/main/java/no/nav/registre/sdforvalter/config/SecurityConfig.java
+++ b/apps/testnorge-statisk-data-forvalter/src/main/java/no/nav/registre/sdforvalter/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package no.nav.registre.sdforvalter.config;
 
 import lombok.extern.slf4j.Slf4j;
+import no.nav.dolly.libs.security.config.DollyHttpSecurity;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
@@ -10,35 +11,19 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 
-import static org.springframework.security.web.util.matcher.AntPathRequestMatcher.antMatcher;
-
-/**
- * Remove this call with AzureAd config
- */
 @Slf4j
 @Configuration
 @Order(1)
-public class SecurityConfig {
+class SecurityConfig {
 
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
+    SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
         return httpSecurity
                 .sessionManagement(c -> c.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .csrf(AbstractHttpConfigurer::disable)
-                .authorizeHttpRequests(c -> c
-                        .requestMatchers(
-                                antMatcher("/internal/**"),
-                                antMatcher("/webjars/**"),
-                                antMatcher("/swagger-resources/**"),
-                                antMatcher("/v3/api-docs/**"),
-                                antMatcher("/swagger-ui/**"),
-                                antMatcher("/swagger"),
-                                antMatcher("/error"),
-                                antMatcher("/swagger-ui.html"))
-                        .permitAll()
-                        .requestMatchers(antMatcher("/api/**"))
-                        .fullyAuthenticated())
+                .authorizeHttpRequests(DollyHttpSecurity.withDefaultHttpRequests())
                 .oauth2ResourceServer(c -> c.jwt(Customizer.withDefaults()))
                 .build();
     }
+
 }

--- a/apps/tps-messaging-service/src/main/java/no/nav/testnav/apps/tpsmessagingservice/config/SecurityConfig.java
+++ b/apps/tps-messaging-service/src/main/java/no/nav/testnav/apps/tpsmessagingservice/config/SecurityConfig.java
@@ -1,7 +1,7 @@
 package no.nav.testnav.apps.tpsmessagingservice.config;
 
 import no.nav.dolly.libs.security.config.DollyHttpSecurity;
-import org.springframework.context.annotation.Bean;
+import  org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;

--- a/libs/reactive-proxy/src/main/java/no/nav/testnav/libs/reactiveproxy/config/SecurityConfig.java
+++ b/libs/reactive-proxy/src/main/java/no/nav/testnav/libs/reactiveproxy/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package no.nav.testnav.libs.reactiveproxy.config;
 
 import lombok.RequiredArgsConstructor;
+import no.nav.dolly.libs.security.config.DollyServerHttpSecurity;
 import no.nav.testnav.libs.reactivesecurity.config.SecureOAuth2ServerToServerConfiguration;
 import no.nav.testnav.libs.reactivesecurity.manager.JwtReactiveAuthenticationManager;
 import org.springframework.context.annotation.Bean;
@@ -11,31 +12,22 @@ import org.springframework.security.config.annotation.web.reactive.EnableWebFlux
 import org.springframework.security.config.web.server.ServerHttpSecurity;
 import org.springframework.security.web.server.SecurityWebFilterChain;
 
-
 @Configuration
 @EnableWebFluxSecurity
 @EnableReactiveMethodSecurity
 @RequiredArgsConstructor
 @Import(SecureOAuth2ServerToServerConfiguration.class)
-public class SecurityConfig {
+class SecurityConfig {
 
     private final JwtReactiveAuthenticationManager jwtReactiveAuthenticationManager;
 
     @Bean
-    public SecurityWebFilterChain springSecurityFilterChain(ServerHttpSecurity httpSecurity) {
+    SecurityWebFilterChain springSecurityFilterChain(ServerHttpSecurity httpSecurity) {
         return httpSecurity
                 .csrf(ServerHttpSecurity.CsrfSpec::disable)
-                .authorizeExchange(authorizeConfig -> authorizeConfig.pathMatchers(
-                        "/internal/**",
-                        "/webjars/**",
-                        "/swagger-resources/**",
-                        "/v3/api-docs/**",
-                        "/swagger-ui/**",
-                        "/swagger",
-                        "/error",
-                        "/swagger-ui.html"
-                ).permitAll().anyExchange().authenticated())
+                .authorizeExchange(DollyServerHttpSecurity.withDefaultHttpRequests())
                 .oauth2ResourceServer(oauth2RSConfig -> oauth2RSConfig.jwt(jwtSpec -> jwtSpec.authenticationManager(jwtReactiveAuthenticationManager)))
                 .build();
     }
+
 }

--- a/libs/reactive-proxy/src/main/java/no/nav/testnav/libs/reactiveproxy/config/SecurityConfig.java
+++ b/libs/reactive-proxy/src/main/java/no/nav/testnav/libs/reactiveproxy/config/SecurityConfig.java
@@ -17,7 +17,7 @@ import org.springframework.security.web.server.SecurityWebFilterChain;
 @EnableReactiveMethodSecurity
 @RequiredArgsConstructor
 @Import(SecureOAuth2ServerToServerConfiguration.class)
-class SecurityConfig {
+public class SecurityConfig {
 
     private final JwtReactiveAuthenticationManager jwtReactiveAuthenticationManager;
 

--- a/libs/reactive-security/src/main/java/no/nav/dolly/libs/security/config/DollyServerHttpSecurity.java
+++ b/libs/reactive-security/src/main/java/no/nav/dolly/libs/security/config/DollyServerHttpSecurity.java
@@ -11,28 +11,8 @@ import org.springframework.security.config.web.server.ServerHttpSecurity;
 public class DollyServerHttpSecurity {
 
     /**
-     * Allow access to certain common endpoints ({@code /error}, {@code /internal}, {@code /swagger} etc.) without authentication, protecting all others.
-     * @return A customizer for use with {@code .authorizeExchange(...)}.
-     */
-    public static Customizer<ServerHttpSecurity.AuthorizeExchangeSpec> withDefaultHttpRequests() {
-        return spec -> spec
-                .pathMatchers(
-                        "/error",
-                        "/internal/**",
-                        "/swagger",
-                        "/swagger-resources/**",
-                        "/swagger-ui.html",
-                        "/swagger-ui/**",
-                        "/v3/api-docs/**",
-                        "/webjars/**")
-                .permitAll()
-                .anyExchange()
-                .authenticated();
-
-    }
-
-    /**
-     * Allow access to certain common endpoints ({@code /error}, {@code /internal}, {@code /swagger} etc.) without authentication, but avoid completing the configuration with {@code .anyExchange().authenticated()}, allowing for overrides.
+     * Allow access to certain common endpoints ({@code /error}, {@code /internal}, {@code /swagger} etc.) without authentication,
+     * but avoid completing the configuration with {@code .anyExchange().authenticated()}, allowing for further configuration.
      * @return A customizer for use with {@code .authorizeExchange(...)}.
      */
     public static Customizer<ServerHttpSecurity.AuthorizeExchangeSpec> allowDefaultHttpRequests() {
@@ -47,6 +27,18 @@ public class DollyServerHttpSecurity {
                         "/v3/api-docs/**",
                         "/webjars/**")
                 .permitAll();
+    }
+
+    /**
+     * Allow access to certain common endpoints ({@code /error}, {@code /internal}, {@code /swagger} etc.) without authentication,
+     * protecting all others.
+     * @return A customizer for use with {@code .authorizeExchange(...)}.
+     */
+    public static Customizer<ServerHttpSecurity.AuthorizeExchangeSpec> withDefaultHttpRequests() {
+        return spec -> {
+            allowDefaultHttpRequests().customize(spec);
+            spec.anyExchange().authenticated();
+        };
     }
 
 }

--- a/libs/reactive-security/src/main/java/no/nav/dolly/libs/security/config/DollyServerHttpSecurity.java
+++ b/libs/reactive-security/src/main/java/no/nav/dolly/libs/security/config/DollyServerHttpSecurity.java
@@ -11,9 +11,8 @@ import org.springframework.security.config.web.server.ServerHttpSecurity;
 public class DollyServerHttpSecurity {
 
     /**
-     * <p>Allow access to certain common endpoints ({@code /error}, {@code /internal}, {@code /swagger} etc.) without authentication, protecting all others.</p>
-     * <p>Customize further as needed after calling this method, if necessary</p>
-     * @return A customizer for use as {@code .authorizeExchange(DollyServerHttpSecurity.withDefaultHttpRequests())}.
+     * Allow access to certain common endpoints ({@code /error}, {@code /internal}, {@code /swagger} etc.) without authentication, protecting all others.
+     * @return A customizer for use with {@code .authorizeExchange(...)}.
      */
     public static Customizer<ServerHttpSecurity.AuthorizeExchangeSpec> withDefaultHttpRequests() {
         return spec -> spec
@@ -30,6 +29,24 @@ public class DollyServerHttpSecurity {
                 .anyExchange()
                 .authenticated();
 
+    }
+
+    /**
+     * Allow access to certain common endpoints ({@code /error}, {@code /internal}, {@code /swagger} etc.) without authentication, but avoid completing the configuration with {@code .anyExchange().authenticated()}, allowing for overrides.
+     * @return A customizer for use with {@code .authorizeExchange(...)}.
+     */
+    public static Customizer<ServerHttpSecurity.AuthorizeExchangeSpec> allowDefaultHttpRequests() {
+        return spec -> spec
+                .pathMatchers(
+                        "/error",
+                        "/internal/**",
+                        "/swagger",
+                        "/swagger-resources/**",
+                        "/swagger-ui.html",
+                        "/swagger-ui/**",
+                        "/v3/api-docs/**",
+                        "/webjars/**")
+                .permitAll();
     }
 
 }

--- a/libs/reactive-security/src/main/java/no/nav/dolly/libs/security/config/DollyServerHttpSecurity.java
+++ b/libs/reactive-security/src/main/java/no/nav/dolly/libs/security/config/DollyServerHttpSecurity.java
@@ -4,40 +4,45 @@ import lombok.experimental.UtilityClass;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.web.server.ServerHttpSecurity;
 
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.stream.Stream;
+
 /**
  * Utility class for configuring Spring Security for a reactive web application.
  */
 @UtilityClass
 public class DollyServerHttpSecurity {
 
-    /**
-     * Allow access to certain common endpoints ({@code /error}, {@code /internal}, {@code /swagger} etc.) without authentication,
-     * but avoid completing the configuration with {@code .anyExchange().authenticated()}, allowing for further configuration.
-     * @return A customizer for use with {@code .authorizeExchange(...)}.
-     */
-    public static Customizer<ServerHttpSecurity.AuthorizeExchangeSpec> allowDefaultHttpRequests() {
-        return spec -> spec
-                .pathMatchers(
-                        "/error",
-                        "/internal/**",
-                        "/swagger",
-                        "/swagger-resources/**",
-                        "/swagger-ui.html",
-                        "/swagger-ui/**",
-                        "/v3/api-docs/**",
-                        "/webjars/**")
-                .permitAll();
-    }
+    private static final String[] OPEN_ENDPOINTS = new String[]{
+            "/error",
+            "/internal/**",
+            "/swagger",
+            "/swagger-resources/**",
+            "/swagger-ui.html",
+            "/swagger-ui/**",
+            "/v3/api-docs/**",
+            "/webjars/**"
+    };
 
     /**
      * Allow access to certain common endpoints ({@code /error}, {@code /internal}, {@code /swagger} etc.) without authentication,
      * protecting all others.
+     *
+     * @param including Additional endpoints to include in the open list.
      * @return A customizer for use with {@code .authorizeExchange(...)}.
      */
-    public static Customizer<ServerHttpSecurity.AuthorizeExchangeSpec> withDefaultHttpRequests() {
+    public static Customizer<ServerHttpSecurity.AuthorizeExchangeSpec> withDefaultHttpRequests(String... including) {
         return spec -> {
-            allowDefaultHttpRequests().customize(spec);
-            spec.anyExchange().authenticated();
+            var endpoints = Optional
+                    .ofNullable(including)
+                    .map(paths -> Stream
+                            .concat(Arrays.stream(OPEN_ENDPOINTS), Arrays.stream(paths))
+                            .toArray(String[]::new))
+                    .orElse(OPEN_ENDPOINTS);
+            spec
+                    .pathMatchers(endpoints).permitAll()
+                    .anyExchange().authenticated();
         };
     }
 

--- a/libs/reactive-security/src/main/java/no/nav/dolly/libs/security/config/DollyServerHttpSecurity.java
+++ b/libs/reactive-security/src/main/java/no/nav/dolly/libs/security/config/DollyServerHttpSecurity.java
@@ -1,0 +1,35 @@
+package no.nav.dolly.libs.security.config;
+
+import lombok.experimental.UtilityClass;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+
+/**
+ * Utility class for configuring Spring Security for a reactive web application.
+ */
+@UtilityClass
+public class DollyServerHttpSecurity {
+
+    /**
+     * <p>Allow access to certain common endpoints ({@code /error}, {@code /internal}, {@code /swagger} etc.) without authentication, protecting all others.</p>
+     * <p>Customize further as needed after calling this method, if necessary</p>
+     * @return A customizer for use as {@code .authorizeExchange(DollyServerHttpSecurity.withDefaultHttpRequests())}.
+     */
+    public static Customizer<ServerHttpSecurity.AuthorizeExchangeSpec> withDefaultHttpRequests() {
+        return spec -> spec
+                .pathMatchers(
+                        "/error",
+                        "/internal/**",
+                        "/swagger",
+                        "/swagger-resources/**",
+                        "/swagger-ui.html",
+                        "/swagger-ui/**",
+                        "/v3/api-docs/**",
+                        "/webjars/**")
+                .permitAll()
+                .anyExchange()
+                .authenticated();
+
+    }
+
+}

--- a/libs/servlet-security/src/main/java/no/nav/dolly/libs/security/config/DollyHttpSecurity.java
+++ b/libs/servlet-security/src/main/java/no/nav/dolly/libs/security/config/DollyHttpSecurity.java
@@ -5,9 +5,17 @@ import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AuthorizeHttpRequestsConfigurer;
 
+/**
+ * Utility class for configuring Spring Security for a servlet web application.
+ */
 @UtilityClass
 public class DollyHttpSecurity {
 
+    /**
+     * <p>Allow access to certain common endpoints ({@code /error}, {@code /internal}, {@code /swagger} etc.) without authentication, protecting all others.</p>
+     * <p>Customize further as needed after calling this method, if necessary.</p>
+     * @return A customizer for use as {@code .authorizeHttpRequests(DollyHttpSecurity.withDefaultHttpRequests())}.
+     */
     public static Customizer<AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry> withDefaultHttpRequests() {
         return registry -> registry
                 .requestMatchers(

--- a/libs/servlet-security/src/main/java/no/nav/dolly/libs/security/config/DollyHttpSecurity.java
+++ b/libs/servlet-security/src/main/java/no/nav/dolly/libs/security/config/DollyHttpSecurity.java
@@ -5,42 +5,45 @@ import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AuthorizeHttpRequestsConfigurer;
 
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.stream.Stream;
+
 /**
  * Utility class for configuring Spring Security for a servlet web application.
  */
 @UtilityClass
 public class DollyHttpSecurity {
 
-    /**
-     * Allow access to certain common endpoints ({@code /error}, {@code /internal}, {@code /swagger} etc.) without authentication,
-     * but avoid completing the configuration with {@code .anyRequest().fullyAuthenticated()}, allowing for further configuration.
-     *
-     * @return A customizer for use with {@code .authorizeHttpRequests(...)}.
-     */
-    public static Customizer<AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry> allowDefaultHttpRequests() {
-        return registry -> registry
-                .requestMatchers(
-                        "/error",
-                        "/internal/**",
-                        "/swagger",
-                        "/swagger-resources/**",
-                        "/swagger-ui.html",
-                        "/swagger-ui/**",
-                        "/v3/api-docs/**",
-                        "/webjars/**")
-                .permitAll();
-    }
+    private static final String[] OPEN_ENDPOINTS = new String[]{
+            "/error",
+            "/internal/**",
+            "/swagger",
+            "/swagger-resources/**",
+            "/swagger-ui.html",
+            "/swagger-ui/**",
+            "/v3/api-docs/**",
+            "/webjars/**"
+    };
 
     /**
      * Allow access to certain common endpoints ({@code /error}, {@code /internal}, {@code /swagger} etc.) without authentication,
      * protecting all others.
      *
+     * @param including Additional endpoints to include in the open list.
      * @return A customizer for use with {@code .authorizeHttpRequests(...)}.
      */
-    public static Customizer<AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry> withDefaultHttpRequests() {
+    public static Customizer<AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry> withDefaultHttpRequests(String... including) {
         return registry -> {
-            allowDefaultHttpRequests().customize(registry);
-            registry.anyRequest().fullyAuthenticated();
+            var endpoints = Optional
+                    .ofNullable(including)
+                    .map(paths -> Stream
+                            .concat(Arrays.stream(OPEN_ENDPOINTS), Arrays.stream(paths))
+                            .toArray(String[]::new))
+                    .orElse(OPEN_ENDPOINTS);
+            registry
+                    .requestMatchers(endpoints).permitAll()
+                    .anyRequest().fullyAuthenticated();
         };
     }
 

--- a/libs/servlet-security/src/main/java/no/nav/dolly/libs/security/config/DollyHttpSecurity.java
+++ b/libs/servlet-security/src/main/java/no/nav/dolly/libs/security/config/DollyHttpSecurity.java
@@ -12,10 +12,12 @@ import org.springframework.security.config.annotation.web.configurers.AuthorizeH
 public class DollyHttpSecurity {
 
     /**
-     * Allow access to certain common endpoints ({@code /error}, {@code /internal}, {@code /swagger} etc.) without authentication, protecting all others.
-     * @return A customizer for use as {@code .authorizeHttpRequests(DollyHttpSecurity.withDefaultHttpRequests())}.
+     * Allow access to certain common endpoints ({@code /error}, {@code /internal}, {@code /swagger} etc.) without authentication,
+     * but avoid completing the configuration with {@code .anyRequest().fullyAuthenticated()}, allowing for further configuration.
+     *
+     * @return A customizer for use with {@code .authorizeHttpRequests(...)}.
      */
-    public static Customizer<AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry> withDefaultHttpRequests() {
+    public static Customizer<AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry> allowDefaultHttpRequests() {
         return registry -> registry
                 .requestMatchers(
                         "/error",
@@ -26,9 +28,20 @@ public class DollyHttpSecurity {
                         "/swagger-ui/**",
                         "/v3/api-docs/**",
                         "/webjars/**")
-                .permitAll()
-                .anyRequest()
-                .fullyAuthenticated();
+                .permitAll();
+    }
+
+    /**
+     * Allow access to certain common endpoints ({@code /error}, {@code /internal}, {@code /swagger} etc.) without authentication,
+     * protecting all others.
+     *
+     * @return A customizer for use with {@code .authorizeHttpRequests(...)}.
+     */
+    public static Customizer<AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry> withDefaultHttpRequests() {
+        return registry -> {
+            allowDefaultHttpRequests().customize(registry);
+            registry.anyRequest().fullyAuthenticated();
+        };
     }
 
 }

--- a/libs/servlet-security/src/main/java/no/nav/dolly/libs/security/config/DollyHttpSecurity.java
+++ b/libs/servlet-security/src/main/java/no/nav/dolly/libs/security/config/DollyHttpSecurity.java
@@ -12,8 +12,7 @@ import org.springframework.security.config.annotation.web.configurers.AuthorizeH
 public class DollyHttpSecurity {
 
     /**
-     * <p>Allow access to certain common endpoints ({@code /error}, {@code /internal}, {@code /swagger} etc.) without authentication, protecting all others.</p>
-     * <p>Customize further as needed after calling this method, if necessary.</p>
+     * Allow access to certain common endpoints ({@code /error}, {@code /internal}, {@code /swagger} etc.) without authentication, protecting all others.
      * @return A customizer for use as {@code .authorizeHttpRequests(DollyHttpSecurity.withDefaultHttpRequests())}.
      */
     public static Customizer<AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry> withDefaultHttpRequests() {

--- a/libs/servlet-security/src/main/java/no/nav/dolly/libs/security/config/DollyHttpSecurity.java
+++ b/libs/servlet-security/src/main/java/no/nav/dolly/libs/security/config/DollyHttpSecurity.java
@@ -27,8 +27,7 @@ public class DollyHttpSecurity {
                         "/v3/api-docs/**",
                         "/webjars/**")
                 .permitAll()
-                .requestMatchers(
-                        "/api/**")
+                .anyRequest()
                 .fullyAuthenticated();
     }
 


### PR DESCRIPTION
Lagt til ny `DollyServerHttpSecurity` for WebFlux, tilsvarende `DollyHttpSecurity` for server.

Har også oppdatert sistnevnte for lettere bruk når flere endepunkter skal åpnes enn defaults. Der dependencies tillater er `DollyServerHttpSecurity` eller `DollyHttpSecurity` lagt til.