### PR TITLE
feature/importer-historisk-relatert-person

### DIFF
--- a/apps/dolly-frontend/src/main/js/src/pages/gruppe/PersonVisning/PersonVisning.tsx
+++ b/apps/dolly-frontend/src/main/js/src/pages/gruppe/PersonVisning/PersonVisning.tsx
@@ -348,10 +348,8 @@ export default ({
 		const relatertePersoner = []
 
 		data.pdl?.hentPerson?.sivilstand
-			?.filter(
-				(siv) =>
-					!siv?.metadata?.historisk &&
-					['GIFT', 'REGISTRERT_PARTNER', 'SEPARERT', 'SEPARERT_PARTNER'].includes(siv?.type),
+			?.filter((siv) =>
+				['GIFT', 'REGISTRERT_PARTNER', 'SEPARERT', 'SEPARERT_PARTNER'].includes(siv?.type),
 			)
 			?.forEach((person) => {
 				relatertePersoner.push({
@@ -370,10 +368,8 @@ export default ({
 			})
 
 		data.pdl?.hentPerson?.forelderBarnRelasjon
-			?.filter(
-				(forelderBarn) =>
-					!forelderBarn?.metadata?.historisk &&
-					['BARN', 'MOR', 'MEDMOR', 'FAR'].includes(forelderBarn?.relatertPersonsRolle),
+			?.filter((forelderBarn) =>
+				['BARN', 'MOR', 'MEDMOR', 'FAR'].includes(forelderBarn?.relatertPersonsRolle),
 			)
 			?.forEach((person) => {
 				relatertePersoner.push({


### PR DESCRIPTION
Fjernet filtrering på historiske forhold ved import av relaterte personer, slik at man f.eks. kan importere og sette fraskilt partner som forelder til barn.