### PR TITLE
Fix: Eksport til Excel feiler for minst en gruppe 

### DIFF
--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/personservice/PersonServiceConsumer.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/personservice/PersonServiceConsumer.java
@@ -23,6 +23,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.util.Objects.isNull;
 import static no.nav.dolly.util.JacksonExchangeStrategyUtil.getJacksonStrategy;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 @Service
 @Slf4j
@@ -66,19 +67,24 @@ public class PersonServiceConsumer extends ConsumerStatus {
     @Timed(name = "providers", tags = {"operation", "pdl_getPersoner"})
     public Flux<PdlPersonBolk> getPdlPersonerNoRetries(List<String> identer) {
 
-        return getPdlPersoner(identer, new AtomicInteger(MAX_RETRIES));
+        return getPdlPersoner(identer, new AtomicInteger(MAX_RETRIES))
+                .doOnNext(resultat -> {
+                    if (isNotBlank(resultat.getErrors())) {
+                        log.error("Feil mottatt fra person-service {} ved henting av identer {}",
+                                resultat.getErrors(), String.join(", ", identer));
+                    }
+                });
     }
 
     @Timed(name = "providers", tags = {"operation", "pdl_getPersoner"})
     public Flux<PdlPersonBolk> getPdlPersoner(List<String> identer, AtomicInteger retry) {
 
         return tokenService.exchange(serverProperties)
-                .flatMapMany(token -> Flux.range(0, identer.size() / BLOCK_SIZE + 1)
-                        .flatMap(index -> new PdlPersonerGetCommand(webClient,
-                                identer.subList(index * BLOCK_SIZE, Math.min((index + 1) * BLOCK_SIZE, identer.size())),
-                                token.getTokenValue()
+                .flatMapMany(token -> Flux.fromIterable(identer)
+                        .buffer(BLOCK_SIZE)
+                        .flatMap(identerBlokk -> new PdlPersonerGetCommand(webClient,
+                                identerBlokk, token.getTokenValue()
                         ).call()))
-
                 .flatMap(resultat -> {
 
                     if (retry.get() < MAX_RETRIES &&

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/personservice/PersonServiceConsumer.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/personservice/PersonServiceConsumer.java
@@ -20,6 +20,8 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static java.util.Objects.isNull;
 import static no.nav.dolly.util.JacksonExchangeStrategyUtil.getJacksonStrategy;
@@ -69,9 +71,13 @@ public class PersonServiceConsumer extends ConsumerStatus {
 
         return getPdlPersoner(identer, new AtomicInteger(MAX_RETRIES))
                 .doOnNext(resultat -> {
-                    if (isNotBlank(resultat.getErrors())) {
-                        log.error("Feil mottatt fra person-service {} ved henting av identer {}",
-                                resultat.getErrors(), String.join(", ", identer));
+                    if (isNotBlank(resultat.getMessage())) {
+                        log.error("Feil mottatt fra person-service {} ved henting av identer {} ...",
+                                resultat.getMessage(),
+                                IntStream.range(0, 10)
+                                        .filter(i -> i < identer.size())
+                                        .mapToObj(identer::get)
+                                        .collect(Collectors.joining(", ")));
                     }
                 });
     }
@@ -88,8 +94,8 @@ public class PersonServiceConsumer extends ConsumerStatus {
                 .flatMap(resultat -> {
 
                     if (retry.get() < MAX_RETRIES &&
-                            (isNull(resultat.getData()) || resultat.getData().getHentPersonBolk().stream()
-                                    .anyMatch(data -> isNull(data.getPerson())))) {
+                        (isNull(resultat.getData()) || resultat.getData().getHentPersonBolk().stream()
+                                .anyMatch(data -> isNull(data.getPerson())))) {
 
                         return Flux.just(true)
                                 .doOnNext(melding ->

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/personservice/command/PdlPersonerGetCommand.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/personservice/command/PdlPersonerGetCommand.java
@@ -35,10 +35,10 @@ public class PdlPersonerGetCommand implements Callable<Flux<PdlPersonBolk>> {
                 .retrieve()
                 .bodyToFlux(PdlPersonBolk.class)
                 .doOnError(WebClientError.logTo(log))
-
                 .retryWhen(WebClientError.is5xxException())
-                .onErrorResume(throwable -> throwable instanceof WebClientResponseException.NotFound,
-                        throwable -> Mono.empty());
+                .onErrorResume(WebClientResponseException.class::isInstance,
+                        throwable -> Mono.just(PdlPersonBolk.builder()
+                                .errors(((WebClientResponseException) throwable).getResponseBodyAsString())
+                                .build()));
     }
-
 }

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/personservice/command/PdlPersonerGetCommand.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/personservice/command/PdlPersonerGetCommand.java
@@ -2,11 +2,11 @@ package no.nav.dolly.bestilling.personservice.command;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import lombok.val;
 import no.nav.dolly.domain.PdlPersonBolk;
 import no.nav.testnav.libs.reactivecore.web.WebClientError;
 import no.nav.testnav.libs.reactivecore.web.WebClientHeader;
 import org.springframework.web.reactive.function.client.WebClient;
-import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -36,9 +36,12 @@ public class PdlPersonerGetCommand implements Callable<Flux<PdlPersonBolk>> {
                 .bodyToFlux(PdlPersonBolk.class)
                 .doOnError(WebClientError.logTo(log))
                 .retryWhen(WebClientError.is5xxException())
-                .onErrorResume(WebClientResponseException.class::isInstance,
-                        throwable -> Mono.just(PdlPersonBolk.builder()
-                                .errors(((WebClientResponseException) throwable).getResponseBodyAsString())
-                                .build()));
+                .onErrorResume(throwable -> {
+                    val error = WebClientError.describe(throwable);
+                    return Mono.just(PdlPersonBolk.builder()
+                            .message(error.getMessage())
+                            .status(error.getStatus())
+                            .build());
+                });
     }
 }

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/domain/PdlPersonBolk.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/domain/PdlPersonBolk.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.http.HttpStatus;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -17,7 +18,8 @@ public class PdlPersonBolk {
 
     private Data data;
     private JsonNode extensions;
-    private String errors;
+    private String message;
+    private HttpStatus status;
 
     @lombok.Data
     @Builder

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/domain/PdlPersonBolk.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/domain/PdlPersonBolk.java
@@ -17,6 +17,7 @@ public class PdlPersonBolk {
 
     private Data data;
     private JsonNode extensions;
+    private String errors;
 
     @lombok.Data
     @Builder

--- a/apps/dolly-backend/src/test/java/no/nav/dolly/bestilling/personservice/PersonServiceConsumerTest.java
+++ b/apps/dolly-backend/src/test/java/no/nav/dolly/bestilling/personservice/PersonServiceConsumerTest.java
@@ -1,0 +1,121 @@
+package no.nav.dolly.bestilling.personservice;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import no.nav.dolly.bestilling.AbstractConsumerTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import reactor.test.StepVerifier;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PersonServiceConsumerTest extends AbstractConsumerTest {
+
+    private static final int BLOCK_SIZE = 100;
+
+    private static final String PDL_PERSON_BOLK_RESPONSE = """
+            {
+                "data": {
+                    "hentPersonBolk": [
+                        {
+                            "ident": "12345678901",
+                            "person": {
+                                "navn": [{ "fornavn": "Test", "etternavn": "Testesen" }]
+                            },
+                            "code": "ok"
+                        }
+                    ],
+                    "hentGeografiskTilknytningBolk": [],
+                    "hentIdenterBolk": []
+                }
+            }
+            """;
+
+    @Autowired
+    private PersonServiceConsumer personServiceConsumer;
+
+    @AfterEach
+    void cleanUp() {
+        WireMock.reset();
+    }
+
+    @Test
+    void shouldHandleExactlyBlockSizeIdenterWithSingleRequest() {
+        stubPdlPersonerEndpoint();
+
+        var identer = generateIdenter(BLOCK_SIZE);
+
+        personServiceConsumer.getPdlPersoner(identer)
+                .collectList()
+                .as(StepVerifier::create)
+                .assertNext(results -> assertThat(results).isNotEmpty())
+                .verifyComplete();
+
+        verify(1, getRequestedFor(urlPathMatching("(.*)/api/v2/personer/identer")));
+    }
+
+    @Test
+    void shouldSplitIntoTwoRequestsWhenIdenterExceedBlockSize() {
+        stubPdlPersonerEndpoint();
+
+        var identer = generateIdenter(BLOCK_SIZE + 1);
+
+        personServiceConsumer.getPdlPersoner(identer)
+                .collectList()
+                .as(StepVerifier::create)
+                .assertNext(results -> assertThat(results).isNotEmpty())
+                .verifyComplete();
+
+        verify(2, getRequestedFor(urlPathMatching("(.*)/api/v2/personer/identer")));
+    }
+
+    @Test
+    void shouldHandleEmptyIdenterListWithNoRequests() {
+        stubPdlPersonerEndpoint();
+
+        personServiceConsumer.getPdlPersoner(List.of())
+                .collectList()
+                .as(StepVerifier::create)
+                .assertNext(results -> assertThat(results).isEmpty())
+                .verifyComplete();
+
+        verify(0, getRequestedFor(urlPathMatching("(.*)/api/v2/personer/identer")));
+    }
+
+    @Test
+    void shouldHandleExactlyDoubleBlockSizeWithTwoRequests() {
+        stubPdlPersonerEndpoint();
+
+        var identer = generateIdenter(BLOCK_SIZE * 2);
+
+        personServiceConsumer.getPdlPersoner(identer)
+                .collectList()
+                .as(StepVerifier::create)
+                .assertNext(results -> assertThat(results).isNotEmpty())
+                .verifyComplete();
+
+        verify(2, getRequestedFor(urlPathMatching("(.*)/api/v2/personer/identer")));
+    }
+
+    private List<String> generateIdenter(int count) {
+        return IntStream.range(0, count)
+                .mapToObj(i -> String.format("%011d", i))
+                .toList();
+    }
+
+    private void stubPdlPersonerEndpoint() {
+        stubFor(get(urlPathMatching("(.*)/api/v2/personer/identer"))
+                .willReturn(ok()
+                        .withBody(PDL_PERSON_BOLK_RESPONSE)
+                        .withHeader("Content-Type", "application/json")));
+    }
+}

--- a/apps/dolly-backend/src/test/resources/application-test.yml
+++ b/apps/dolly-backend/src/test/resources/application-test.yml
@@ -34,6 +34,11 @@ consumers:
     namespace: dolly
     url: http://localhost:${wiremock.server.port:0}/pdl
     cluster: dev-fss
+  testnav-person-service:
+    name: testnav-person-service
+    namespace: dolly
+    url: http://localhost:${wiremock.server.port:0}/person-service
+    cluster: dev-gcp
   testnav-organisasjon-service:
     url: https://testnav-organisasjon-service.intern.dev.nav.no
     name: testnav-organisasjon-service


### PR DESCRIPTION
This pull request improves the error handling and request batching logic in the `PersonServiceConsumer` and its related classes, and adds comprehensive tests for these behaviors. The main changes include enhanced error reporting, more robust request splitting for large lists of identifiers, and new tests to verify batching and error handling.

**Error handling improvements:**

* Updated `PdlPersonerGetCommand` to return a `PdlPersonBolk` object containing error details (`message` and `status`) instead of emitting empty results on errors, allowing downstream consumers to handle errors more gracefully. [[1]](diffhunk://#diff-eed21066b81d5f8ff64006f8f845cbb6fd571c2a07f20b0c43d10affffd3102fL38-L43) [[2]](diffhunk://#diff-7f239f7ba7cbcd6f9f9a372f69249499e20218bd967c932ad52783cf7b217181R21-R22)

**Request batching logic:**

* Refactored `PersonServiceConsumer#getPdlPersoner` to use `.buffer(BLOCK_SIZE)` for splitting identifier lists into blocks, ensuring correct batching regardless of input size and eliminating off-by-one errors.
* Added logging for error responses, including the error message and up to the first 10 identifiers involved, to aid in debugging.

**Testing and configuration:**

* Added a new test class `PersonServiceConsumerTest` to verify batching (single, double, and empty block cases) and error handling when calling the person service.
* Updated test configuration (`application-test.yml`) to include the `testnav-person-service` consumer, supporting the new tests.

**Other code improvements:**

* Added necessary imports and minor refactoring for clarity and consistency in the affected files. [[1]](diffhunk://#diff-3bcf5c53ead53eb2ba5f2ab29a4e02eb9fe946430fd33a0ff991c138f3ceb863R23-R28) [[2]](diffhunk://#diff-eed21066b81d5f8ff64006f8f845cbb6fd571c2a07f20b0c43d10affffd3102fR5-L9) [[3]](diffhunk://#diff-7f239f7ba7cbcd6f9f9a372f69249499e20218bd967c932ad52783cf7b217181R8)