### PR TITLE
Refactor filtering logic and simplify PersonListe component

### DIFF
--- a/apps/dolly-frontend/src/main/js/src/ducks/fagsystem/index.tsx
+++ b/apps/dolly-frontend/src/main/js/src/ducks/fagsystem/index.tsx
@@ -253,11 +253,14 @@ export const selectPersonListe = (identer, bestillingStatuser, fagsystem) => {
 		return null
 	}
 
-	const identListe = Object.values(identer).filter(
-		(gruppeIdent) =>
-			Object.keys(fagsystem.pdlforvalter).includes(gruppeIdent.ident) ||
-			Object.keys(fagsystem.pdl).includes(gruppeIdent.ident),
-	)
+	const identListe = Object.values(identer).filter((gruppeIdent) => {
+		if (gruppeIdent.master === 'PDLF') {
+			return gruppeIdent.ident in fagsystem.pdlforvalter
+		} else if (gruppeIdent.master === 'PDL') {
+			return gruppeIdent.ident in fagsystem.pdl
+		}
+		return false
+	})
 
 	return identListe.map((ident) => {
 		if (ident.master === 'PDLF') {

--- a/apps/dolly-frontend/src/main/js/src/pages/gruppe/PersonListe/PersonListe.tsx
+++ b/apps/dolly-frontend/src/main/js/src/pages/gruppe/PersonListe/PersonListe.tsx
@@ -18,7 +18,6 @@ import PersonVisningConnector from '@/pages/gruppe/PersonVisning/PersonVisningCo
 import { DollyCopyButton } from '@/components/ui/button/CopyButton/DollyCopyButton'
 import { Bestilling, useGruppeById } from '@/utils/hooks/useGruppe'
 import { useLocation } from 'react-router'
-import { usePdlfPersoner } from '@/utils/hooks/usePdlForvalter'
 
 const PersonIBrukButtonConnector = React.lazy(
 	() => import('@/components/ui/button/PersonIBrukButton/PersonIBrukButtonConnector'),
@@ -70,34 +69,6 @@ export default function PersonListe({
 	const location = useLocation()
 
 	const personListe = sokSelector(selectPersonListe(identer, bestillingStatuser, fagsystem), search)
-
-	const pdlfIdenter = useMemo(() => personListe?.map((p) => p.identNr).join(','), [personListe])
-
-	const { pdlfPersoner } = usePdlfPersoner(pdlfIdenter)
-
-	if (pdlfPersoner) {
-		const pdlfMap = {}
-		pdlfPersoner.forEach((entry) => {
-			if (entry?.person?.ident) {
-				pdlfMap[entry.person.ident] = entry.person
-			}
-		})
-		personListe?.forEach((person) => {
-			const redigertPerson = pdlfMap[person?.identNr]
-			if (redigertPerson) {
-				const fornavn = redigertPerson?.navn?.[0]?.fornavn || ''
-				const mellomnavn = redigertPerson?.navn?.[0]?.mellomnavn
-					? `${redigertPerson?.navn?.[0]?.mellomnavn?.charAt(0)}.`
-					: ''
-				const etternavn = redigertPerson?.navn?.[0]?.etternavn || ''
-				if (!redigertPerson.doedsfall) {
-					person.alder = person.alder.split(' ')[0]
-				}
-				person.kjonn = redigertPerson.kjoenn?.[0]?.kjoenn
-				person.navn = `${fornavn} ${mellomnavn} ${etternavn}`
-			}
-		})
-	}
 
 	useEffect(() => {
 		const idents =
@@ -253,7 +224,7 @@ export default function PersonListe({
 		return column
 	})
 
-	if ((isFetching || isLoading) && personListe?.length === 0) {
+	if (isFetching || isLoading) {
 		return <Loading label="Laster personer ..." panel />
 	}
 


### PR DESCRIPTION
This pull request refactors how person data is filtered and displayed in the `PersonListe` component, focusing on simplifying logic and removing unnecessary hooks. The main changes include updating the filtering algorithm in `selectPersonListe`, removing the `usePdlfPersoner` hook and related data merging logic, and simplifying the loading state condition.

**Filtering and Data Selection:**
- Refactored the filtering logic in `selectPersonListe` to check the `master` property of each `gruppeIdent`, ensuring that only relevant identities from the correct source (`PDLF` or `PDL`) are included.

**Person Data Management:**
- Removed the use of the `usePdlfPersoner` hook and the associated logic for merging PDLF person data into the main person list, simplifying the component and reducing unnecessary data fetching and transformation. [[1]](diffhunk://#diff-974681afd51822f80f1b9a89e8b342f67082ed09fdc1f1a211fc70c8623f81bfL21) [[2]](diffhunk://#diff-974681afd51822f80f1b9a89e8b342f67082ed09fdc1f1a211fc70c8623f81bfL74-L101)

**UI and Loading State:**
- Simplified the loading condition to display the loading spinner whenever data is fetching or loading, regardless of the current length of `personListe`.