### PR TITLE
Feature/skattekort tilpasninger

### DIFF
--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/skattekort/form/Form.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/skattekort/form/Form.tsx
@@ -63,11 +63,6 @@ export const SkattekortForm = () => {
 	}
 
 	const isResultatOK = (index: number): boolean => {
-		const arbeidstaker = formMethods.watch('skattekort.arbeidsgiverSkatt')[index]?.arbeidstaker?.[0]
-		return arbeidstaker?.resultatPaaForespoersel === 'SKATTEKORTOPPLYSNINGER_OK'
-	}
-
-	const showForskuddstrekk = (index: number): boolean => {
 		const gyldigeResultater = [
 			'SKATTEKORTOPPLYSNINGER_OK',
 			'UTGAATT_DNUMMER_SKATTEKORT_FOR_FOEDSELSNUMMER_ER_LEVERT',
@@ -167,7 +162,7 @@ export const SkattekortForm = () => {
 									isMulti={true}
 									onBlur={() => onBlurTillegsinformasjon(path, index)}
 								/>
-								{showForskuddstrekk(index) && !isTilleggsopplysning(index) && (
+								{isResultatOK(index) && !isTilleggsopplysning(index) && (
 									<ForskuddstrekkForm
 										formMethods={formMethods}
 										path={`${path}.arbeidstaker[0].skattekort`}

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/skattekort/form/Form.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/skattekort/form/Form.tsx
@@ -67,6 +67,12 @@ export const SkattekortForm = () => {
 		return arbeidstaker?.resultatPaaForespoersel === 'SKATTEKORTOPPLYSNINGER_OK'
 	}
 
+	const showTillegsopplysning = (index: number): boolean => {
+		const gyldigeResultater = ['SKATTEKORTOPPLYSNINGER_OK', 'IKKE_SKATTEKORT']
+		const arbeidstaker = formMethods.watch('skattekort.arbeidsgiverSkatt')[index]?.arbeidstaker?.[0]
+		return gyldigeResultater.includes(arbeidstaker?.resultatPaaForespoersel)
+	}
+
 	const isTilleggsopplysning = (index: number): boolean => {
 		const arbeidstaker = formMethods.watch('skattekort.arbeidsgiverSkatt')[index]?.arbeidstaker?.[0]
 		return arbeidstaker?.tilleggsopplysning?.find(
@@ -150,7 +156,7 @@ export const SkattekortForm = () => {
 										/>
 									)}
 								</div>
-								{isResultatOK(index) && (
+								{showTillegsopplysning(index) && (
 									<FormSelect
 										name={`${path}.arbeidstaker[0].tilleggsopplysning`}
 										label="Tilleggsopplysning"

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/skattekort/form/Form.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/skattekort/form/Form.tsx
@@ -67,8 +67,11 @@ export const SkattekortForm = () => {
 		return arbeidstaker?.resultatPaaForespoersel === 'SKATTEKORTOPPLYSNINGER_OK'
 	}
 
-	const showTillegsopplysning = (index: number): boolean => {
-		const gyldigeResultater = ['SKATTEKORTOPPLYSNINGER_OK', 'IKKE_SKATTEKORT']
+	const showForskuddstrekk = (index: number): boolean => {
+		const gyldigeResultater = [
+			'SKATTEKORTOPPLYSNINGER_OK',
+			'UTGAATT_DNUMMER_SKATTEKORT_FOR_FOEDSELSNUMMER_ER_LEVERT',
+		]
 		const arbeidstaker = formMethods.watch('skattekort.arbeidsgiverSkatt')[index]?.arbeidstaker?.[0]
 		return gyldigeResultater.includes(arbeidstaker?.resultatPaaForespoersel)
 	}
@@ -156,17 +159,15 @@ export const SkattekortForm = () => {
 										/>
 									)}
 								</div>
-								{showTillegsopplysning(index) && (
-									<FormSelect
-										name={`${path}.arbeidstaker[0].tilleggsopplysning`}
-										label="Tilleggsopplysning"
-										options={tilleggsopplysning}
-										size="grow"
-										isMulti={true}
-										onBlur={() => onBlurTillegsinformasjon(path, index)}
-									/>
-								)}
-								{isResultatOK(index) && !isTilleggsopplysning(index) && (
+								<FormSelect
+									name={`${path}.arbeidstaker[0].tilleggsopplysning`}
+									label="Tilleggsopplysning"
+									options={tilleggsopplysning}
+									size="grow"
+									isMulti={true}
+									onBlur={() => onBlurTillegsinformasjon(path, index)}
+								/>
+								{showForskuddstrekk(index) && !isTilleggsopplysning(index) && (
 									<ForskuddstrekkForm
 										formMethods={formMethods}
 										path={`${path}.arbeidstaker[0].skattekort`}

--- a/apps/dolly-frontend/src/main/js/src/utils/hooks/useSkattekort.tsx
+++ b/apps/dolly-frontend/src/main/js/src/utils/hooks/useSkattekort.tsx
@@ -38,6 +38,7 @@ const SKATTEKORT_KODEVERK: Record<string, Record<string, string>> = {
 		'Skattekortopplysninger OK': 'SKATTEKORTOPPLYSNINGER_OK',
 		'Ikke trekkplikt': 'IKKE_TREKKPLIKT',
 		'Ikke skattekort': 'IKKE_SKATTEKORT',
+		'Utgått d-nummer': 'UTGAATT_DNUMMER_SKATTEKORT_FOR_FOEDSELSNUMMER_ER_LEVERT',
 	},
 	TILLEGGSOPPLYSNING: {
 		'Opphold på Svalbard': 'OPPHOLD_PAA_SVALBARD',
@@ -53,6 +54,7 @@ const SKATTEKORT_KODEVERK: Record<string, Record<string, string>> = {
 		'Skattekortopplysninger OK': 'skattekortopplysningerOK',
 		'Ikke trekkplikt': 'ikkeTrekkplikt',
 		'Ikke skattekort': 'ikkeSkattekort',
+		'Utgått d-nummer': 'utgaattDnummerSkattekortForFoedselsnummerErLevert',
 	},
 	TILLEGGSOPPLYSNING_FRA_SOKOS: {
 		'Opphold på Svalbard': 'oppholdPaaSvalbard',


### PR DESCRIPTION
This pull request updates the handling of skattekort (tax card) result codes to support an additional valid result and ensures the code mappings and UI logic reflect this. The main changes include updating the result validation logic, adding new code mappings, and adjusting the form rendering conditions.

**Skattekort result handling improvements:**

* The `isResultatOK` function in `Form.tsx` now considers both `'SKATTEKORTOPPLYSNINGER_OK'` and the new `'UTGAATT_DNUMMER_SKATTEKORT_FOR_FOEDSELSNUMMER_ER_LEVERT'` as valid results, allowing for broader acceptance of valid skattekort responses.
* The form rendering logic was updated to ensure that the additional valid result code is correctly handled when showing or hiding components like `FormSelect` and `ForskuddstrekkForm`. [[1]](diffhunk://#diff-de0bf06b5c09561b9ceb09bea4a14fb3eb6a2de10e5fe5d3bc4dfb46df2f4110L153) [[2]](diffhunk://#diff-de0bf06b5c09561b9ceb09bea4a14fb3eb6a2de10e5fe5d3bc4dfb46df2f4110L162)

**Code mapping updates:**

* The `SKATTEKORT_KODEVERK` mapping in `useSkattekort.tsx` now includes the new result `'Utgått d-nummer'` mapped to `'UTGAATT_DNUMMER_SKATTEKORT_FOR_FOEDSELSNUMMER_ER_LEVERT'` for internal consistency.
* The corresponding lowercase mapping for `'Utgått d-nummer'` was also added for alternative usages.