### PR TITLE
Bugfix/eier av gruppe

### DIFF
--- a/apps/dolly-backend/src/main/java/no/nav/dolly/mapper/strategy/TestgruppeMedBestillingIdMappingStrategy.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/mapper/strategy/TestgruppeMedBestillingIdMappingStrategy.java
@@ -13,7 +13,6 @@ import org.springframework.stereotype.Component;
 
 import java.util.Comparator;
 
-import static java.util.Objects.nonNull;
 import static org.apache.commons.lang3.BooleanUtils.isTrue;
 
 @Component
@@ -56,9 +55,6 @@ public class TestgruppeMedBestillingIdMappingStrategy implements MappingStrategy
                                         .build())
                                 .toList());
                         testgruppeMedBestillingId.setErLaast(isTrue(testgruppe.getErLaast()));
-                        if (nonNull(context) && nonNull(context.getProperty("brukerId"))) {
-                            testgruppeMedBestillingId.setErEierAvGruppe(testgruppe.getOpprettetAv().getBrukerId().equals(context.getProperty("brukerId")));
-                        }
                     }
                 })
                 .register();

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/provider/TestgruppeController.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/provider/TestgruppeController.java
@@ -87,7 +87,7 @@ public class TestgruppeController {
     @PutMapping(value = "/{gruppeId}/tilknytning/{brukerId}")
     @Operation(description = "Endre tilknytning av gruppe")
     public void endreGruppeTilknytning(@PathVariable("gruppeId") Long gruppeId,
-                                             @PathVariable("brukerId") String brukerId) {
+                                       @PathVariable("brukerId") String brukerId) {
 
         testgruppeService.endreGruppeTilknytning(gruppeId, brukerId);
     }
@@ -112,7 +112,6 @@ public class TestgruppeController {
         return mapperFacade.map(testgruppeService.fetchTestgruppeById(gruppe.getId()), RsTestgruppeMedBestillingId.class);
     }
 
-    //    @Cacheable(CACHE_GRUPPE)
     @GetMapping("/{gruppeId}/page/{pageNo}")
     @Operation(description = "Hent paginert testgruppe")
     public RsTestgruppeMedBestillingId getPaginertTestgruppe(@PathVariable("gruppeId") Long gruppeId,
@@ -124,7 +123,7 @@ public class TestgruppeController {
         return testgruppeService.fetchPaginertTestgruppeById(gruppeId, pageNo, pageSize, sortKolonne, sortRetning);
     }
 
-    //    @Cacheable(CACHE_GRUPPE)
+    @Cacheable(CACHE_GRUPPE)
     @GetMapping("/{gruppeId}")
     @Operation(description = "Hent testgruppe")
     public RsTestgruppeMedBestillingId getTestgruppe(@PathVariable("gruppeId") Long gruppeId) {

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/provider/TestgruppeController.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/provider/TestgruppeController.java
@@ -112,7 +112,7 @@ public class TestgruppeController {
         return mapperFacade.map(testgruppeService.fetchTestgruppeById(gruppe.getId()), RsTestgruppeMedBestillingId.class);
     }
 
-    @Cacheable(CACHE_GRUPPE)
+    //    @Cacheable(CACHE_GRUPPE)
     @GetMapping("/{gruppeId}/page/{pageNo}")
     @Operation(description = "Hent paginert testgruppe")
     public RsTestgruppeMedBestillingId getPaginertTestgruppe(@PathVariable("gruppeId") Long gruppeId,

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/provider/TestgruppeController.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/provider/TestgruppeController.java
@@ -124,7 +124,7 @@ public class TestgruppeController {
         return testgruppeService.fetchPaginertTestgruppeById(gruppeId, pageNo, pageSize, sortKolonne, sortRetning);
     }
 
-    @Cacheable(CACHE_GRUPPE)
+    //    @Cacheable(CACHE_GRUPPE)
     @GetMapping("/{gruppeId}")
     @Operation(description = "Hent testgruppe")
     public RsTestgruppeMedBestillingId getTestgruppe(@PathVariable("gruppeId") Long gruppeId) {

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/service/TestgruppeService.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/service/TestgruppeService.java
@@ -3,7 +3,6 @@ package no.nav.dolly.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import ma.glasnost.orika.MapperFacade;
-import ma.glasnost.orika.MappingContext;
 import no.nav.dolly.bestilling.pdldata.PdlDataConsumer;
 import no.nav.dolly.consumer.brukerservice.BrukerServiceConsumer;
 import no.nav.dolly.consumer.brukerservice.dto.TilgangDTO;
@@ -97,11 +96,11 @@ public class TestgruppeService {
                 .build();
 
 
-        var context = new MappingContext.Factory().getContext();
-        context.setProperty("brukerId", bruker.getBrukerId());
-
-        var rsTestgruppe = mapperFacade.map(testgruppe, RsTestgruppeMedBestillingId.class, context);
+        var rsTestgruppe = mapperFacade.map(testgruppe, RsTestgruppeMedBestillingId.class);
         rsTestgruppe.setAntallIdenter((int) testidentPage.getTotalElements());
+        System.out.println("Gruppe opprettet av bruker: " + rsTestgruppe.getOpprettetAv().getBrukerId());
+        System.out.println("Gjeldende brukerId: " + bruker.getBrukerId());
+        rsTestgruppe.setErEierAvGruppe(bruker.getBrukerId().equals(rsTestgruppe.getOpprettetAv().getBrukerId()));
 
         var bestillingerPage = bestillingService.getBestillingerFromGruppeIdPaginert(testgruppe.getId(), 0, 1);
         rsTestgruppe.setAntallBestillinger(bestillingerPage.getTotalElements());

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/service/TestgruppeService.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/service/TestgruppeService.java
@@ -98,8 +98,6 @@ public class TestgruppeService {
 
         var rsTestgruppe = mapperFacade.map(testgruppe, RsTestgruppeMedBestillingId.class);
         rsTestgruppe.setAntallIdenter((int) testidentPage.getTotalElements());
-        System.out.println("Gruppe opprettet av bruker: " + rsTestgruppe.getOpprettetAv().getBrukerId());
-        System.out.println("Gjeldende brukerId: " + bruker.getBrukerId());
         rsTestgruppe.setErEierAvGruppe(bruker.getBrukerId().equals(rsTestgruppe.getOpprettetAv().getBrukerId()));
 
         var bestillingerPage = bestillingService.getBestillingerFromGruppeIdPaginert(testgruppe.getId(), 0, 1);


### PR DESCRIPTION
This pull request refactors the `TestgruppeMedBestillingIdMappingStrategy` and related classes in the `dolly-backend` module to simplify the mapping logic and remove unnecessary dependencies. Key changes include eliminating the use of `MappingContext` and refactoring the logic for determining group ownership.

### Refactoring of mapping logic:
* Removed the use of `MappingContext` in `TestgruppeMedBestillingIdMappingStrategy` and `TestgruppeService`. The `brukerId` property is now directly compared during mapping without relying on the context. (`[[1]](diffhunk://#diff-7db2b8f0a24479f3e27b5086ca7c6fb767ee15245f0a5aafa9ac89b7c4c31f1fL59-L61)`, `[[2]](diffhunk://#diff-61acd1c7b46114201a62fc8a4010d1284c889ae1b5fa308c5562a1e34092bb43L100-R101)`)
* Simplified the logic for setting `erEierAvGruppe` in `TestgruppeService` by directly comparing `brukerId` values. (`[apps/dolly-backend/src/main/java/no/nav/dolly/service/TestgruppeService.javaL100-R101](diffhunk://#diff-61acd1c7b46114201a62fc8a4010d1284c889ae1b5fa308c5562a1e34092bb43L100-R101)`)

### Code cleanup:
* Removed unused imports, including `MappingContext` and `nonNull`, to improve code readability. (`[[1]](diffhunk://#diff-7db2b8f0a24479f3e27b5086ca7c6fb767ee15245f0a5aafa9ac89b7c4c31f1fL16)`, `[[2]](diffhunk://#diff-61acd1c7b46114201a62fc8a4010d1284c889ae1b5fa308c5562a1e34092bb43L6)`)

### API adjustments:
* Removed the `@Cacheable` annotation from the `getPaginertTestgruppe` endpoint in `TestgruppeController`, likely to address caching concerns or improve performance. (`[apps/dolly-backend/src/main/java/no/nav/dolly/provider/TestgruppeController.javaL115](diffhunk://#diff-344b5688c24aac01fff3fd0a46c42b1912e801fffc3e7d56357c10dd17c7fc1bL115)`)