### PR TITLE
Fix: Add kodeverknavn to KodeverkBetydningerResponse and implement fi…

### DIFF
--- a/apps/kodeverk-service/src/main/java/no/nav/testnav/kodeverkservice/consumer/KodeverkSelectorService.java
+++ b/apps/kodeverk-service/src/main/java/no/nav/testnav/kodeverkservice/consumer/KodeverkSelectorService.java
@@ -3,6 +3,7 @@ package no.nav.testnav.kodeverkservice.consumer;
 import lombok.RequiredArgsConstructor;
 import no.nav.testnav.kodeverkservice.service.KodeverkService;
 import no.nav.testnav.kodeverkservice.utility.TemaHistarkUtility;
+import no.nav.testnav.kodeverkservice.utility.VergemaalFylkesembeterUtility;
 import no.nav.testnav.kodeverkservice.utility.YrkesklassifiseringUtility;
 import no.nav.testnav.libs.dto.kodeverkservice.v1.KodeverkAdjustedDTO;
 import no.nav.testnav.libs.dto.kodeverkservice.v1.KodeverkDTO;
@@ -10,6 +11,7 @@ import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 
 import static no.nav.testnav.kodeverkservice.utility.CommonKeysAndUtils.TEMAHISTARK;
+import static no.nav.testnav.kodeverkservice.utility.CommonKeysAndUtils.VERGEMAAL_FYLKESEMBETER;
 import static no.nav.testnav.kodeverkservice.utility.CommonKeysAndUtils.YRKESKLASSIFISERING;
 
 @Service
@@ -23,6 +25,7 @@ public class KodeverkSelectorService {
         return switch (kodeverk) {
             case TEMAHISTARK -> Mono.just(TemaHistarkUtility.getKodeverk());
             case YRKESKLASSIFISERING -> Mono.just(YrkesklassifiseringUtility.getKodeverk());
+            case VERGEMAAL_FYLKESEMBETER -> Mono.just(VergemaalFylkesembeterUtility.getKodeverk());
             default -> kodeverkService.getKodeverkMap(kodeverk);
         };
     }
@@ -32,6 +35,7 @@ public class KodeverkSelectorService {
         return switch (kodeverkNavn) {
             case TEMAHISTARK -> Mono.just(TemaHistarkUtility.getKodeverkAdjusted());
             case YRKESKLASSIFISERING -> Mono.just(YrkesklassifiseringUtility.getKodeverkAdjusted());
+            case VERGEMAAL_FYLKESEMBETER -> Mono.just(VergemaalFylkesembeterUtility.getKodeverkAdjusted());
             default -> kodeverkService.getKodeverkByName(kodeverkNavn);
         };
     }

--- a/apps/kodeverk-service/src/main/java/no/nav/testnav/kodeverkservice/utility/CommonKeysAndUtils.java
+++ b/apps/kodeverk-service/src/main/java/no/nav/testnav/kodeverkservice/utility/CommonKeysAndUtils.java
@@ -13,6 +13,7 @@ public final class CommonKeysAndUtils {
 
     public static final String TEMAHISTARK = "TemaHistark";
     public static final String YRKESKLASSIFISERING = "Yrkesklassifisering";
+    public static final String VERGEMAAL_FYLKESEMBETER = "Vergemål_Fylkesmannsembeter";
 
     public static final LocalDate GYLDIG_FRA = LocalDate.of(1900, 1, 1);
     public static final LocalDate GYLDIG_TIL = LocalDate.of(9999, 12, 31);

--- a/apps/kodeverk-service/src/main/java/no/nav/testnav/kodeverkservice/utility/TemaHistarkUtility.java
+++ b/apps/kodeverk-service/src/main/java/no/nav/testnav/kodeverkservice/utility/TemaHistarkUtility.java
@@ -10,7 +10,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static no.nav.testnav.kodeverkservice.utility.CommonKeysAndUtils.*;
+import static no.nav.testnav.kodeverkservice.utility.CommonKeysAndUtils.GYLDIG_FRA;
+import static no.nav.testnav.kodeverkservice.utility.CommonKeysAndUtils.GYLDIG_TIL;
+import static no.nav.testnav.kodeverkservice.utility.CommonKeysAndUtils.TEMAHISTARK;
 
 @UtilityClass
 public class TemaHistarkUtility {

--- a/apps/kodeverk-service/src/main/java/no/nav/testnav/kodeverkservice/utility/VergemaalFylkesembeterUtility.java
+++ b/apps/kodeverk-service/src/main/java/no/nav/testnav/kodeverkservice/utility/VergemaalFylkesembeterUtility.java
@@ -1,0 +1,63 @@
+package no.nav.testnav.kodeverkservice.utility;
+
+import lombok.experimental.UtilityClass;
+import no.nav.testnav.libs.dto.kodeverkservice.v1.KodeverkAdjustedDTO;
+import no.nav.testnav.libs.dto.kodeverkservice.v1.KodeverkDTO;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static no.nav.testnav.kodeverkservice.utility.CommonKeysAndUtils.GYLDIG_FRA;
+import static no.nav.testnav.kodeverkservice.utility.CommonKeysAndUtils.GYLDIG_TIL;
+import static no.nav.testnav.kodeverkservice.utility.CommonKeysAndUtils.VERGEMAAL_FYLKESEMBETER;
+
+@UtilityClass
+public class VergemaalFylkesembeterUtility {
+
+    private static final List<Map<String, String>> fylkesembeter = new ArrayList<>();
+
+    static {
+        fylkesembeter.add(Map.of("FMAV", "Statsforvalter i Agder"));
+        fylkesembeter.add(Map.of("FMIN", "Statsforvalter i Innlandet"));
+        fylkesembeter.add(Map.of("FMMR", "Statsforvalter i Møre og Romsdal"));
+        fylkesembeter.add(Map.of("FMNO", "Statsforvalter i Nordland"));
+        fylkesembeter.add(Map.of("FMOV", "Statsforvalter i Østfold, Buskerud, Oslo og Akershus"));
+        fylkesembeter.add(Map.of("FMRO", "Statsforvalter i Rogaland"));
+        fylkesembeter.add(Map.of("FMTF", "Statsforvalter i Troms og Finnmark"));
+        fylkesembeter.add(Map.of("FMTL", "Statsforvalter i Trøndelag"));
+        fylkesembeter.add(Map.of("FMVL", "Statsforvaltar i Vestland"));
+        fylkesembeter.add(Map.of("FMVT", "Statsforvalter i Vestfold og Telemark"));
+
+    }
+
+    public static KodeverkDTO getKodeverk() {
+
+        return KodeverkDTO.builder()
+                .kodeverknavn(VERGEMAAL_FYLKESEMBETER)
+                .kodeverk(fylkesembeter.stream()
+                        .map(Map::entrySet)
+                        .flatMap(Collection::stream)
+                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)))
+                .build();
+    }
+
+    public static KodeverkAdjustedDTO getKodeverkAdjusted() {
+
+        return KodeverkAdjustedDTO.builder()
+                .name(VERGEMAAL_FYLKESEMBETER)
+                .koder(fylkesembeter.stream()
+                        .map(Map::entrySet)
+                        .flatMap(Collection::stream)
+                        .map(e -> KodeverkAdjustedDTO.KodeAdjusted.builder()
+                                .value(e.getKey())
+                                .label(e.getValue())
+                                .gyldigFra(GYLDIG_FRA)
+                                .gyldigTil(GYLDIG_TIL)
+                                .build())
+                        .toList())
+                .build();
+    }
+}

--- a/apps/kodeverk-service/src/main/java/no/nav/testnav/kodeverkservice/utility/VergemaalFylkesembeterUtility.java
+++ b/apps/kodeverk-service/src/main/java/no/nav/testnav/kodeverkservice/utility/VergemaalFylkesembeterUtility.java
@@ -4,7 +4,6 @@ import lombok.experimental.UtilityClass;
 import no.nav.testnav.libs.dto.kodeverkservice.v1.KodeverkAdjustedDTO;
 import no.nav.testnav.libs.dto.kodeverkservice.v1.KodeverkDTO;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -17,21 +16,19 @@ import static no.nav.testnav.kodeverkservice.utility.CommonKeysAndUtils.VERGEMAA
 @UtilityClass
 public class VergemaalFylkesembeterUtility {
 
-    private static final List<Map<String, String>> fylkesembeter = new ArrayList<>();
+    private static final List<Map<String, String>> fylkesembeter = List.of(
 
-    static {
-        fylkesembeter.add(Map.of("FMAV", "Statsforvalter i Agder"));
-        fylkesembeter.add(Map.of("FMIN", "Statsforvalter i Innlandet"));
-        fylkesembeter.add(Map.of("FMMR", "Statsforvalter i Møre og Romsdal"));
-        fylkesembeter.add(Map.of("FMNO", "Statsforvalter i Nordland"));
-        fylkesembeter.add(Map.of("FMOV", "Statsforvalter i Østfold, Buskerud, Oslo og Akershus"));
-        fylkesembeter.add(Map.of("FMRO", "Statsforvalter i Rogaland"));
-        fylkesembeter.add(Map.of("FMTF", "Statsforvalter i Troms og Finnmark"));
-        fylkesembeter.add(Map.of("FMTL", "Statsforvalter i Trøndelag"));
-        fylkesembeter.add(Map.of("FMVL", "Statsforvaltar i Vestland"));
-        fylkesembeter.add(Map.of("FMVT", "Statsforvalter i Vestfold og Telemark"));
-
-    }
+            Map.of("FMAV", "Statsforvalter i Agder"),
+            Map.of("FMIN", "Statsforvalter i Innlandet"),
+            Map.of("FMMR", "Statsforvalter i Møre og Romsdal"),
+            Map.of("FMNO", "Statsforvalter i Nordland"),
+            Map.of("FMOV", "Statsforvalter i Østfold, Buskerud, Oslo og Akershus"),
+            Map.of("FMRO", "Statsforvalter i Rogaland"),
+            Map.of("FMTF", "Statsforvalter i Troms og Finnmark"),
+            Map.of("FMTL", "Statsforvalter i Trøndelag"),
+            Map.of("FMVL", "Statsforvaltar i Vestland"),
+            Map.of("FMVT", "Statsforvalter i Vestfold og Telemark")
+    );
 
     public static KodeverkDTO getKodeverk() {
 

--- a/apps/kodeverk-service/src/main/java/no/nav/testnav/kodeverkservice/utility/YrkesklassifiseringUtility.java
+++ b/apps/kodeverk-service/src/main/java/no/nav/testnav/kodeverkservice/utility/YrkesklassifiseringUtility.java
@@ -11,7 +11,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static no.nav.testnav.kodeverkservice.utility.CommonKeysAndUtils.*;
+import static no.nav.testnav.kodeverkservice.utility.CommonKeysAndUtils.GYLDIG_FRA;
+import static no.nav.testnav.kodeverkservice.utility.CommonKeysAndUtils.GYLDIG_TIL;
+import static no.nav.testnav.kodeverkservice.utility.CommonKeysAndUtils.YRKESKLASSIFISERING;
 
 @UtilityClass
 public class YrkesklassifiseringUtility {
@@ -19,7 +21,6 @@ public class YrkesklassifiseringUtility {
     private static final List<Map<String, String>> yrkesklassifisering = new ArrayList<>();
 
     static {
-
         yrkesklassifisering.add(Map.of("0", "Militære yrker og uoppgitt"));
         yrkesklassifisering.add(Map.of("1", "Ledere"));
         yrkesklassifisering.add(Map.of("2", "Akademiske yrker"));


### PR DESCRIPTION
This pull request introduces support for a new `Vergemål_Fylkesmannsembeter` kodeverk in the `kodeverk-service` application. The changes include adding a new utility class, updating existing methods to handle the new kodeverk, and defining constants for its name and validity period.

### Addition of `Vergemål_Fylkesmannsembeter` Kodeverk:

* **New Utility Class**: Added `VergemaalFylkesembeterUtility` to define and manage the `Vergemål_Fylkesmannsembeter` kodeverk, including its mappings and validity periods.
* **Constants Update**: Added `VERGEMAAL_FYLKESEMBETER` as a new constant in `CommonKeysAndUtils` for the kodeverk name.

### Integration with Existing Services:

* **`getKodeverkMap` Method**: Updated `KodeverkSelectorService` to handle `Vergemål_Fylkesmannsembeter` in the `getKodeverkMap` method.
* **`getKodeverkByName` Method**: Updated `KodeverkSelectorService` to handle `Vergemål_Fylkesmannsembeter` in the `getKodeverkByName` method.
* **Imports and Static Keys**: Added necessary imports and static keys for `VergemaalFylkesembeterUtility` and its associated constant in `KodeverkSelectorService`.…ltering logic for specific entries