### PR TITLE
Remove unused replyURLs from application configurations

### DIFF
--- a/apps/dolly-frontend/config.unstable.yml
+++ b/apps/dolly-frontend/config.unstable.yml
@@ -23,10 +23,6 @@ spec:
       allowAllUsers: true
       enabled: true
       tenant: nav.no
-      replyURLs:
-        - https://dolly-frontend-dev-unstable.intern.dev.nav.no/login/oauth2/code/aad
-        - http://localhost:8020/login/oauth2/code/aad
-        - http://localhost:3000/login/oauth2/code/aad
   accessPolicy:
     outbound:
       rules:

--- a/apps/dolly-frontend/config.yml
+++ b/apps/dolly-frontend/config.yml
@@ -23,8 +23,6 @@ spec:
       allowAllUsers: true
       enabled: true
       tenant: nav.no
-      replyURLs:
-        - "https://dolly.ekstern.dev.nav.no/login/oauth2/code/aad"
   replicas:
     min: 1
     max: 2

--- a/apps/oversikt-frontend/config.yml
+++ b/apps/oversikt-frontend/config.yml
@@ -17,9 +17,6 @@ spec:
     application:
       enabled: true
       tenant: nav.no
-      replyURLs:
-        - "https://testnav-oversikt.intern.dev.nav.no/login/oauth2/code/aad"
-        - "http://localhost:8080/login/oauth2/code/aad"
       claims:
         groups:
           - id: 9c7efec1-1599-4216-a67e-6fd53a6a951c

--- a/apps/tps-messaging-frontend/config.yml
+++ b/apps/tps-messaging-frontend/config.yml
@@ -14,9 +14,6 @@ spec:
     application:
       enabled: true
       tenant: nav.no
-      replyURLs:
-        - "https://testnav-tps-messaging.ekstern.dev.nav.no/login/oauth2/code/aad"
-        - "http://localhost:8080/login/oauth2/code/aad"
       claims:
         groups:
           - id: 9c7efec1-1599-4216-a67e-6fd53a6a951c # Dolly team


### PR DESCRIPTION
The replyURLs entries were removed from multiple frontend app configs as they are no longer required. This cleanup reduces redundancy and aligns configurations with the current application requirements. #deploy-test-frontend
#deploy-oversikt-frontend