### PR TITLE
change/github_actions_versions_bump

### DIFF
--- a/.github/workflows/common.integration-test.yml
+++ b/.github/workflows/common.integration-test.yml
@@ -26,7 +26,7 @@ jobs:
           java-version: 21
           distribution: 'temurin'
       - name: "Gradle"
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v4
         with:
           cache-read-only: false
       - name: "Build"
@@ -44,7 +44,7 @@ jobs:
           echo Wait on service...
           bash -c 'while [[ "$(curl --connect-timeout 2 -s -o /dev/null -w ''%{http_code}'' ${{ inputs.healthcheck }})" != "200" ]]; do echo ...; sleep 5; done; echo Service is up;'
       - name: "Run integration tests"
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v4
         with:
           cache-read-only: false
       - name: "Build"

--- a/.github/workflows/common.workflow.backend.yml
+++ b/.github/workflows/common.workflow.backend.yml
@@ -82,7 +82,7 @@ jobs:
           java-version: 21
       - name: "Gradle"
         id: gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v4
         with:
           cache-read-only: false
       - name: "Build"

--- a/.github/workflows/common.workflow.frontend.yml
+++ b/.github/workflows/common.workflow.frontend.yml
@@ -114,7 +114,7 @@ jobs:
           java-version: 21
       - name: "Gradle"
         id: gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v4
         with:
           cache-read-only: false
         env:

--- a/.github/workflows/common.workflow.libs.backend.yml
+++ b/.github/workflows/common.workflow.libs.backend.yml
@@ -47,7 +47,7 @@ jobs:
           java-version: 21
       - name: "Gradle"
         id: gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v4
         with:
           cache-read-only: false
       - name: "Build"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
           git config --global user.email "dolly@nav.no"
           git config --global user.name "$GITHUB_ACTOR"
       - name: "Gradle"
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v4
       - name: "Create version"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/scheduled.scan.markdown.yml
+++ b/.github/workflows/scheduled.scan.markdown.yml
@@ -19,14 +19,14 @@ jobs:
       - name: "Checkout"
         uses: actions/checkout@v4
       - name: "Markdown"
-        uses: gaurav-nelson/github-action-markdown-link-check@v1
+        uses: tcort/github-action-markdown-link-check@v1
         with:
           folder-path: ${{ inputs.working-directory }}
           config-file: .github/workflows/scheduled.scan.markdown.json
           use-quiet-mode: yes
       - name: "Slack"
         if: ${{ failure() }}
-        uses: slackapi/slack-github-action@v1.25.0
+        uses: slackapi/slack-github-action@v2.1.0
         with:
           payload: |
             {

--- a/.github/workflows/scheduled.scan.markdown.yml
+++ b/.github/workflows/scheduled.scan.markdown.yml
@@ -8,9 +8,6 @@ on:
         description: "Directory to scan, e.g. apps/dolly-backend. Defaults to whole repo."
         default: "."
         required: true
-    secrets:
-      SLACK_DEAD_URLS_WEBHOOK_URL:
-        required: true
 
 jobs:
   markdown:


### PR DESCRIPTION
Bumper gradle/actions/setup-gradle til v4 i et forsøk på å løse deprecated cache-bruk.

Også noen mindre endringer i andre actions pga. deprecation/version bump.