### PR TITLE
Forsøk på å fikse alle personliste-bugs

### DIFF
--- a/apps/dolly-frontend/src/main/js/src/ducks/fagsystem/index.tsx
+++ b/apps/dolly-frontend/src/main/js/src/ducks/fagsystem/index.tsx
@@ -253,14 +253,11 @@ export const selectPersonListe = (identer, bestillingStatuser, fagsystem) => {
 		return null
 	}
 
-	const identListe = Object.values(identer).filter((gruppeIdent) => {
-		if (gruppeIdent.master === 'PDLF') {
-			return gruppeIdent.ident in fagsystem.pdlforvalter
-		} else if (gruppeIdent.master === 'PDL') {
-			return gruppeIdent.ident in fagsystem.pdl
-		}
-		return false
-	})
+	const identListe = Object.values(identer).filter(
+		(gruppeIdent) =>
+			Object.keys(fagsystem.pdlforvalter).includes(gruppeIdent.ident) ||
+			Object.keys(fagsystem.pdl).includes(gruppeIdent.ident),
+	)
 
 	return identListe.map((ident) => {
 		if (ident.master === 'PDLF') {

--- a/apps/dolly-frontend/src/main/js/src/pages/gruppe/PersonListe/PersonListe.tsx
+++ b/apps/dolly-frontend/src/main/js/src/pages/gruppe/PersonListe/PersonListe.tsx
@@ -18,6 +18,7 @@ import PersonVisningConnector from '@/pages/gruppe/PersonVisning/PersonVisningCo
 import { DollyCopyButton } from '@/components/ui/button/CopyButton/DollyCopyButton'
 import { Bestilling, useGruppeById } from '@/utils/hooks/useGruppe'
 import { useLocation } from 'react-router'
+import { usePdlfPersoner } from '@/utils/hooks/usePdlForvalter'
 
 const PersonIBrukButtonConnector = React.lazy(
 	() => import('@/components/ui/button/PersonIBrukButton/PersonIBrukButtonConnector'),
@@ -49,7 +50,6 @@ export default function PersonListe({
 	const [isKommentarModalOpen, openKommentarModal, closeKommentarModal] = useBoolean(false)
 	const [selectedIdent, setSelectedIdent] = useState(null)
 	const [identListe, setIdentListe] = useState([])
-	const [initialLoadDone, setInitialLoadDone] = useState(false)
 	const dispatch = useDispatch()
 	const { gruppe: gruppeInfo } = useGruppeById(gruppeId)
 
@@ -71,6 +71,34 @@ export default function PersonListe({
 
 	const personListe = sokSelector(selectPersonListe(identer, bestillingStatuser, fagsystem), search)
 
+	const pdlfIdenter = useMemo(() => personListe?.map((p) => p.identNr).join(','), [personListe])
+
+	const { pdlfPersoner } = usePdlfPersoner(pdlfIdenter)
+
+	if (pdlfPersoner) {
+		const pdlfMap = {}
+		pdlfPersoner.forEach((entry) => {
+			if (entry?.person?.ident && entry?.person?.folkeregisterPersonstatus) {
+				pdlfMap[entry.person.ident] = entry.person
+			}
+		})
+		personListe?.forEach((person) => {
+			const redigertPerson = pdlfMap[person?.identNr]
+			if (redigertPerson) {
+				const fornavn = redigertPerson?.navn?.[0]?.fornavn || ''
+				const mellomnavn = redigertPerson?.navn?.[0]?.mellomnavn
+					? `${redigertPerson?.navn?.[0]?.mellomnavn?.charAt(0)}.`
+					: ''
+				const etternavn = redigertPerson?.navn?.[0]?.etternavn || ''
+				if (!redigertPerson.doedsfall) {
+					person.alder = person.alder.split(' ')[0]
+				}
+				person.kjonn = redigertPerson.kjoenn?.[0]?.kjoenn
+				person.navn = `${fornavn} ${mellomnavn} ${etternavn}`
+			}
+		})
+	}
+
 	useEffect(() => {
 		const idents =
 			identer &&
@@ -90,12 +118,6 @@ export default function PersonListe({
 		}
 		fetchPdlPersoner(identListe)
 	}, [identListe])
-
-	useEffect(() => {
-		if (!initialLoadDone && !isFetching && personListe?.length > 0) {
-			setInitialLoadDone(true)
-		}
-	}, [isFetching, personListe, initialLoadDone])
 
 	const getKommentarTekst = (tekst) => {
 		const beskrivelse = tekst.length > 170 ? tekst.substring(0, 170) + '...' : tekst
@@ -231,7 +253,7 @@ export default function PersonListe({
 		return column
 	})
 
-	if (!initialLoadDone && (isFetching || isLoading)) {
+	if (isFetching || isLoading) {
 		return <Loading label="Laster personer ..." panel />
 	}
 


### PR DESCRIPTION
This pull request updates the logic for selecting and displaying persons in the group person list, primarily to improve how person data is fetched and displayed from the PDL Forvalter system. The main improvements include enhancing the filtering logic for identities, integrating additional person information from PDL Forvalter, and simplifying the loading state management.

**Enhancements to person selection and data integration:**

* Updated the `selectPersonListe` function to simplify and broaden the filtering logic, now including persons whose identities exist in either `fagsystem.pdlforvalter` or `fagsystem.pdl`, regardless of the `master` property.
* Integrated the `usePdlfPersoner` hook in `PersonListe.tsx` to fetch and merge additional person details (such as name, gender, and status) from PDL Forvalter for each person in the list. The fetched data is used to update the displayed information, including handling of names and gender, and adjusting age display for non-deceased persons. [[1]](diffhunk://#diff-974681afd51822f80f1b9a89e8b342f67082ed09fdc1f1a211fc70c8623f81bfR21) [[2]](diffhunk://#diff-974681afd51822f80f1b9a89e8b342f67082ed09fdc1f1a211fc70c8623f81bfR74-R101)

**Simplification of loading and state management:**

* Removed the `initialLoadDone` state and its associated effect, simplifying the logic for determining when to show the loading indicator. Now, the loading spinner is shown whenever data is being fetched or loaded. [[1]](diffhunk://#diff-974681afd51822f80f1b9a89e8b342f67082ed09fdc1f1a211fc70c8623f81bfL52) [[2]](diffhunk://#diff-974681afd51822f80f1b9a89e8b342f67082ed09fdc1f1a211fc70c8623f81bfL94-L99) [[3]](diffhunk://#diff-974681afd51822f80f1b9a89e8b342f67082ed09fdc1f1a211fc70c8623f81bfL234-R256)