### PR TITLE
Bugfix/bad request bestilling id backend

### DIFF
--- a/apps/dolly-backend/src/main/java/no/nav/dolly/mapper/BestillingMapper.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/mapper/BestillingMapper.java
@@ -9,7 +9,7 @@ public class BestillingMapper {
     public Bestilling shallowCopyBestilling(Bestilling bestilling) {
 
         return Bestilling.builder()
-                .bruker(bestilling.getBruker())
+                .brukerId(bestilling.getBrukerId())
                 .id(bestilling.getId())
                 .gruppeId(bestilling.getGruppeId())
                 .antallIdenter(bestilling.getAntallIdenter())

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/mapper/BestillingMapper.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/mapper/BestillingMapper.java
@@ -9,6 +9,7 @@ public class BestillingMapper {
     public Bestilling shallowCopyBestilling(Bestilling bestilling) {
 
         return Bestilling.builder()
+                .bruker(bestilling.getBruker())
                 .id(bestilling.getId())
                 .gruppeId(bestilling.getGruppeId())
                 .antallIdenter(bestilling.getAntallIdenter())


### PR DESCRIPTION
This pull request makes a minor update to the `BestillingMapper` class by ensuring that the `brukerId` field is included when creating a shallow copy of a `Bestilling` object.

- Added mapping of the `brukerId` property in the `shallowCopyBestilling` method of `BestillingMapper` to ensure the copied object retains the user ID.