### PR TITLE
Bugfix/fix automatisk rerendring av personliste ved endring

### DIFF
--- a/apps/dolly-frontend/src/main/js/src/pages/gruppe/PersonListe/PersonListe.tsx
+++ b/apps/dolly-frontend/src/main/js/src/pages/gruppe/PersonListe/PersonListe.tsx
@@ -18,6 +18,7 @@ import PersonVisningConnector from '@/pages/gruppe/PersonVisning/PersonVisningCo
 import { DollyCopyButton } from '@/components/ui/button/CopyButton/DollyCopyButton'
 import { Bestilling, useGruppeById } from '@/utils/hooks/useGruppe'
 import { useLocation } from 'react-router'
+import { usePdlfPersoner } from '@/utils/hooks/usePdlForvalter'
 
 const PersonIBrukButtonConnector = React.lazy(
 	() => import('@/components/ui/button/PersonIBrukButton/PersonIBrukButtonConnector'),
@@ -70,6 +71,34 @@ export default function PersonListe({
 	const location = useLocation()
 
 	const personListe = sokSelector(selectPersonListe(identer, bestillingStatuser, fagsystem), search)
+
+	const pdlfIdenter = useMemo(() => personListe?.map((p) => p.identNr).join(','), [personListe])
+
+	const { pdlfPersoner } = usePdlfPersoner(pdlfIdenter)
+
+	if (pdlfPersoner) {
+		const pdlfMap = {}
+		pdlfPersoner.forEach((entry) => {
+			if (entry?.person?.ident) {
+				pdlfMap[entry.person.ident] = entry.person
+			}
+		})
+		personListe?.forEach((person) => {
+			const redigertPerson = pdlfMap[person?.identNr]
+			if (redigertPerson) {
+				const fornavn = redigertPerson?.navn?.[0]?.fornavn || ''
+				const mellomnavn = redigertPerson?.navn?.[0]?.mellomnavn
+					? `${redigertPerson?.navn?.[0]?.mellomnavn?.charAt(0)}.`
+					: ''
+				const etternavn = redigertPerson?.navn?.[0]?.etternavn || ''
+				if (!redigertPerson.doedsfall) {
+					person.alder = person.alder.split(' ')[0]
+				}
+				person.kjonn = redigertPerson.kjoenn?.[0]?.kjoenn
+				person.navn = `${fornavn} ${mellomnavn} ${etternavn}`
+			}
+		})
+	}
 
 	useEffect(() => {
 		const idents =
@@ -231,7 +260,7 @@ export default function PersonListe({
 		return column
 	})
 
-	if (!initialLoadDone && (isFetching || isLoading)) {
+	if ((isFetching || isLoading) && personListe?.length === 0) {
 		return <Loading label="Laster personer ..." panel />
 	}
 

--- a/apps/dolly-frontend/src/main/js/src/pages/gruppe/PersonListe/PersonListe.tsx
+++ b/apps/dolly-frontend/src/main/js/src/pages/gruppe/PersonListe/PersonListe.tsx
@@ -79,7 +79,7 @@ export default function PersonListe({
 	if (pdlfPersoner) {
 		const pdlfMap = {}
 		pdlfPersoner.forEach((entry) => {
-			if (entry?.person?.ident) {
+			if (entry?.person?.ident && entry?.person?.folkeregisterPersonstatus) {
 				pdlfMap[entry.person.ident] = entry.person
 			}
 		})
@@ -260,7 +260,7 @@ export default function PersonListe({
 		return column
 	})
 
-	if ((isFetching || isLoading) && personListe?.length === 0) {
+	if (isFetching || isLoading) {
 		return <Loading label="Laster personer ..." panel />
 	}
 

--- a/apps/dolly-frontend/src/main/js/src/pages/gruppe/PersonListe/PersonListe.tsx
+++ b/apps/dolly-frontend/src/main/js/src/pages/gruppe/PersonListe/PersonListe.tsx
@@ -50,7 +50,6 @@ export default function PersonListe({
 	const [isKommentarModalOpen, openKommentarModal, closeKommentarModal] = useBoolean(false)
 	const [selectedIdent, setSelectedIdent] = useState(null)
 	const [identListe, setIdentListe] = useState([])
-	const [initialLoadDone, setInitialLoadDone] = useState(false)
 	const dispatch = useDispatch()
 	const { gruppe: gruppeInfo } = useGruppeById(gruppeId)
 
@@ -119,12 +118,6 @@ export default function PersonListe({
 		}
 		fetchPdlPersoner(identListe)
 	}, [identListe])
-
-	useEffect(() => {
-		if (!initialLoadDone && !isFetching && personListe?.length > 0) {
-			setInitialLoadDone(true)
-		}
-	}, [isFetching, personListe, initialLoadDone])
 
 	const getKommentarTekst = (tekst) => {
 		const beskrivelse = tekst.length > 170 ? tekst.substring(0, 170) + '...' : tekst


### PR DESCRIPTION
This pull request enhances the `PersonListe` component by integrating additional person data from the PDL Forvalter service and updating the displayed person information accordingly. It also adjusts the loading state logic for a smoother user experience.

**Integration of PDL Forvalter data:**

* Added the `usePdlfPersoner` hook to fetch enriched person data from PDL Forvalter, and mapped this data to update fields such as `navn`, `kjonn`, and `alder` for each person in the list when available. [[1]](diffhunk://#diff-974681afd51822f80f1b9a89e8b342f67082ed09fdc1f1a211fc70c8623f81bfR21) [[2]](diffhunk://#diff-974681afd51822f80f1b9a89e8b342f67082ed09fdc1f1a211fc70c8623f81bfR75-R102)

**User experience improvements:**

* Simplified the loading state check to show the loading indicator whenever data is being fetched or loaded, regardless of the `initialLoadDone` flag.