### PR TITLE
feature/agents-md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -29,10 +29,10 @@ Generate code for a Spring Boot + Gradle + Java backend and React (TypeScript) f
 
 ## JS / React / TS:
 
-- Javascript: Match the versions already configured in the touched module; in this repo that is typically React 19, TypeScript 5, React Router, React Hook Form, useSWR, and Styled Components.
+- JavaScript: Match the versions already configured in the touched module; in this repo that is typically React 19, TypeScript 5, React Router, React Hook Form, useSWR, and Styled Components.
 - Functional components,
   hooks unless otherwise specified.
-- Javascript tests: MSW, React Testing Library, Vitest, Playwright for e2e.
+- JavaScript tests: MSW, React Testing Library, Vitest, Playwright for e2e.
 - TypeScript interfaces should be explicit for props
 - Functional components, hooks only.
 - Components should be:

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,23 +5,21 @@ Generate code for a Spring Boot + Gradle + Java backend and React (TypeScript) f
 ## General Style
 
 - IMPORTANT: Prefer obvious code over clever code.
+- IMPORTANT: Follow the touched module's existing conventions before applying a global preference.
 - IMPORTANT: DO NOT ADD ANY COMMENTS unless asked, and DO NOT REMOVE or MODIFY existing comments in the code.
-- Provide entire files instead of snippets, unless specified.
 - use descriptive variable names unless in a loop or other obvious context.
 
 ## Java
 
-- Java: Spring Boot 3.x, Java 21, unless otherwise specified.
+- Java: Match the versions already configured in the touched module; in this repo that is typically Spring Boot 3.x and Java 21.
 - Java tests: JUnit 5, AssertJ, Mockito; name test methods: `should<Behavior>()`.
 - Null handling: prefer `Optional` only at API boundaries.
 - Keep functions small; extract private helpers.
-- IMPORTANT: Always use `isNull(obj)` and `nonNull(obj)` from `java.util.Objects` instead of `obj == null` or `obj != null`.
-- IMPORTANT: Always use `isBlank(str)` and `isNotBlank(str)` from Apache Commons Lang3 instead of manual string checks.
+- IMPORTANT: Prefer `isNull(obj)` and `nonNull(obj)` from `java.util.Objects` when adding or refactoring null checks, especially where the surrounding code already follows that pattern.
+- IMPORTANT: Prefer Apache Commons Lang3 `isBlank(str)` and `isNotBlank(str)` for blank-string checks when the module already uses Commons Lang.
 - Logging: SLF4J, no `System.out`.
 - Avoid deprecated Spring APIs.
-- Always use explicit, fully qualified Java imports.
-- Never use wildcard imports (e.g., `import com.example.package.*`).
-- Ensure all necessary classes are imported individually.
+- Prefer explicit Java imports and avoid wildcard imports in new or modified code.
 
 ## REST
 
@@ -31,7 +29,8 @@ Generate code for a Spring Boot + Gradle + Java backend and React (TypeScript) f
 
 ## JS / React / TS:
 
-- Javascript: React 18, TypeScript 5, React Router, React Hook Form, useSWR, Styled components, functional components,
+- Javascript: Match the versions already configured in the touched module; in this repo that is typically React 19, TypeScript 5, React Router, React Hook Form, useSWR, and Styled Components.
+- Functional components,
   hooks unless otherwise specified.
 - Javascript tests: MSW, React Testing Library, Vitest, Playwright for e2e.
 - TypeScript interfaces should be explicit for props
@@ -40,16 +39,17 @@ Generate code for a Spring Boot + Gradle + Java backend and React (TypeScript) f
     - Self-contained and reusable where possible
     - Focused on a single responsibility
     - Well-typed with TypeScript
-- Prefer using useSWR for data fetching and create a custom hook.
+- Prefer existing useSWR + custom hook patterns for frontend read-fetching, but follow the local data-flow pattern in the touched area.
 - Prefer early returns for conditionals
 - TypeScript strict mode assumptions.
 - Uses NAV design system (@navikt/ds-react and @navikt/ds-css)
-- Prefer NAV design system components and styling where possible
+- Prefer NAV design system components and styling where the touched frontend already uses them.
 - Keep components small and focused
 - Follow accessibility best practices
 - Reuse existing UI components; do not introduce new state libs
+- Prefer existing frontend request helpers, custom hooks, and UI patterns before introducing parallel abstractions.
 - Prefer creating .tsx files for components, not .ts
-- Export components directly where they are written, never in dedicated export/index files.
+- Prefer following the local folder convention for component exports; use direct exports unless the touched area already uses index/barrel files.
 
 ## Error Handling React / TS:
 
@@ -60,4 +60,4 @@ Generate code for a Spring Boot + Gradle + Java backend and React (TypeScript) f
 ## What NOT to do
 
 - Do not invent APIs not present.
-- Do not add libraries without minimal justification comment.
+- Do not add libraries unless existing repo dependencies or utilities are insufficient.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,83 @@
+# AGENTS Guide for testnorge
+
+## Big picture
+- Monorepo is a Gradle composite build; root `settings.gradle` auto-includes builds from `apps/`, `libs/`, `mocks/`, `plugins/`, `proxies/`, `xsd/`.
+- Root `build.gradle` fans out `build`, `clean`, `assemble`, `sonarqube`, and `dollyValidation` to included builds.
+- `apps/` are deployables, `libs/` are shared modules, `proxies/` are integration gateways; follow this flow as a baseline: `apps/dolly-frontend` -> `apps/dolly-backend` -> consumers in `apps/dolly-backend/src/main/resources/application.yml`.
+- Runtime boundaries are codified in NAIS manifests (`config.yml`, `config.test.yml`) through `accessPolicy`, ingresses, and secrets.
+
+## How these instructions work together
+- `AGENTS.md` covers repo structure, build/test workflow, architecture, and operational constraints for this monorepo.
+- `.github/copilot-instructions.md` covers code style, implementation patterns, and language-specific expectations.
+- Use `AGENTS.md` first to understand where and how to change the repo, then apply `.github/copilot-instructions.md` when writing or refactoring code.
+
+## Build and validation workflow
+- Day-to-day development is usually run from the specific app or proxy directory rather than repo root.
+- Before running shell commands, determine the developer OS from explicit environment metadata if available; otherwise probe once using the active shell, and if still unclear provide both PowerShell and bash/zsh variants instead of guessing.
+- PowerShell:
+```powershell
+Set-Location apps/dolly-backend
+./gradlew build
+```
+- bash/zsh:
+```bash
+cd apps/dolly-backend
+./gradlew build
+```
+- `build` normally runs `dollyValidation` for apps and proxies, so `dollyValidation` does not need to be executed explicitly during normal local development.
+- `dollyValidation` (`plugins/java/src/main/java/no/nav/dolly/plugins/DollyBuildValidationTask.java`) enforces consistency between:
+  - module `build.gradle` dependencies on `no.nav.testnav.libs:*`
+  - module `settings.gradle` `includeBuild ../../libs/<lib>` entries
+  - `.github/workflows/app.<name>.yml` / `proxy.<name>.yml` `on.push.paths`
+- When adding/removing shared libs, update all three files above in the same PR.
+- `iTest` exists for supported modules, but is not normally run locally during day-to-day development.
+- On macOS, tests or local runs that rely on Docker/Testcontainers may require the environment variables documented in root `README.md`.
+
+## Comment style
+- Do not add code comments unless asked, and do not remove or modify existing comments.
+- If an agent adds code comments, write them as complete sentences and terminate them with appropriate punctuation (normally `.`).
+
+## Backend, proxy, and frontend patterns
+- Shared service plugins are `dolly-apps` and `dolly-proxies` (`plugins/java/src/main/groovy`); they standardize Java 21, WebFlux + Undertow, test setup, and artifact packaging.
+- Integrations are config-driven: app consumers live in `application.yml` (`consumers`), network permissions in `config.yml` (`accessPolicy.inbound/outbound`).
+- Cross-tenant proxy cases (NAV + Trygdeetaten) use two `AzureAdApplication` resources and dual secrets; reference `proxies/dolly-proxy/config.yml`.
+- Frontend source is under `apps/*/src/main/js`; build path is pnpm/Vite first, then Gradle packaging (`.github/workflows/common.workflow.frontend.yml`).
+- `apps/dolly-frontend` uses mixed Redux + Router + SWR (`src/main/js/src/Store.tsx`, `src/main/js/src/RootComponent.tsx`); extend existing state patterns instead of introducing new ones.
+- Frontend prefers NAV design system components (`@navikt/ds-react`, `@navikt/ds-css`) and reuse of existing UI components before introducing new ones.
+- API utilities are centralized in `apps/dolly-frontend/src/main/js/src/api/index.ts`; MSW is only enabled in test mode via `apps/dolly-frontend/src/main/js/src/index.tsx`.
+- Frontend tests use Vitest, React Testing Library, MSW, and Playwright.
+
+## CI/CD and ops details
+- App/proxy workflows delegate to reusable workflows in `.github/workflows/common.workflow.*.yml`.
+- Non-master deploys are commit-message driven (`#deploy-...`, `#deploy-test-...`), and `#nodeploy` disables deploy.
+- Frontend module commands.
+- PowerShell:
+```powershell
+Set-Location apps/dolly-frontend/src/main/js
+pnpm install --frozen-lockfile
+pnpm start
+pnpm run test:vitest-run
+pnpm run test:playwright-run
+```
+- bash/zsh:
+```bash
+cd apps/dolly-frontend/src/main/js
+pnpm install --frozen-lockfile
+pnpm start
+pnpm run test:vitest-run
+pnpm run test:playwright-run
+```
+- Private npm packages require a GitHub token in user `.npmrc` (`apps/dolly-frontend/README.md`).
+- Proxy table in `docs/modules/ROOT/pages/index.adoc` is generated; regenerate after proxy config changes.
+- PowerShell:
+```powershell
+python .\scripts\generate_proxy_table.py
+```
+- bash/zsh:
+```bash
+python ./scripts/generate_proxy_table.py
+```
+
+
+
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,15 +15,15 @@
 - Day-to-day development is usually run from the specific app or proxy directory rather than repo root.
 - Before running shell commands, determine the developer OS from explicit environment metadata if available; otherwise probe once using the active shell, and if still unclear provide both PowerShell and bash/zsh variants instead of guessing.
 - PowerShell:
-```powershell
-Set-Location apps/dolly-backend
-./gradlew build
-```
+  ```powershell
+  Set-Location apps/dolly-backend
+  ./gradlew build
+  ```
 - bash/zsh:
-```bash
-cd apps/dolly-backend
-./gradlew build
-```
+  ```bash
+  cd apps/dolly-backend
+  ./gradlew build
+  ```
 - `build` normally runs `dollyValidation` for apps and proxies, so `dollyValidation` does not need to be executed explicitly during normal local development.
 - `dollyValidation` (`plugins/java/src/main/java/no/nav/dolly/plugins/DollyBuildValidationTask.java`) enforces consistency between:
   - module `build.gradle` dependencies on `no.nav.testnav.libs:*`
@@ -52,31 +52,31 @@ cd apps/dolly-backend
 - Non-master deploys are commit-message driven (`#deploy-...`, `#deploy-test-...`), and `#nodeploy` disables deploy.
 - Frontend module commands.
 - PowerShell:
-```powershell
-Set-Location apps/dolly-frontend/src/main/js
-pnpm install --frozen-lockfile
-pnpm start
-pnpm run test:vitest-run
-pnpm run test:playwright-run
-```
+  ```powershell
+  Set-Location apps/dolly-frontend/src/main/js
+  pnpm install --frozen-lockfile
+  pnpm start
+  pnpm run test:vitest-run
+  pnpm run test:playwright-run
+  ```
 - bash/zsh:
-```bash
-cd apps/dolly-frontend/src/main/js
-pnpm install --frozen-lockfile
-pnpm start
-pnpm run test:vitest-run
-pnpm run test:playwright-run
-```
+  ```bash
+  cd apps/dolly-frontend/src/main/js
+  pnpm install --frozen-lockfile
+  pnpm start
+  pnpm run test:vitest-run
+  pnpm run test:playwright-run
+  ```
 - Private npm packages require a GitHub token in user `.npmrc` (`apps/dolly-frontend/README.md`).
 - Proxy table in `docs/modules/ROOT/pages/index.adoc` is generated; regenerate after proxy config changes.
 - PowerShell:
-```powershell
-python .\scripts\generate_proxy_table.py
-```
+  ```powershell
+  python .\scripts\generate_proxy_table.py
+  ```
 - bash/zsh:
-```bash
-python ./scripts/generate_proxy_table.py
-```
+  ```bash
+  python ./scripts/generate_proxy_table.py
+  ```
 
 
 


### PR DESCRIPTION
This pull request updates the project's contributor guidance and adds a new documentation file to clarify repo structure and development practices. The main focus is on making code style and implementation instructions more context-aware and explicit, and on providing a comprehensive overview of the monorepo's architecture and workflows.

**Documentation and Guidance Improvements**

* Added a new `AGENTS.md` file that provides a high-level overview of the monorepo structure, build/test workflows, architecture, and operational constraints. It also explains how to use this guide in conjunction with `.github/copilot-instructions.md`, and includes platform-specific command examples and CI/CD details.
* Updated `.github/copilot-instructions.md` to clarify that code style and implementation patterns should follow the conventions of the touched module or area, rather than enforcing global preferences. This includes language versions, import styles, utility usage, and frontend patterns. [[1]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R8-R22) [[2]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L34-R33) [[3]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L43-R52)

**Backend and Frontend Conventions**

* Java and JavaScript/React instructions now emphasize matching the versions and patterns already used in the specific module being changed, rather than hardcoding versions or styles. [[1]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R8-R22) [[2]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L34-R33)
* Frontend guidance now prioritizes reusing existing request helpers, custom hooks, and UI patterns, and following local export conventions, rather than introducing new abstractions or enforcing a single export style.

**Dependency Management**

* The prohibition on adding new libraries has been relaxed: new libraries may be added if existing repo dependencies or utilities are insufficient, rather than requiring a justification comment for every addition.