### PR TITLE
Legg til historikk-felt i AlderspensjonVedtakDTO og oppdater relatert…

### DIFF
--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/pensjonforvalter/domain/AlderspensjonVedtakDTO.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/pensjonforvalter/domain/AlderspensjonVedtakDTO.java
@@ -1,6 +1,7 @@
 package no.nav.dolly.bestilling.pensjonforvalter.domain;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
@@ -8,6 +9,8 @@ import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 @Data
 @SuperBuilder
@@ -21,4 +24,7 @@ public class AlderspensjonVedtakDTO extends AlderspensjonVedtakRequest {
 
     private LocalDate datoForrigeGraderteUttak;
     private Integer nyUttaksgrad;
+
+    @Builder.Default
+    private List<AlderspensjonVedtakDTO> historikk = new ArrayList<>();
 }

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/pensjonforvalter/service/PensjonPersondataService.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/pensjonforvalter/service/PensjonPersondataService.java
@@ -129,10 +129,11 @@ public class PensjonPersondataService {
                         .flatMapMany(tuple -> {
                             if (isRevurderingValid(tuple.getT1(), tuple.getT2())) {
                                 return pensjonforvalterConsumer.lagreRevurderingVedtak(tuple.getT1())
-                                        .flatMap(response ->
+                                        .flatMap(response -> isNoMatch(tuple.getT2(), tuple.getT1()) ?
                                                 pensjonforvalterHelper.saveTransaksjonId(ident, miljoe,
                                                                 bestilling.getId(), SystemTyper.PEN_AP_REVURDERING, tuple.getT1())
-                                                        .thenReturn(response));
+                                                        .thenReturn(response) :
+                                                Mono.just(response));
                             } else {
 
                                 return miscRevurderingResponse(tuple.getT1(), tuple.getT2(), miljoe, isUpdateEndre);
@@ -140,24 +141,28 @@ public class PensjonPersondataService {
                         }));
     }
 
+    private static boolean isNoMatch(AlderspensjonVedtakDTO response, RevurderingVedtakRequest request) {
+
+        return response.getHistorikk().stream()
+                .noneMatch(historikk ->
+                        historikk.getFom().equals(request.getFom()));
+    }
+
     private static boolean isRevurderingValid(RevurderingVedtakRequest request, AlderspensjonVedtakDTO response) {
 
-        var eksisterendeFom = nonNull(response.getFom()) ? response.getFom() : response.getIverksettelsesdato();
-
-        return nonNull(request.getFom()) && request.getFom().isAfter(eksisterendeFom);
+        return nonNull(request.getFom()) &&
+                request.getFom().isAfter(response.getFom());
     }
 
     private static Mono<PensjonforvalterResponse> miscRevurderingResponse(RevurderingVedtakRequest request,
                                                                           AlderspensjonVedtakDTO response, String miljoe,
                                                                           boolean isUpdateEndre) {
 
-        var eksisterendeFom = nonNull(response.getFom()) ? response.getFom() : response.getIverksettelsesdato();
-
         String message;
         if (isUpdateEndre && isNull(request.getFom())) {
             message = "Automatisk revurderingsvedtak ikke mulig når dato for sivilstandsendring mangler.";
 
-        } else if (isUpdateEndre && request.getFom().isBefore(eksisterendeFom)) {
+        } else if (isUpdateEndre && request.getFom().isBefore(response.getFom())) {
             message = "Automatisk revurderingsvedtak ikke mulig når dato for sivilstandsendring er før dato på forrige vedtak.";
 
         } else {
@@ -172,7 +177,7 @@ public class PensjonPersondataService {
                                         .build())
                                 .message(message)
                                 .build())
-                                .miljo(miljoe)
+                        .miljo(miljoe)
                         .build()))
                 .build());
     }

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/pensjonforvalter/service/PensjonPersondataService.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/pensjonforvalter/service/PensjonPersondataService.java
@@ -150,7 +150,7 @@ public class PensjonPersondataService {
 
     private static boolean isRevurderingValid(RevurderingVedtakRequest request, AlderspensjonVedtakDTO response) {
 
-        return nonNull(request.getFom()) &&
+        return nonNull(response.getFom()) && nonNull(request.getFom()) &&
                 request.getFom().isAfter(response.getFom());
     }
 

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/pensjonforvalter/service/PensjonVedtakService.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/pensjonforvalter/service/PensjonVedtakService.java
@@ -171,7 +171,8 @@ public class PensjonVedtakService {
         }
 
         return Flux.fromIterable(miljoer)
-                .flatMap(miljoe -> pensjonforvalterHelper.hentSisteVedtakAP(ident, miljoe)
+                .flatMap(miljoe -> pensjonforvalterHelper.hentForrigeVedtakAP(ident, miljoe,
+                                pensjondata.getAlderspensjonNyUtaksgrad().getFom())
                         .flatMap(vedtak -> {
                             var context = new MappingContext.Factory().getContext();
                             context.setProperty(ALDERSPENSJON_VEDTAK, vedtak);
@@ -199,7 +200,9 @@ public class PensjonVedtakService {
 
     private static boolean isNoMatch(AlderspensjonVedtakDTO response, AlderspensjonNyUtaksgradRequest request) {
 
-        return response.getHistorikk().stream()
+        return !(response.getFom().equals(request.getFom()) &&
+                response.getUttaksgrad().equals(request.getNyUttaksgrad())) &&
+                response.getHistorikk().stream()
                 .noneMatch(historikk ->
                         historikk.getFom().equals(request.getFom()) &&
                                 historikk.getUttaksgrad().equals(request.getNyUttaksgrad()));

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/pensjonforvalter/service/PensjonVedtakService.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/pensjonforvalter/service/PensjonVedtakService.java
@@ -28,6 +28,8 @@ import java.time.Period;
 import java.util.List;
 import java.util.Set;
 
+import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
 import static no.nav.dolly.bestilling.pensjonforvalter.utils.PensjonforvalterUtils.IDENT;
 import static no.nav.dolly.bestilling.pensjonforvalter.utils.PensjonforvalterUtils.MILJOER;
 import static no.nav.dolly.bestilling.pensjonforvalter.utils.PensjonforvalterUtils.NAV_ENHET;
@@ -205,7 +207,8 @@ public class PensjonVedtakService {
 
     private static boolean isValid(AlderspensjonNyUtaksgradRequest request, AlderspensjonVedtakDTO response) {
 
-        return request.getFom().isAfter(response.getFom()) &&
+        return nonNull(response.getFom()) &&
+                request.getFom().isAfter(response.getFom()) &&
                 (request.getNyUttaksgrad().equals(0) || request.getNyUttaksgrad().equals(100) ||
                         Period.between(response.getDatoForrigeGraderteUttak(), request.getFom()).getYears() >= 1);
     }
@@ -215,7 +218,10 @@ public class PensjonVedtakService {
                                                                           boolean isUpdateEndre) {
 
         String message;
-        if (isUpdateEndre && request.getFom().isBefore(response.getFom())) {
+        if (isNull(response.getFom())) {
+            message = "Uttaksgrad kan ikke endres da vedtak for alderspensjon mangler.";
+
+        }else if (isUpdateEndre && request.getFom().isBefore(response.getFom())) {
             message = "Automatisk vedtak av ny uttaksgrad ikke mulig for dato tidligere enn dato på forrige vedtak.";
 
         } else if (isUpdateEndre && !request.getNyUttaksgrad().equals(0) && !request.getNyUttaksgrad().equals(100) &&

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/pensjonforvalter/service/PensjonVedtakService.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/pensjonforvalter/service/PensjonVedtakService.java
@@ -36,8 +36,6 @@ import static no.nav.dolly.bestilling.pensjonforvalter.utils.PensjonforvalterUti
 import static no.nav.dolly.bestilling.pensjonforvalter.utils.PensjonforvalterUtils.PEN_UFORETRYGD;
 import static no.nav.dolly.bestilling.pensjonforvalter.utils.PensjonforvalterUtils.getStatus;
 import static no.nav.dolly.bestilling.pensjonforvalter.utils.PensjonforvalterUtils.hasVedtak;
-import static no.nav.dolly.domain.resultset.SystemTyper.PEN_AP;
-import static no.nav.dolly.domain.resultset.SystemTyper.PEN_UT;
 import static org.apache.commons.lang3.BooleanUtils.isTrue;
 
 @Slf4j
@@ -119,8 +117,9 @@ public class PensjonVedtakService {
                                                         Flux.fromIterable(response.getStatus())
                                                                 .filter(status -> status.getResponse().isResponse2xx())
                                                                 .flatMap(status ->
-                                                                        pensjonforvalterHelper.saveAPTransaksjonId(ident, status.getMiljo(), bestillingId,
-                                                                                PEN_AP, pensjonRequest))
+                                                                        pensjonforvalterHelper.saveAPTransaksjonId(ident,
+                                                                                status.getMiljo(), bestillingId,
+                                                                                pensjonRequest))
                                                                 .then(Mono.just(response)));
 
                                     } else {
@@ -151,8 +150,9 @@ public class PensjonVedtakService {
                                                         .flatMap(response -> Flux.fromIterable(response.getStatus())
                                                                 .filter(status -> status.getResponse().isResponse2xx())
                                                                 .flatMap(status ->
-                                                                        pensjonforvalterHelper.saveAPTransaksjonId(ident, status.getMiljo(), bestillingId,
-                                                                                PEN_UT, request))
+                                                                        pensjonforvalterHelper.saveUTTransaksjonId(ident,
+                                                                                status.getMiljo(), bestillingId,
+                                                                                request))
                                                                 .then(Mono.just(response))));
 
                                     } else {
@@ -178,17 +178,29 @@ public class PensjonVedtakService {
                                             AlderspensjonNyUtaksgradRequest.class, context))
                                     .zipWith(Mono.just(vedtak));
                         })
-                        .flatMapMany(tuple ->
-                                isValid(tuple.getT1(), tuple.getT2()) ?
-                                        pensjonforvalterConsumer.lagreAPNyUttaksgrad(tuple.getT1())
-                                                .zipWith(Mono.just(tuple.getT1()))
-                                                .flatMap(tuple2 -> Flux.fromIterable(tuple2.getT1().getStatus())
-                                                        .filter(status -> status.getResponse().isResponse2xx())
-                                                        .flatMap(status ->
+                        .flatMapMany(tuple -> {
+                            if (isValid(tuple.getT1(), tuple.getT2())) {
+                                return pensjonforvalterConsumer.lagreAPNyUttaksgrad(tuple.getT1())
+                                        .flatMap(response -> Flux.fromIterable(response.getStatus())
+                                                .filter(status -> status.getResponse().isResponse2xx())
+                                                .flatMap(status ->
+                                                        isNoMatch(tuple.getT2(), tuple.getT1()) ?
                                                                 pensjonforvalterHelper.saveTransaksjonId(ident, status.getMiljo(), bestilling.getId(),
-                                                                                SystemTyper.PEN_AP_NY_UTTAKSGRAD, tuple2.getT2())
-                                                                        .thenReturn(tuple2.getT1()))) :
-                                        miscRevurderingResponse(tuple.getT1(), tuple.getT2(), miljoe, isUpdateEndre)));
+                                                                                SystemTyper.PEN_AP_NY_UTTAKSGRAD, tuple.getT1())
+                                                                        .thenReturn(response) :
+                                                                Mono.just(response)));
+                            } else {
+                                return miscRevurderingResponse(tuple.getT1(), tuple.getT2(), miljoe, isUpdateEndre);
+                            }
+                        }));
+    }
+
+    private static boolean isNoMatch(AlderspensjonVedtakDTO response, AlderspensjonNyUtaksgradRequest request) {
+
+        return response.getHistorikk().stream()
+                .noneMatch(historikk ->
+                        historikk.getFom().equals(request.getFom()) &&
+                                historikk.getUttaksgrad().equals(request.getNyUttaksgrad()));
     }
 
     private static boolean isValid(AlderspensjonNyUtaksgradRequest request, AlderspensjonVedtakDTO response) {
@@ -199,16 +211,16 @@ public class PensjonVedtakService {
     }
 
     private static Mono<PensjonforvalterResponse> miscRevurderingResponse(AlderspensjonNyUtaksgradRequest request,
-                                                                   AlderspensjonVedtakDTO response, String miljoe,
+                                                                          AlderspensjonVedtakDTO response, String miljoe,
                                                                           boolean isUpdateEndre) {
 
         String message;
-         if (isUpdateEndre && request.getFom().isBefore(response.getFom())) {
-             message = "Automatisk vedtak av ny uttaksgrad ikke mulig for dato tidligere enn dato på forrige vedtak.";
+        if (isUpdateEndre && request.getFom().isBefore(response.getFom())) {
+            message = "Automatisk vedtak av ny uttaksgrad ikke mulig for dato tidligere enn dato på forrige vedtak.";
 
-         } else if (isUpdateEndre && !request.getNyUttaksgrad().equals(0) && !request.getNyUttaksgrad().equals(100) &&
-                 Period.between(response.getDatoForrigeGraderteUttak(), request.getFom()).getYears() < 1) {
-             message = "Automatisk vedtak med gradert uttak ikke mulig oftere enn hver 12 måned.";
+        } else if (isUpdateEndre && !request.getNyUttaksgrad().equals(0) && !request.getNyUttaksgrad().equals(100) &&
+                Period.between(response.getDatoForrigeGraderteUttak(), request.getFom()).getYears() < 1) {
+            message = "Automatisk vedtak med gradert uttak ikke mulig oftere enn hver 12 måned.";
 
         } else {
             return Mono.empty();
@@ -222,7 +234,7 @@ public class PensjonVedtakService {
                                         .build())
                                 .message(message)
                                 .build())
-                                .miljo(miljoe)
+                        .miljo(miljoe)
                         .build()))
                 .build());
     }


### PR DESCRIPTION
This pull request introduces enhancements to the handling of pension decisions, particularly focusing on tracking the history of decisions and ensuring transactional integrity when saving pension data. The most important changes include adding a history field to the `AlderspensjonVedtakDTO`, updating service logic to utilize this history for validation, and improving transaction mapping for different pension types.

### Pension decision history enhancements

* Added a `historikk` field to `AlderspensjonVedtakDTO` to maintain a list of previous decisions, initialized by default as an empty list. (`AlderspensjonVedtakDTO.java`) [[1]](diffhunk://#diff-5e7ae7d618bd795a492a4d99cd5e7237a62bb98edcbe8d9ad961aff16de99f66R4-R13) [[2]](diffhunk://#diff-5e7ae7d618bd795a492a4d99cd5e7237a62bb98edcbe8d9ad961aff16de99f66R27-R29)
* Updated helper logic to populate the `historikk` field when fetching the latest pension decision, enabling downstream services to access decision history. (`PensjonforvalterHelper.java`)

### Service logic improvements

* Refactored validation logic in `PensjonPersondataService` and `PensjonVedtakService` to use the new `historikk` field for checking if a decision matches previous entries, preventing duplicate transactions and incorrect updates. (`PensjonPersondataService.java`, `PensjonVedtakService.java`) [[1]](diffhunk://#diff-b86f4de23117fa29b8a8a0ac06171c9fbd40f9971e99a6a763b1069ca477f768L132-R165) [[2]](diffhunk://#diff-6a2a9e348a8707b2e2afa54b1db23d8da2066a3a36ba208ea7f0b75d3a31e736L181-R203)
* Added new helper methods (`isNoMatch`) in service classes to encapsulate history-based validation for both regular and graded pension decisions. (`PensjonPersondataService.java`, `PensjonVedtakService.java`) [[1]](diffhunk://#diff-b86f4de23117fa29b8a8a0ac06171c9fbd40f9971e99a6a763b1069ca477f768L132-R165) [[2]](diffhunk://#diff-6a2a9e348a8707b2e2afa54b1db23d8da2066a3a36ba208ea7f0b75d3a31e736L181-R203)

### Transaction mapping and cleanup

* Improved transaction mapping logic by introducing `saveUTTransaksjonId` and updating `saveAPTransaksjonId` to clean up related transaction types before saving new ones, ensuring consistency in transaction records. (`PensjonforvalterHelper.java`)
* Updated service calls to use the new transaction mapping methods, removing unnecessary system type parameters and ensuring proper transaction handling for each pension type. (`PensjonVedtakService.java`) [[1]](diffhunk://#diff-6a2a9e348a8707b2e2afa54b1db23d8da2066a3a36ba208ea7f0b75d3a31e736L122-R122) [[2]](diffhunk://#diff-6a2a9e348a8707b2e2afa54b1db23d8da2066a3a36ba208ea7f0b75d3a31e736L154-R155)

These changes collectively enhance the reliability and traceability of pension decision handling in the backend, reducing the risk of duplicate or inconsistent records.