### PR TITLE
Refactor InntektAar references (Monday commit - Nu j*vlar, nu comitter vi!)

### DIFF
--- a/apps/dolly-frontend/src/main/js/playwright/mocks/BasicMocks.ts
+++ b/apps/dolly-frontend/src/main/js/playwright/mocks/BasicMocks.ts
@@ -793,31 +793,31 @@ export const brregstubMock = {
 
 export const pensjonMock = [
 	{
-		inntektAar: 2012,
+		InntektAar: 2012,
 		belop: 10457,
 	},
 	{
-		inntektAar: 2013,
+		InntektAar: 2013,
 		belop: 10850,
 	},
 	{
-		inntektAar: 2014,
+		InntektAar: 2014,
 		belop: 11253,
 	},
 	{
-		inntektAar: 2015,
+		InntektAar: 2015,
 		belop: 11533,
 	},
 	{
-		inntektAar: 2016,
+		InntektAar: 2016,
 		belop: 11821,
 	},
 	{
-		inntektAar: 2017,
+		InntektAar: 2017,
 		belop: 12020,
 	},
 	{
-		inntektAar: 2018,
+		InntektAar: 2018,
 		belop: 12345,
 	},
 ]

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/pensjon/visning/PensjonVisning.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/pensjon/visning/PensjonVisning.tsx
@@ -17,7 +17,7 @@ export const sjekkManglerPensjonData = (pensjonData) => {
 }
 
 const getTittel = (data) => {
-	const inntektsaar = data?.map((inntekt) => inntekt.inntektAar)
+	const inntektsaar = data?.map((inntekt) => inntekt.InntektAar)
 	const foerste = Math.min(...inntektsaar)
 	const siste = Math.max(...inntektsaar)
 	return `Pensjonsgivende inntekter (${foerste} - ${siste})`
@@ -36,7 +36,7 @@ const PensjonInntekt = ({ data, isPanelOpen, setPanelOpen }) => {
 			<DollyFieldArray data={inntekter} nested>
 				{(inntekt, idx) => (
 					<div className="person-visning_content" key={idx}>
-						<TitleValue title="Inntektsår" value={inntekt?.inntektAar} />
+						<TitleValue title="Inntektsår" value={inntekt?.InntektAar} />
 						<TitleValue title="Beløp" value={inntekt?.belop} />
 					</div>
 				)}


### PR DESCRIPTION
- Update 'inntektAar' to 'InntektAar' in pensjonMock for consistency
- Modify PensjonVisning.tsx to reference 'InntektAar' instead of 'inntektAar' in data mapping and rendering #deploy-test-dolly-frontend