### PR TITLE
Feature: Legge til Kelvin AAP

### DIFF
--- a/apps/api-oversikt-service/src/main/resources/data/apioversikt.yml
+++ b/apps/api-oversikt-service/src/main/resources/data/apioversikt.yml
@@ -76,7 +76,7 @@ system:
       url: https://institusjon-opphold-testdata.dev.intern.nav.no/swagger-ui/index.html#/INSTITUSJONSOPPHOLD/post
     delete:
       url: https://institusjon-opphold-testdata.dev.intern.nav.no/swagger-ui/index.html#/INSTITUSJONSOPPHOLD/delete
-  - register: kelvinAap
+  - register: kelvin-aap
     namespace: aap
     kubernetes-name: behandlingsflyt
     cluster: dev-gcp

--- a/apps/api-oversikt-service/src/main/resources/data/apioversikt.yml
+++ b/apps/api-oversikt-service/src/main/resources/data/apioversikt.yml
@@ -157,6 +157,12 @@ system:
     cluster: dev-fss
     read:
       url: https://norg2.intern.dev.nav.no/norg2/api
+  - register: skattekort
+    kubernetes-name: sokos-skattekort
+    namespace: okonomi
+    cluster: dev-gcp
+    write:
+      url: https://sokos-skattekort.intern.dev.nav.no/api/v1/person/docs
   - register: skjermingsregister
     kubernetes-name: skjermede-personer
     namespace: nom
@@ -169,12 +175,6 @@ system:
     cluster: dev-gcp
     write:
       url: https://sigrun-skd-stub.intern.dev.nav.no/swagger-ui/index.html?urls.primaryName=Endepunkter+for+testdata
-  - register: skattekort
-    kubernetes-name: sokos-skattekort
-    namespace: okonomi
-    cluster: dev-gcp
-    write:
-      url: https://sokos-skattekort.intern.dev.nav.no/api/v1/person/docs
   - register: sykemelding
     kubernetes-name: syfosmregler
     namespace: teamsykmelding

--- a/apps/api-oversikt-service/src/main/resources/data/apioversikt.yml
+++ b/apps/api-oversikt-service/src/main/resources/data/apioversikt.yml
@@ -76,6 +76,14 @@ system:
       url: https://institusjon-opphold-testdata.dev.intern.nav.no/swagger-ui/index.html#/INSTITUSJONSOPPHOLD/post
     delete:
       url: https://institusjon-opphold-testdata.dev.intern.nav.no/swagger-ui/index.html#/INSTITUSJONSOPPHOLD/delete
+  - register: kelvinApp
+    namespace: aap
+    kubernetes-name: behandlingsflyt
+    cluster: dev-gcp
+    read:
+      url: https://behandlingsflyt.intern.dev.nav.no/swagger-ui/index.html#/Behandlingsflyt/getBehandlingsflyt
+    write:
+      url: https://behandlingsflyt.intern.dev.nav.no/swagger-ui/index.html#/Behandlingsflyt/postBehandlingsflyt
   - register: kodeverk
     namespace: team-rocket
     kubernetes-name: kodeverk-api

--- a/apps/api-oversikt-service/src/main/resources/data/apioversikt.yml
+++ b/apps/api-oversikt-service/src/main/resources/data/apioversikt.yml
@@ -81,9 +81,9 @@ system:
     kubernetes-name: behandlingsflyt
     cluster: dev-gcp
     read:
-      url: https://behandlingsflyt.intern.dev.nav.no/swagger-ui/index.html#/Behandlingsflyt/getBehandlingsflyt
+      url: https://aap-behandlingsflyt.intern.dev.nav.no/swagger-ui/index.html#/Dolly/post_api_test_behandlingStatus
     write:
-      url: https://behandlingsflyt.intern.dev.nav.no/swagger-ui/index.html#/Behandlingsflyt/postBehandlingsflyt
+      url: https://aap-behandlingsflyt.intern.dev.nav.no/swagger-ui/index.html#/Dolly/post_api_test_opprettOgFullfoerBehandling
   - register: kodeverk
     namespace: team-rocket
     kubernetes-name: kodeverk-api
@@ -169,6 +169,12 @@ system:
     cluster: dev-gcp
     write:
       url: https://sigrun-skd-stub.intern.dev.nav.no/swagger-ui/index.html?urls.primaryName=Endepunkter+for+testdata
+  - register: skattekort
+    kubernetes-name: sokos-skattekort
+    namespace: okonomi
+    cluster: dev-gcp
+    write:
+      url: https://sokos-skattekort.intern.dev.nav.no/api/v1/person/docs
   - register: sykemelding
     kubernetes-name: syfosmregler
     namespace: teamsykmelding

--- a/apps/api-oversikt-service/src/main/resources/data/apioversikt.yml
+++ b/apps/api-oversikt-service/src/main/resources/data/apioversikt.yml
@@ -76,7 +76,7 @@ system:
       url: https://institusjon-opphold-testdata.dev.intern.nav.no/swagger-ui/index.html#/INSTITUSJONSOPPHOLD/post
     delete:
       url: https://institusjon-opphold-testdata.dev.intern.nav.no/swagger-ui/index.html#/INSTITUSJONSOPPHOLD/delete
-  - register: kelvinApp
+  - register: kelvinAap
     namespace: aap
     kubernetes-name: behandlingsflyt
     cluster: dev-gcp

--- a/apps/dolly-backend/build.gradle
+++ b/apps/dolly-backend/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     implementation "org.springframework.boot:spring-boot-starter-validation"
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation "org.springframework.retry:spring-retry"
+    implementation "org.springframework.boot:spring-boot-flyway"
 
     implementation "org.opensearch.client:opensearch-java:$versions.opensearchClient"
     implementation "org.apache.httpcomponents.client5:httpclient5"

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/kelvinaap/KelvinAapClient.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/kelvinaap/KelvinAapClient.java
@@ -1,0 +1,69 @@
+package no.nav.dolly.bestilling.kelvinaap;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import ma.glasnost.orika.MapperFacade;
+import no.nav.dolly.bestilling.ClientRegister;
+import no.nav.dolly.bestilling.kelvinaap.domain.AapOpprettRequest;
+import no.nav.dolly.domain.jpa.BestillingProgress;
+import no.nav.dolly.domain.resultset.RsDollyBestilling;
+import no.nav.dolly.domain.resultset.RsDollyUtvidetBestilling;
+import no.nav.dolly.domain.resultset.dolly.DollyPerson;
+import no.nav.dolly.mapper.MappingContextUtils;
+import no.nav.dolly.service.TransactionHelperService;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+import static java.util.Objects.nonNull;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.apache.commons.lang3.StringUtils.substring;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class KelvinAapClient implements ClientRegister {
+
+    private final KelvinAapConsumer kelvinAapConsumer;
+    private final MapperFacade mapperFacade;
+    private final TransactionHelperService transactionHelperService;
+
+    @Override
+    public Mono<BestillingProgress> gjenopprett(RsDollyUtvidetBestilling bestilling, DollyPerson dollyPerson, BestillingProgress progress, boolean isOpprettEndre) {
+
+        return Mono.just(bestilling)
+                .filter(bestilling1 -> nonNull(bestilling1.getKelvinAap()))
+                .map(RsDollyBestilling::getKelvinAap)
+                .map(kelvinAap -> {
+                    val context = MappingContextUtils.getMappingContext();
+                    context.setProperty("ident", dollyPerson.getIdent());
+                    return mapperFacade.map(kelvinAap, AapOpprettRequest.class, context);
+                })
+                .flatMap(kelvinAapConsumer::createAap)
+                .map(response -> {
+                    if (isNotBlank(response.getSaksnummer())) {
+                        log.info("AAP opprettet for ident {}: saksnummer {}", dollyPerson.getIdent(), response);
+                        return "OK";
+                    } else {
+                        log.error("Feil ved oppretting av AAP for ident {}: {}", dollyPerson.getIdent(), response);
+                        return "FEIL: %s %s".formatted(response.getStatus(), response.getError());
+                    }
+                })
+                .flatMap(status -> oppdaterStatus(progress, status));
+    }
+
+    @Override
+    public void release(List<String> identer) {
+
+        // Kelvin AAP har ingen egen release-funksjonalitet, så denne metoden er implementert som en no-op.
+    }
+
+    private Mono<BestillingProgress> oppdaterStatus(BestillingProgress progress, String status) {
+
+        return transactionHelperService.persister(progress,
+                BestillingProgress::getKelvinAapStatus,
+                BestillingProgress::setKelvinAapStatus, substring(status, 0, 255));
+    }
+}

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/kelvinaap/KelvinAapClient.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/kelvinaap/KelvinAapClient.java
@@ -39,6 +39,7 @@ public class KelvinAapClient implements ClientRegister {
                 .flatMap(kelvinAap -> kelvinAapConsumer.readAap(dollyPerson.getIdent())
                         .zipWith(Mono.just(kelvinAap)))
                 .flatMap(kelvinAap -> {
+                    log.info("Hentet AAP for ident {} {}", dollyPerson.getIdent(), kelvinAap.getT1());
                     if (nonNull(kelvinAap.getT1().getStatus())) {
                         val errStatus = "FEIL ved henting av AAP for ident: %s, %s %s".formatted(
                                 dollyPerson.getIdent(), kelvinAap.getT1().getStatus(), kelvinAap.getT1().getError());
@@ -61,7 +62,6 @@ public class KelvinAapClient implements ClientRegister {
                                         return "FEIL: %s %s".formatted(response.getStatus(), response.getError());
                                     }
                                 });
-
                     }
                 })
                 .flatMap(status -> oppdaterStatus(progress, status));

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/kelvinaap/KelvinAapClient.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/kelvinaap/KelvinAapClient.java
@@ -36,19 +36,32 @@ public class KelvinAapClient implements ClientRegister {
         return Mono.just(bestilling)
                 .filter(bestilling1 -> nonNull(bestilling1.getKelvinAap()))
                 .map(RsDollyBestilling::getKelvinAap)
-                .map(kelvinAap -> {
-                    val context = MappingContextUtils.getMappingContext();
-                    context.setProperty("ident", dollyPerson.getIdent());
-                    return mapperFacade.map(kelvinAap, AapOpprettRequest.class, context);
-                })
-                .flatMap(kelvinAapConsumer::createAap)
-                .map(response -> {
-                    if (isNotBlank(response.getSaksnummer())) {
-                        log.info("AAP opprettet for ident {}: saksnummer {}", dollyPerson.getIdent(), response);
-                        return "OK";
+                .flatMap(kelvinAap -> kelvinAapConsumer.readAap(dollyPerson.getIdent())
+                        .zipWith(Mono.just(kelvinAap)))
+                .flatMap(kelvinAap -> {
+                    if (nonNull(kelvinAap.getT1().getStatus())) {
+                        val errStatus = "FEIL ved henting av AAP for ident: %s, %s %s".formatted(
+                                dollyPerson.getIdent(), kelvinAap.getT1().getStatus(), kelvinAap.getT1().getError());
+                        log.error(errStatus);
+                        return Mono.just(errStatus);
+                    } else if (nonNull(kelvinAap.getT1().getSoeknad())) {
+                        log.info("AAP behandling for ident {} finnes allerede: {}", dollyPerson.getIdent(), kelvinAap.getT1());
+                        return Mono.just("OK");
                     } else {
-                        log.error("Feil ved oppretting av AAP for ident {}: {}", dollyPerson.getIdent(), response);
-                        return "FEIL: %s %s".formatted(response.getStatus(), response.getError());
+                        val context = MappingContextUtils.getMappingContext();
+                        context.setProperty("ident", dollyPerson.getIdent());
+                        var aapOpprettRequest = mapperFacade.map(kelvinAap.getT2(), AapOpprettRequest.class, context);
+                        return kelvinAapConsumer.createAap(aapOpprettRequest)
+                                .map(response -> {
+                                    if (isNotBlank(response.getSaksnummer())) {
+                                        log.info("AAP opprettet for ident {}: saksnummer {}", dollyPerson.getIdent(), response);
+                                        return "OK";
+                                    } else {
+                                        log.error("Feil ved oppretting av AAP for ident {}: {}", dollyPerson.getIdent(), response);
+                                        return "FEIL: %s %s".formatted(response.getStatus(), response.getError());
+                                    }
+                                });
+
                     }
                 })
                 .flatMap(status -> oppdaterStatus(progress, status));

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/kelvinaap/KelvinAapClient.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/kelvinaap/KelvinAapClient.java
@@ -55,7 +55,7 @@ public class KelvinAapClient implements ClientRegister {
                         return kelvinAapConsumer.createAap(aapOpprettRequest)
                                 .map(response -> {
                                     if (isNotBlank(response.getSaksnummer())) {
-                                        log.info("AAP opprettet for ident {}: saksnummer {}", dollyPerson.getIdent(), response);
+                                        log.info("AAP opprettet for ident {}: saksnummer {}", dollyPerson.getIdent(), response.getSaksnummer());
                                         return "OK";
                                     } else {
                                         log.error("Feil ved oppretting av AAP for ident {}: {}", dollyPerson.getIdent(), response);

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/kelvinaap/KelvinAapConsumer.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/kelvinaap/KelvinAapConsumer.java
@@ -1,9 +1,11 @@
 package no.nav.dolly.bestilling.kelvinaap;
 
 import lombok.extern.slf4j.Slf4j;
+import no.nav.dolly.bestilling.kelvinaap.command.AapBehandlingStatusPostCommand;
 import no.nav.dolly.bestilling.kelvinaap.command.AapOpprettOgFullfoerPostCommand;
 import no.nav.dolly.bestilling.kelvinaap.domain.AapOpprettRequest;
 import no.nav.dolly.bestilling.kelvinaap.domain.AapOpprettResponse;
+import no.nav.dolly.bestilling.kelvinaap.domain.AapStatusResponse;
 import no.nav.dolly.config.Consumers;
 import no.nav.testnav.libs.securitycore.domain.ServerProperties;
 import no.nav.testnav.libs.standalone.reactivesecurity.exchange.TokenExchange;
@@ -42,5 +44,11 @@ public class KelvinAapConsumer {
         return tokenService.exchange(serverProperties)
                 .flatMap(token ->
                         new AapOpprettOgFullfoerPostCommand(webClient, request, token.getTokenValue()).call());
+    }
+
+    public Mono<AapStatusResponse> readAap(String ident) {
+
+        return tokenService.exchange(serverProperties)
+                .flatMap(token -> new AapBehandlingStatusPostCommand(webClient, ident, token.getTokenValue()).call());
     }
 }

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/kelvinaap/KelvinAapConsumer.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/kelvinaap/KelvinAapConsumer.java
@@ -1,0 +1,46 @@
+package no.nav.dolly.bestilling.kelvinaap;
+
+import lombok.extern.slf4j.Slf4j;
+import no.nav.dolly.bestilling.kelvinaap.command.AapOpprettOgFullfoerPostCommand;
+import no.nav.dolly.bestilling.kelvinaap.domain.AapOpprettRequest;
+import no.nav.dolly.bestilling.kelvinaap.domain.AapOpprettResponse;
+import no.nav.dolly.config.Consumers;
+import no.nav.testnav.libs.securitycore.domain.ServerProperties;
+import no.nav.testnav.libs.standalone.reactivesecurity.exchange.TokenExchange;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+import tools.jackson.databind.json.JsonMapper;
+
+import static no.nav.dolly.util.JacksonExchangeStrategyUtil.getJacksonStrategy;
+
+@Slf4j
+@Service
+public class KelvinAapConsumer {
+
+    private final WebClient webClient;
+    private final TokenExchange tokenService;
+    private final ServerProperties serverProperties;
+
+    public KelvinAapConsumer(
+            TokenExchange tokenService,
+            Consumers consumers,
+            JsonMapper jsonMapper,
+            WebClient webClient) {
+
+        this.tokenService = tokenService;
+        serverProperties = consumers.getTestnavDollyProxy();
+        this.webClient = webClient
+                .mutate()
+                .baseUrl(serverProperties.getUrl())
+                .exchangeStrategies(getJacksonStrategy(jsonMapper))
+                .build();
+    }
+
+    public Mono<AapOpprettResponse>  createAap(AapOpprettRequest request) {
+
+        return tokenService.exchange(serverProperties)
+                .flatMap(token ->
+                        new AapOpprettOgFullfoerPostCommand(webClient, request, token.getTokenValue()).call());
+    }
+}

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/kelvinaap/KelvinAapConsumer.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/kelvinaap/KelvinAapConsumer.java
@@ -1,6 +1,7 @@
 package no.nav.dolly.bestilling.kelvinaap;
 
 import lombok.extern.slf4j.Slf4j;
+import no.nav.dolly.bestilling.ConsumerStatus;
 import no.nav.dolly.bestilling.kelvinaap.command.AapBehandlingStatusPostCommand;
 import no.nav.dolly.bestilling.kelvinaap.command.AapOpprettOgFullfoerPostCommand;
 import no.nav.dolly.bestilling.kelvinaap.domain.AapOpprettRequest;
@@ -18,7 +19,7 @@ import static no.nav.dolly.util.JacksonExchangeStrategyUtil.getJacksonStrategy;
 
 @Slf4j
 @Service
-public class KelvinAapConsumer {
+public class KelvinAapConsumer extends ConsumerStatus {
 
     private final WebClient webClient;
     private final TokenExchange tokenService;
@@ -50,5 +51,15 @@ public class KelvinAapConsumer {
 
         return tokenService.exchange(serverProperties)
                 .flatMap(token -> new AapBehandlingStatusPostCommand(webClient, ident, token.getTokenValue()).call());
+    }
+
+    @Override
+    public String serviceUrl() {
+        return serverProperties.getUrl();
+    }
+
+    @Override
+    public String consumerName() {
+        return "testnav-dolly-proxy";
     }
 }

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/kelvinaap/command/AapBehandlingStatusPostCommand.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/kelvinaap/command/AapBehandlingStatusPostCommand.java
@@ -1,0 +1,54 @@
+package no.nav.dolly.bestilling.kelvinaap.command;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import no.nav.dolly.bestilling.aareg.domain.ArbeidsforholdRespons;
+import no.nav.testnav.libs.dto.aareg.v1.Arbeidsforhold;
+import no.nav.testnav.libs.reactivecore.web.WebClientError;
+import no.nav.testnav.libs.reactivecore.web.WebClientHeader;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.core.publisher.Flux;
+import reactor.util.retry.Retry;
+
+import java.util.concurrent.Callable;
+
+import static java.time.Duration.ofSeconds;
+
+@RequiredArgsConstructor
+@Slf4j
+public class AapBehandlingStatusPostCommand implements Callable<Flux<ArbeidsforholdRespons>> {
+
+    private static final String AAP_OPPRETT_URL = "/kelvin-aap/api/test/behandlingStatus";
+    private final WebClient webClient;
+    private final String miljoe;
+    private final Arbeidsforhold arbeidsforhold;
+    private final String token;
+
+    @Override
+    public Flux<ArbeidsforholdRespons> call() {
+
+        return webClient.post()
+                .uri(uriBuilder -> uriBuilder.path(AAP_OPPRETT_URL)
+                        .build())
+                .headers(WebClientHeader.bearer(token))
+                .body(BodyInserters.fromValue(arbeidsforhold))
+                .retrieve()
+                .bodyToFlux(Arbeidsforhold.class)
+                .map(arbeidsforhold1 -> ArbeidsforholdRespons.builder()
+                        .arbeidsforhold(arbeidsforhold1)
+                        .miljoe(miljoe)
+                        .build())
+                .doOnError(WebClientError.logTo(log))
+                .retryWhen(Retry.fixedDelay(3, ofSeconds(5))
+                                .filter(throwable -> throwable instanceof WebClientResponseException responseException &&
+                                        responseException.getStatusCode().is5xxServerError())
+                        .onRetryExhaustedThrow(((retryBackoffSpec, lastSignal) ->
+                                new RuntimeException("Retries exhausted: %s".formatted(lastSignal.failure().getMessage())))))
+                .onErrorResume(error -> Flux.just(ArbeidsforholdRespons.builder()
+                        .miljoe(miljoe)
+                        .error(error)
+                        .build()));
+    }
+}

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/kelvinaap/command/AapBehandlingStatusPostCommand.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/kelvinaap/command/AapBehandlingStatusPostCommand.java
@@ -2,14 +2,15 @@ package no.nav.dolly.bestilling.kelvinaap.command;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import no.nav.dolly.bestilling.aareg.domain.ArbeidsforholdRespons;
-import no.nav.testnav.libs.dto.aareg.v1.Arbeidsforhold;
+import lombok.val;
+import no.nav.dolly.bestilling.kelvinaap.domain.AapStatusRequest;
+import no.nav.dolly.bestilling.kelvinaap.domain.AapStatusResponse;
 import no.nav.testnav.libs.reactivecore.web.WebClientError;
 import no.nav.testnav.libs.reactivecore.web.WebClientHeader;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
-import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 import reactor.util.retry.Retry;
 
 import java.util.concurrent.Callable;
@@ -18,37 +19,37 @@ import static java.time.Duration.ofSeconds;
 
 @RequiredArgsConstructor
 @Slf4j
-public class AapBehandlingStatusPostCommand implements Callable<Flux<ArbeidsforholdRespons>> {
+public class AapBehandlingStatusPostCommand implements Callable<Mono<AapStatusResponse>> {
 
     private static final String AAP_OPPRETT_URL = "/kelvin-aap/api/test/behandlingStatus";
     private final WebClient webClient;
-    private final String miljoe;
-    private final Arbeidsforhold arbeidsforhold;
+    private final String ident;
     private final String token;
 
     @Override
-    public Flux<ArbeidsforholdRespons> call() {
+    public Mono<AapStatusResponse> call() {
 
         return webClient.post()
                 .uri(uriBuilder -> uriBuilder.path(AAP_OPPRETT_URL)
                         .build())
                 .headers(WebClientHeader.bearer(token))
-                .body(BodyInserters.fromValue(arbeidsforhold))
+                .body(BodyInserters.fromValue(AapStatusRequest.builder()
+                        .ident(ident)
+                        .build()))
                 .retrieve()
-                .bodyToFlux(Arbeidsforhold.class)
-                .map(arbeidsforhold1 -> ArbeidsforholdRespons.builder()
-                        .arbeidsforhold(arbeidsforhold1)
-                        .miljoe(miljoe)
-                        .build())
+                .bodyToMono(AapStatusResponse.class)
                 .doOnError(WebClientError.logTo(log))
                 .retryWhen(Retry.fixedDelay(3, ofSeconds(5))
-                                .filter(throwable -> throwable instanceof WebClientResponseException responseException &&
-                                        responseException.getStatusCode().is5xxServerError())
+                        .filter(throwable -> throwable instanceof WebClientResponseException responseException &&
+                                             responseException.getStatusCode().is5xxServerError())
                         .onRetryExhaustedThrow(((retryBackoffSpec, lastSignal) ->
                                 new RuntimeException("Retries exhausted: %s".formatted(lastSignal.failure().getMessage())))))
-                .onErrorResume(error -> Flux.just(ArbeidsforholdRespons.builder()
-                        .miljoe(miljoe)
-                        .error(error)
-                        .build()));
+                .onErrorResume(error -> {
+                    val feilmelding = WebClientError.describe(error);
+                    return Mono.just(AapStatusResponse.builder()
+                            .status(feilmelding.getStatus())
+                            .error(feilmelding.getMessage())
+                            .build());
+                });
     }
 }

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/kelvinaap/command/AapBehandlingStatusPostCommand.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/kelvinaap/command/AapBehandlingStatusPostCommand.java
@@ -17,11 +17,12 @@ import java.util.concurrent.Callable;
 
 import static java.time.Duration.ofSeconds;
 
-@RequiredArgsConstructor
 @Slf4j
+@RequiredArgsConstructor
 public class AapBehandlingStatusPostCommand implements Callable<Mono<AapStatusResponse>> {
 
     private static final String AAP_OPPRETT_URL = "/kelvin-aap/api/test/behandlingStatus";
+
     private final WebClient webClient;
     private final String ident;
     private final String token;

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/kelvinaap/command/AapBehandlingStatusPostCommand.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/kelvinaap/command/AapBehandlingStatusPostCommand.java
@@ -21,7 +21,7 @@ import static java.time.Duration.ofSeconds;
 @RequiredArgsConstructor
 public class AapBehandlingStatusPostCommand implements Callable<Mono<AapStatusResponse>> {
 
-    private static final String AAP_OPPRETT_URL = "/kelvin-aap/api/test/behandlingStatus";
+    private static final String AAP_STATUS_URL = "/kelvin-aap/api/test/behandlingStatus";
 
     private final WebClient webClient;
     private final String ident;
@@ -31,7 +31,7 @@ public class AapBehandlingStatusPostCommand implements Callable<Mono<AapStatusRe
     public Mono<AapStatusResponse> call() {
 
         return webClient.post()
-                .uri(uriBuilder -> uriBuilder.path(AAP_OPPRETT_URL)
+                .uri(uriBuilder -> uriBuilder.path(AAP_STATUS_URL)
                         .build())
                 .headers(WebClientHeader.bearer(token))
                 .body(BodyInserters.fromValue(AapStatusRequest.builder()

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/kelvinaap/command/AapOpprettOgFullfoerPostCommand.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/kelvinaap/command/AapOpprettOgFullfoerPostCommand.java
@@ -17,11 +17,12 @@ import java.util.concurrent.Callable;
 
 import static java.time.Duration.ofSeconds;
 
-@RequiredArgsConstructor
 @Slf4j
+@RequiredArgsConstructor
 public class AapOpprettOgFullfoerPostCommand implements Callable<Mono<AapOpprettResponse>> {
 
     private static final String AAP_OPPRETT_URL = "/kelvin-aap/api/test/opprettOgFullfoerBehandling";
+
     private final WebClient webClient;
     private final AapOpprettRequest aapOpprettRequest;
     private final String token;

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/kelvinaap/command/AapOpprettOgFullfoerPostCommand.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/kelvinaap/command/AapOpprettOgFullfoerPostCommand.java
@@ -21,7 +21,7 @@ import static java.time.Duration.ofSeconds;
 @Slf4j
 public class AapOpprettOgFullfoerPostCommand implements Callable<Mono<AapOpprettResponse>> {
 
-    private static final String AAP_OPPRETT_URL = "/kelvin-aap/api/test/opprettOgFullforBehandling";
+    private static final String AAP_OPPRETT_URL = "/kelvin-aap/api/test/opprettOgFullfoerBehandling";
     private final WebClient webClient;
     private final AapOpprettRequest aapOpprettRequest;
     private final String token;

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/kelvinaap/command/AapOpprettOgFullfoerPostCommand.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/kelvinaap/command/AapOpprettOgFullfoerPostCommand.java
@@ -1,0 +1,53 @@
+package no.nav.dolly.bestilling.kelvinaap.command;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import no.nav.dolly.bestilling.kelvinaap.domain.AapOpprettRequest;
+import no.nav.dolly.bestilling.kelvinaap.domain.AapOpprettResponse;
+import no.nav.testnav.libs.reactivecore.web.WebClientError;
+import no.nav.testnav.libs.reactivecore.web.WebClientHeader;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.core.publisher.Mono;
+import reactor.util.retry.Retry;
+
+import java.util.concurrent.Callable;
+
+import static java.time.Duration.ofSeconds;
+
+@RequiredArgsConstructor
+@Slf4j
+public class AapOpprettOgFullfoerPostCommand implements Callable<Mono<AapOpprettResponse>> {
+
+    private static final String AAP_OPPRETT_URL = "/kelvin-aap/api/test/opprettOgFullforBehandling";
+    private final WebClient webClient;
+    private final AapOpprettRequest aapOpprettRequest;
+    private final String token;
+
+    @Override
+    public Mono<AapOpprettResponse> call() {
+
+        return webClient.post()
+                .uri(uriBuilder -> uriBuilder.path(AAP_OPPRETT_URL)
+                        .build())
+                .headers(WebClientHeader.bearer(token))
+                .body(BodyInserters.fromValue(aapOpprettRequest))
+                .retrieve()
+                .bodyToMono(AapOpprettResponse.class)
+                .doOnError(WebClientError.logTo(log))
+                .retryWhen(Retry.fixedDelay(3, ofSeconds(5))
+                        .filter(throwable -> throwable instanceof WebClientResponseException responseException &&
+                                             responseException.getStatusCode().is5xxServerError())
+                        .onRetryExhaustedThrow((retryBackoffSpec, lastSignal) ->
+                                new RuntimeException("Retries exhausted: %s".formatted(lastSignal.failure().getMessage()))))
+                .onErrorResume(error -> {
+                    val feilmelding = WebClientError.describe(error);
+                    return Mono.just(AapOpprettResponse.builder()
+                            .error(feilmelding.getMessage())
+                            .status(feilmelding.getStatus())
+                            .build());
+                });
+    }
+}

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/kelvinaap/command/AapOpprettOgFullfoerPostCommand.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/kelvinaap/command/AapOpprettOgFullfoerPostCommand.java
@@ -1,5 +1,6 @@
 package no.nav.dolly.bestilling.kelvinaap.command;
 
+import io.swagger.v3.core.util.Json;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
@@ -29,6 +30,8 @@ public class AapOpprettOgFullfoerPostCommand implements Callable<Mono<AapOpprett
 
     @Override
     public Mono<AapOpprettResponse> call() {
+
+        log.info("Oppretter AAP: {}", Json.pretty(aapOpprettRequest));
 
         return webClient.post()
                 .uri(uriBuilder -> uriBuilder.path(AAP_OPPRETT_URL)

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/kelvinaap/domain/AapOpprettRequest.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/kelvinaap/domain/AapOpprettRequest.java
@@ -1,0 +1,58 @@
+package no.nav.dolly.bestilling.kelvinaap.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AapOpprettRequest {
+
+    private AndreUtbetalingerDTO andreUtbetalinger;
+
+    private Boolean erStudent;
+    private Boolean harMedlemskap;
+    private Boolean harYrkesskade;
+    private String ident;
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class AndreUtbetalingerDTO {
+
+        private AfpDTO afp;
+        private Loenn loenn;
+        private Stoenad stoenad;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class AfpDTO {
+
+        private String hvemBetaler;
+    }
+
+    public enum Loenn {
+        Ja,
+        Nei
+    }
+
+    public enum Stoenad {
+        AFP,
+        INTRODUKSJONSSTØNAD,
+        KVALIFISERINGSSTØNAD,
+        LÅN,
+        NEI,
+        OMSORGSSTØNAD,
+        STIPEND,
+        UTLAND,
+        VERV,
+        ØKONOMISK_SOSIALHJELP
+    }
+}

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/kelvinaap/domain/AapOpprettRequest.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/kelvinaap/domain/AapOpprettRequest.java
@@ -45,14 +45,14 @@ public class AapOpprettRequest {
 
     public enum Stoenad {
         AFP,
-        INTRODUKSJONSSTØNAD,
-        KVALIFISERINGSSTØNAD,
-        LÅN,
+        INTRODUKSJONSSTOENAD,
+        KVALIFISERINGSSTOENAD,
+        LAN,
         NEI,
-        OMSORGSSTØNAD,
+        OMSORGSSTOENAD,
         STIPEND,
         UTLAND,
         VERV,
-        ØKONOMISK_SOSIALHJELP
+        OEKONOMISK_SOSIALHJELP
     }
 }

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/kelvinaap/domain/AapOpprettRequest.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/kelvinaap/domain/AapOpprettRequest.java
@@ -5,6 +5,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Data
 @Builder
 @NoArgsConstructor
@@ -26,7 +28,7 @@ public class AapOpprettRequest {
 
         private AfpDTO afp;
         private Loenn loenn;
-        private Stoenad stoenad;
+        private List<Stoenad> stoenad;
     }
 
     @Data

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/kelvinaap/domain/AapOpprettRequest.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/kelvinaap/domain/AapOpprettRequest.java
@@ -41,15 +41,15 @@ public class AapOpprettRequest {
     }
 
     public enum Loenn {
-        Ja,
-        Nei
+        JA,
+        NEI
     }
 
     public enum Stoenad {
         AFP,
         INTRODUKSJONSSTOENAD,
         KVALIFISERINGSSTOENAD,
-        LAN,
+        LAAN,
         NEI,
         OMSORGSSTOENAD,
         STIPEND,

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/kelvinaap/domain/AapOpprettResponse.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/kelvinaap/domain/AapOpprettResponse.java
@@ -1,0 +1,19 @@
+package no.nav.dolly.bestilling.kelvinaap.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AapOpprettResponse {
+
+    private String saksnummer;
+
+    private HttpStatus status;
+    private String error;
+}

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/kelvinaap/domain/AapStatusRequest.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/kelvinaap/domain/AapStatusRequest.java
@@ -1,0 +1,15 @@
+package no.nav.dolly.bestilling.kelvinaap.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AapStatusRequest {
+
+    private String ident;
+}

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/kelvinaap/domain/AapStatusResponse.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/kelvinaap/domain/AapStatusResponse.java
@@ -6,6 +6,8 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.springframework.http.HttpStatus;
 
+import java.util.List;
+
 @Data
 @Builder
 @NoArgsConstructor
@@ -44,7 +46,7 @@ public class AapStatusResponse {
 
         private Loenn loenn;
         private AfpDTO afp;
-        private Stoenad stoenad;
+        private List<Stoenad> stoenad;
     }
 
     @Data

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/kelvinaap/domain/AapStatusResponse.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/kelvinaap/domain/AapStatusResponse.java
@@ -1,21 +1,40 @@
-package no.nav.dolly.domain.resultset.kelvinaap;
+package no.nav.dolly.bestilling.kelvinaap.domain;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.http.HttpStatus;
 
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class RsKelvinAapRequestDTO {
+public class AapStatusResponse {
 
-    private AndreUtbetalingerDTO andreUtbetalinger;
+    private String saksnummer;
+    private String behandlingStatus;
+    private Boolean ferdig;
+    private Soeknad soeknad;
 
-    private Boolean erStudent;
-    private Boolean harMedlemskap;
-    private Boolean harYrkesskade;
+    private HttpStatus status;
+    private String error;
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Soeknad {
+
+        private Boolean erStudent;
+        private Boolean harYrkesskade;
+        private Boolean harMedlemskap;
+
+        private AndreUtbetalingerDTO andreUtbetalinger;
+        private Loenn loenn;
+        private AfpDTO afp;
+        private Stoenad stoenad;
+    }
 
     @Data
     @Builder
@@ -23,8 +42,8 @@ public class RsKelvinAapRequestDTO {
     @AllArgsConstructor
     public static class AndreUtbetalingerDTO {
 
-        private AfpDTO afp;
         private Loenn loenn;
+        private AfpDTO afp;
         private Stoenad stoenad;
     }
 

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/kelvinaap/domain/AapStatusResponse.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/kelvinaap/domain/AapStatusResponse.java
@@ -59,15 +59,15 @@ public class AapStatusResponse {
     }
 
     public enum Loenn {
-        Ja,
-        Nei
+        JA,
+        NEI
     }
 
     public enum Stoenad {
         AFP,
         INTRODUKSJONSSTOENAD,
         KVALIFISERINGSSTOENAD,
-        LAN,
+        LAAN,
         NEI,
         OMSORGSSTOENAD,
         STIPEND,

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/kelvinaap/mapper/KelvinAapMappingStrategy.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/kelvinaap/mapper/KelvinAapMappingStrategy.java
@@ -1,0 +1,27 @@
+package no.nav.dolly.bestilling.kelvinaap.mapper;
+
+import ma.glasnost.orika.CustomMapper;
+import ma.glasnost.orika.MapperFactory;
+import ma.glasnost.orika.MappingContext;
+import no.nav.dolly.bestilling.kelvinaap.domain.AapOpprettRequest;
+import no.nav.dolly.domain.resultset.kelvinaap.RsKelvinAapRequestDTO;
+import no.nav.dolly.mapper.MappingStrategy;
+import org.springframework.stereotype.Component;
+
+@Component
+public class KelvinAapMappingStrategy implements MappingStrategy {
+
+    @Override
+    public void register(MapperFactory factory) {
+        factory.classMap(RsKelvinAapRequestDTO.class, AapOpprettRequest.class)
+                .customize(new CustomMapper<>() {
+                    @Override
+                    public void mapAtoB(RsKelvinAapRequestDTO source, AapOpprettRequest destination, MappingContext context) {
+
+                        destination.setIdent((String) context.getProperty("ident"));
+                    }
+                })
+                .byDefault()
+                .register();
+    }
+}

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/domain/jpa/BestillingProgress.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/domain/jpa/BestillingProgress.java
@@ -130,6 +130,9 @@ public class BestillingProgress implements Serializable {
     @Column("nom_status")
     private String nomStatus;
 
+    @Column("kelvin_aap_status")
+    private String kelvinAapStatus;
+
     @Column("master")
     private Master master;
 

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/domain/resultset/BestilteKriterier.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/domain/resultset/BestilteKriterier.java
@@ -16,6 +16,7 @@ import no.nav.dolly.domain.resultset.histark.RsHistark;
 import no.nav.dolly.domain.resultset.inntektsmeldingstub.RsInntektsmelding;
 import no.nav.dolly.domain.resultset.inntektstub.InntektMultiplierWrapper;
 import no.nav.dolly.domain.resultset.inst.RsInstdata;
+import no.nav.dolly.domain.resultset.kelvinaap.RsKelvinAapRequestDTO;
 import no.nav.dolly.domain.resultset.kontoregister.BankkontoData;
 import no.nav.dolly.domain.resultset.krrstub.RsDigitalKontaktdata;
 import no.nav.dolly.domain.resultset.medl.RsMedl;
@@ -72,4 +73,5 @@ public class BestilteKriterier {
     private RsArbeidssoekerregisteret arbeidssoekerregisteret;
     private List<EtterlatteYtelse> etterlatteYtelser;
     private RsNomData nomdata;
+    private RsKelvinAapRequestDTO kelvinAap;
 }

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/domain/resultset/RsDollyBestilling.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/domain/resultset/RsDollyBestilling.java
@@ -18,6 +18,7 @@ import no.nav.dolly.domain.resultset.histark.RsHistark;
 import no.nav.dolly.domain.resultset.inntektsmeldingstub.RsInntektsmelding;
 import no.nav.dolly.domain.resultset.inntektstub.InntektMultiplierWrapper;
 import no.nav.dolly.domain.resultset.inst.RsInstdata;
+import no.nav.dolly.domain.resultset.kelvinaap.RsKelvinAapRequestDTO;
 import no.nav.dolly.domain.resultset.kontoregister.BankkontoData;
 import no.nav.dolly.domain.resultset.krrstub.RsDigitalKontaktdata;
 import no.nav.dolly.domain.resultset.medl.RsMedl;
@@ -89,6 +90,7 @@ public class RsDollyBestilling {
     private List<YrkesskadeRequest> yrkesskader;
     private RsArbeidssoekerregisteret arbeidssoekerregisteret;
     private List<EtterlatteYtelse> etterlatteYtelser;
+    private RsKelvinAapRequestDTO kelvinAap;
 
     public List<RsAareg> getAareg() {
         if (isNull(aareg)) {

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/domain/resultset/SystemTyper.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/domain/resultset/SystemTyper.java
@@ -24,6 +24,7 @@ public enum SystemTyper {
     INNTK("Inntektstub (INNTK)"),
     INNTKMELD("Inntektsmelding (ALTINN/JOARK)"),
     INST2("Institusjonsopphold (INST2)"),
+    KELVIN_AAP("Kelvin AAP"),
     KONTOREGISTER("Bankkontoregister"),
     KRRSTUB("Digital kontaktinformasjon (DKIF)"),
     MEDL("Medlemskap (MEDL)"),

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/domain/resultset/SystemTyper.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/domain/resultset/SystemTyper.java
@@ -24,7 +24,7 @@ public enum SystemTyper {
     INNTK("Inntektstub (INNTK)"),
     INNTKMELD("Inntektsmelding (ALTINN/JOARK)"),
     INST2("Institusjonsopphold (INST2)"),
-    KELVIN_AAP("Kelvin AAP"),
+    KELVIN_AAP("Nav AAP ytelse"),
     KONTOREGISTER("Bankkontoregister"),
     KRRSTUB("Digital kontaktinformasjon (DKIF)"),
     MEDL("Medlemskap (MEDL)"),

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/domain/resultset/kelvinaap/RsKelvinAapRequestDTO.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/domain/resultset/kelvinaap/RsKelvinAapRequestDTO.java
@@ -1,0 +1,58 @@
+package no.nav.dolly.domain.resultset.kelvinaap;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import no.nav.dolly.bestilling.kelvinaap.domain.AapOpprettRequest;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RsKelvinAapRequestDTO {
+
+    private AndreUtbetalingerDTO andreUtbetalinger;
+
+    private Boolean erStudent;
+    private Boolean harMedlemskap;
+    private Boolean harYrkesskade;
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class AndreUtbetalingerDTO {
+
+        private AfpDTO afp;
+        private Loenn loenn;
+        private Stoenad stoenad;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class AfpDTO {
+
+        private String hvemBetaler;
+    }
+
+    public enum Loenn {
+        Ja,
+        Nei
+    }
+
+    public enum Stoenad {
+        AFP,
+        INTRODUKSJONSSTØNAD,
+        KVALIFISERINGSSTØNAD,
+        LÅN,
+        NEI,
+        OMSORGSSTØNAD,
+        STIPEND,
+        UTLAND,
+        VERV,
+        ØKONOMISK_SOSIALHJELP
+    }
+}

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/domain/resultset/kelvinaap/RsKelvinAapRequestDTO.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/domain/resultset/kelvinaap/RsKelvinAapRequestDTO.java
@@ -5,6 +5,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Data
 @Builder
 @NoArgsConstructor
@@ -25,7 +27,7 @@ public class RsKelvinAapRequestDTO {
 
         private AfpDTO afp;
         private Loenn loenn;
-        private Stoenad stoenad;
+        private List<Stoenad> stoenad;
     }
 
     @Data

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/domain/resultset/kelvinaap/RsKelvinAapRequestDTO.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/domain/resultset/kelvinaap/RsKelvinAapRequestDTO.java
@@ -40,15 +40,15 @@ public class RsKelvinAapRequestDTO {
     }
 
     public enum Loenn {
-        Ja,
-        Nei
+        JA,
+        NEI
     }
 
     public enum Stoenad {
         AFP,
         INTRODUKSJONSSTOENAD,
         KVALIFISERINGSSTOENAD,
-        LAN,
+        LAAN,
         NEI,
         OMSORGSSTOENAD,
         STIPEND,

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/mapper/BestillingKelvinAapStatusMapper.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/mapper/BestillingKelvinAapStatusMapper.java
@@ -1,0 +1,45 @@
+package no.nav.dolly.mapper;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import no.nav.dolly.domain.jpa.BestillingProgress;
+import no.nav.dolly.domain.resultset.RsStatusRapport;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static no.nav.dolly.domain.resultset.SystemTyper.KELVIN_AAP;
+import static no.nav.dolly.mapper.AbstractRsStatusMiljoeIdentForhold.decodeMsg;
+import static no.nav.dolly.util.ListUtil.listOf;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class BestillingKelvinAapStatusMapper {
+
+    public static List<RsStatusRapport> buildKelvinAapStatusMap(List<BestillingProgress> progressList) {
+
+        Map<String, List<String>> statusMap = new HashMap<>();
+
+        progressList.forEach(progress -> {
+            if (isNotBlank(progress.getKelvinAapStatus())) {
+                if (statusMap.containsKey(progress.getKelvinAapStatus())) {
+                    statusMap.get(progress.getKelvinAapStatus()).add(progress.getIdent());
+                } else {
+                    statusMap.put(progress.getKelvinAapStatus(), listOf(progress.getIdent()));
+                }
+            }
+        });
+
+        return statusMap.isEmpty() ? emptyList() :
+                singletonList(RsStatusRapport.builder().id(KELVIN_AAP).navn(KELVIN_AAP.getBeskrivelse())
+                        .statuser(statusMap.entrySet().stream().map(entry -> RsStatusRapport.Status.builder()
+                                        .melding(decodeMsg(entry.getKey()))
+                                        .identer(entry.getValue())
+                                        .build())
+                                .toList())
+                        .build());
+    }
+}

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/mapper/strategy/BestillingStatusMappingStrategy.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/mapper/strategy/BestillingStatusMappingStrategy.java
@@ -33,6 +33,7 @@ import static no.nav.dolly.mapper.BestillingImportFraPdlStatusMapper.buildImport
 import static no.nav.dolly.mapper.BestillingInntektsmeldingStatusMapper.buildInntektsmeldingStatusMap;
 import static no.nav.dolly.mapper.BestillingInntektstubStatusMapper.buildInntektstubStatusMap;
 import static no.nav.dolly.mapper.BestillingInstdataStatusMapper.buildInstdataStatusMap;
+import static no.nav.dolly.mapper.BestillingKelvinAapStatusMapper.buildKelvinAapStatusMap;
 import static no.nav.dolly.mapper.BestillingKontoregisterStatusMapper.buildKontoregisterStatusMap;
 import static no.nav.dolly.mapper.BestillingKrrStubStatusMapper.buildKrrStubStatusMap;
 import static no.nav.dolly.mapper.BestillingMedlStatusMapper.buildMedlStatusMap;
@@ -116,6 +117,7 @@ public class BestillingStatusMappingStrategy implements MappingStrategy {
                         bestillingStatus.getStatus().addAll(buildSkattekortStatusMap(progresser));
                         bestillingStatus.getStatus().addAll(buildTpsMessagingStatusMap(progresser));
                         bestillingStatus.getStatus().addAll(buildAnnenFeilStatusMap(progresser));
+                        bestillingStatus.getStatus().addAll(buildKelvinAapStatusMap(progresser));
                     }
                 })
                 .exclude("bruker")

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/mapper/strategy/DollyRequest2MalBestillingMappingStrategy.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/mapper/strategy/DollyRequest2MalBestillingMappingStrategy.java
@@ -76,6 +76,7 @@ public class DollyRequest2MalBestillingMappingStrategy implements MappingStrateg
                 .field("histark", "histark")
                 .field("inntektsmelding", "inntektsmelding")
                 .field("inntektstub", "inntektstub")
+                .field("kelvinAap", "kelvinAap")
                 .field("krrstub", "krrstub")
                 .field("medl", "medl")
                 .field("navSyntetiskIdent", "navSyntetiskIdent")

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/service/BestillingService.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/service/BestillingService.java
@@ -582,6 +582,7 @@ public class BestillingService {
                                     .tpsMessaging(request2.getTpsMessaging())
                                     .udistub(request2.getUdistub())
                                     .yrkesskader(request2.getYrkesskader())
+                                    .kelvinAap(request2.getKelvinAap())
                                     .build());
                             return Mono.just(isNotBlank(bestKriterier) ? bestKriterier : "{}");
                         }));

--- a/apps/dolly-backend/src/main/resources/application-local.yml
+++ b/apps/dolly-backend/src/main/resources/application-local.yml
@@ -7,15 +7,15 @@ spring:
   cache:
     type: none
   config:
-    import: "sm://"
+    import: "sm@"
   flyway:
     url: jdbc:postgresql://localhost:5432/testnav-dolly-backend-local
     user: testnav-dolly-backend-local
-    password: ${sm\://testnav-dolly-backend-local}
+    password: ${sm@testnav-dolly-backend-local}
   r2dbc:
     url: r2dbc:postgresql://localhost:5432/testnav-dolly-backend-local
     username: testnav-dolly-backend-local
-    password: ${sm\://testnav-dolly-backend-local}
+    password: ${sm@testnav-dolly-backend-local}
   devtools:
     restart:
       enabled: false

--- a/apps/dolly-backend/src/main/resources/application-local.yml
+++ b/apps/dolly-backend/src/main/resources/application-local.yml
@@ -7,15 +7,15 @@ spring:
   cache:
     type: none
   config:
-    import: "sm@"
+    import: "sm://"
   flyway:
     url: jdbc:postgresql://localhost:5432/testnav-dolly-backend-local
     user: testnav-dolly-backend-local
-    password: ${sm@testnav-dolly-backend-local}
+    password: ${sm\://testnav-dolly-backend-local}
   r2dbc:
     url: r2dbc:postgresql://localhost:5432/testnav-dolly-backend-local
     username: testnav-dolly-backend-local
-    password: ${sm@testnav-dolly-backend-local}
+    password: ${sm\://testnav-dolly-backend-local}
   devtools:
     restart:
       enabled: false

--- a/apps/dolly-backend/src/main/resources/application.yml
+++ b/apps/dolly-backend/src/main/resources/application.yml
@@ -27,7 +27,7 @@ spring:
   reactor:
     context-propagation: auto
   flyway:
-    enabled: true # Disabled by default as you should probably think twice before running Flyway-migrations
+    enabled: true
     locations: classpath:db/migration
     baseline-on-migrate: true
   mvc:
@@ -42,9 +42,6 @@ spring:
   jackson:
     parser:
       include-source-in-location: true
-    deserialization:
-      fail-on-null-for-primitives: false
-      fail-on-unknown-properties: false
   http:
     codecs:
       max-in-memory-size: 50MB

--- a/apps/dolly-backend/src/main/resources/db/migration/V1.9.2__ModifyTableBestillingProgress.sql
+++ b/apps/dolly-backend/src/main/resources/db/migration/V1.9.2__ModifyTableBestillingProgress.sql
@@ -1,0 +1,6 @@
+-------------------------------
+-- M O D I F Y   T A B L E S --
+-------------------------------
+
+ALTER TABLE bestilling_progress
+ADD COLUMN kelvin_aap_status VARCHAR(255);

--- a/apps/dolly-backend/src/main/resources/logback-spring.xml
+++ b/apps/dolly-backend/src/main/resources/logback-spring.xml
@@ -9,8 +9,6 @@
     </springProfile>
 
     <logger level="TRACE" name="no.nav.testnav.libs.reactivecore.filter.RequestLogger"/>
-<!--    <logger level="TRACE" name="no.nav.dolly.bestilling.histark.HistarkConsumer"/>-->
-    <logger level="TRACE" name="no.nav.testnav.libs.reactivecore.filter.RequestLogger"/>
     <logger level="TRACE" name="org.jetbrains.nativecerts"/>
     <logger level="TRACE" name="com.intellij.util.net.ssl"/>
     <logger level="ERROR" name="reactor.netty.transport.TransportConnector"/>

--- a/apps/dolly-backend/src/main/resources/logback-spring.xml
+++ b/apps/dolly-backend/src/main/resources/logback-spring.xml
@@ -9,11 +9,11 @@
     </springProfile>
 
     <logger level="TRACE" name="no.nav.testnav.libs.reactivecore.filter.RequestLogger"/>
-    <logger level="TRACE" name="no.nav.dolly.bestilling.histark.HistarkConsumer"/>
+<!--    <logger level="TRACE" name="no.nav.dolly.bestilling.histark.HistarkConsumer"/>-->
     <logger level="TRACE" name="no.nav.testnav.libs.reactivecore.filter.RequestLogger"/>
     <logger level="TRACE" name="org.jetbrains.nativecerts"/>
     <logger level="TRACE" name="com.intellij.util.net.ssl"/>
     <logger level="ERROR" name="reactor.netty.transport.TransportConnector"/>
     <logger level="DEBUG" name="reactor.netty.http.client.HttpClient"/>
-    <logger level="DEBUG" name="no.nav.testnav.libs.reactivecore.logging.WebClientLogger"/>
+<!--    <logger level="DEBUG" name="no.nav.testnav.libs.reactivecore.logging.WebClientLogger"/>-->
 </configuration>

--- a/apps/dolly-backend/src/test/java/no/nav/dolly/bestilling/kelvinaap/KelvinAapConsumerTest.java
+++ b/apps/dolly-backend/src/test/java/no/nav/dolly/bestilling/kelvinaap/KelvinAapConsumerTest.java
@@ -1,0 +1,191 @@
+package no.nav.dolly.bestilling.kelvinaap;
+
+import no.nav.dolly.bestilling.AbstractConsumerTest;
+import no.nav.dolly.bestilling.kelvinaap.domain.AapOpprettRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import reactor.test.StepVerifier;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.badRequest;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.serverError;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class KelvinAapConsumerTest extends AbstractConsumerTest {
+
+    private static final String IDENT = "12345678901";
+    private static final String SAKSNUMMER = "SAK-123456";
+
+    @Autowired
+    private KelvinAapConsumer kelvinAapConsumer;
+
+    @Test
+    void shouldCreateAapSuccessfully() {
+
+        stubFor(post(urlPathMatching("(.*)/kelvin-aap/api/test/opprettOgFullfoerBehandling"))
+                .willReturn(ok()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""
+                                {"saksnummer": "%s"}
+                                """.formatted(SAKSNUMMER))));
+
+        var request = AapOpprettRequest.builder()
+                .ident(IDENT)
+                .erStudent(false)
+                .harMedlemskap(true)
+                .harYrkesskade(false)
+                .build();
+
+        StepVerifier.create(kelvinAapConsumer.createAap(request))
+                .assertNext(response -> {
+                    assertThat(response.getSaksnummer()).isEqualTo(SAKSNUMMER);
+                    assertThat(response.getStatus()).isNull();
+                    assertThat(response.getError()).isNull();
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void shouldHandleCreateAapBadRequest() {
+
+        stubFor(post(urlPathMatching("(.*)/kelvin-aap/api/test/opprettOgFullfoerBehandling"))
+                .willReturn(badRequest()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"message\": \"Ugyldig forespørsel\"}")));
+
+        var request = AapOpprettRequest.builder()
+                .ident(IDENT)
+                .build();
+
+        StepVerifier.create(kelvinAapConsumer.createAap(request))
+                .assertNext(response -> {
+                    assertThat(response.getSaksnummer()).isNull();
+                    assertThat(response.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST);
+                    assertThat(response.getError()).isNotBlank();
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void shouldHandleCreateAapServerError() {
+
+        stubFor(post(urlPathMatching("(.*)/kelvin-aap/api/test/opprettOgFullfoerBehandling"))
+                .willReturn(serverError()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"message\": \"Intern serverfeil\"}")));
+
+        var request = AapOpprettRequest.builder()
+                .ident(IDENT)
+                .build();
+
+        StepVerifier.create(kelvinAapConsumer.createAap(request))
+                .assertNext(response -> {
+                    assertThat(response.getSaksnummer()).isNull();
+                    assertThat(response.getStatus()).isNotNull();
+                    assertThat(response.getError()).isNotBlank();
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void shouldReadAapStatusSuccessfully() {
+
+        stubFor(post(urlPathMatching("(.*)/kelvin-aap/api/test/behandlingStatus"))
+                .willReturn(ok()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""
+                                {
+                                    "saksnummer": "%s",
+                                    "behandlingStatus": "FERDIG",
+                                    "ferdig": true,
+                                    "soeknad": {
+                                        "erStudent": false,
+                                        "harYrkesskade": false,
+                                        "harMedlemskap": true
+                                    }
+                                }
+                                """.formatted(SAKSNUMMER))));
+
+        StepVerifier.create(kelvinAapConsumer.readAap(IDENT))
+                .assertNext(response -> {
+                    assertThat(response.getSaksnummer()).isEqualTo(SAKSNUMMER);
+                    assertThat(response.getBehandlingStatus()).isEqualTo("FERDIG");
+                    assertThat(response.getFerdig()).isTrue();
+                    assertThat(response.getSoeknad()).isNotNull();
+                    assertThat(response.getSoeknad().getErStudent()).isFalse();
+                    assertThat(response.getSoeknad().getHarMedlemskap()).isTrue();
+                    assertThat(response.getStatus()).isNull();
+                    assertThat(response.getError()).isNull();
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void shouldReadAapStatusWithNoExistingBehandling() {
+
+        stubFor(post(urlPathMatching("(.*)/kelvin-aap/api/test/behandlingStatus"))
+                .willReturn(ok()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{}")));
+
+        StepVerifier.create(kelvinAapConsumer.readAap(IDENT))
+                .assertNext(response -> {
+                    assertThat(response.getSoeknad()).isNull();
+                    assertThat(response.getStatus()).isNull();
+                    assertThat(response.getError()).isNull();
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void shouldHandleReadAapBadRequest() {
+
+        stubFor(post(urlPathMatching("(.*)/kelvin-aap/api/test/behandlingStatus"))
+                .willReturn(badRequest()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"message\": \"Ukjent ident\"}")));
+
+        StepVerifier.create(kelvinAapConsumer.readAap(IDENT))
+                .assertNext(response -> {
+                    assertThat(response.getSoeknad()).isNull();
+                    assertThat(response.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST);
+                    assertThat(response.getError()).isNotBlank();
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void shouldHandleReadAapServerError() {
+
+        stubFor(post(urlPathMatching("(.*)/kelvin-aap/api/test/behandlingStatus"))
+                .willReturn(serverError()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"message\": \"Intern serverfeil\"}")));
+
+        StepVerifier.create(kelvinAapConsumer.readAap(IDENT))
+                .assertNext(response -> {
+                    assertThat(response.getSoeknad()).isNull();
+                    assertThat(response.getStatus()).isNotNull();
+                    assertThat(response.getError()).isNotBlank();
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void shouldReturnCorrectServiceUrl() {
+
+        assertThat(kelvinAapConsumer.serviceUrl())
+                .contains("localhost");
+    }
+
+    @Test
+    void shouldReturnCorrectConsumerName() {
+
+        assertThat(kelvinAapConsumer.consumerName())
+                .isEqualTo("testnav-dolly-proxy");
+    }
+}

--- a/apps/dolly-search-service/src/main/java/no/nav/testnav/dollysearchservice/utils/FagsystemQueryUtils.java
+++ b/apps/dolly-search-service/src/main/java/no/nav/testnav/dollysearchservice/utils/FagsystemQueryUtils.java
@@ -45,6 +45,7 @@ public class FagsystemQueryUtils {
             case INNTK -> mustExistQuery(queryBuilder, "inntektstub");
             case INNTKMELD -> mustExistQuery(queryBuilder, "inntektsmelding");
             case INST -> mustExistQuery(queryBuilder, "instdata");
+            case KELVIN_AAP -> mustExistQuery(queryBuilder, "kelvinAap");
             case KRRSTUB -> mustExistQuery(queryBuilder, "krrstub");
             case MEDL -> mustExistQuery(queryBuilder, "medl");
             case NOM -> mustExistQuery(queryBuilder, "nomdata");

--- a/libs/data-transfer-objects/src/main/java/no/nav/testnav/libs/dto/dollysearchservice/v1/ElasticTyper.java
+++ b/libs/data-transfer-objects/src/main/java/no/nav/testnav/libs/dto/dollysearchservice/v1/ElasticTyper.java
@@ -26,6 +26,7 @@ public enum ElasticTyper {
     INNTK("Inntektskomponenten/stub (INNTK)", false),
     INNTKMELD("Inntektsmelding (ALTINN/JOARK)", true),
     INST("Institusjonsopphold (INST2)", true),
+    KELVIN_AAP("Kvinne AAP ytelse", false),
     KRRSTUB("Kontakt- og reservasjonsregister-stub", false),
     MEDL("Medlemskap (MEDL)", false),
     NOM("Nav-ansatt (NOM)", false),

--- a/libs/data-transfer-objects/src/main/java/no/nav/testnav/libs/dto/dollysearchservice/v1/ElasticTyper.java
+++ b/libs/data-transfer-objects/src/main/java/no/nav/testnav/libs/dto/dollysearchservice/v1/ElasticTyper.java
@@ -26,7 +26,7 @@ public enum ElasticTyper {
     INNTK("Inntektskomponenten/stub (INNTK)", false),
     INNTKMELD("Inntektsmelding (ALTINN/JOARK)", true),
     INST("Institusjonsopphold (INST2)", true),
-    KELVIN_AAP("Kvinne AAP ytelse", false),
+    KELVIN_AAP("Kelvin AAP ytelse", false),
     KRRSTUB("Kontakt- og reservasjonsregister-stub", false),
     MEDL("Medlemskap (MEDL)", false),
     NOM("Nav-ansatt (NOM)", false),

--- a/libs/data-transfer-objects/src/main/java/no/nav/testnav/libs/dto/dollysearchservice/v1/ElasticTyper.java
+++ b/libs/data-transfer-objects/src/main/java/no/nav/testnav/libs/dto/dollysearchservice/v1/ElasticTyper.java
@@ -26,7 +26,7 @@ public enum ElasticTyper {
     INNTK("Inntektskomponenten/stub (INNTK)", false),
     INNTKMELD("Inntektsmelding (ALTINN/JOARK)", true),
     INST("Institusjonsopphold (INST2)", true),
-    KELVIN_AAP("Kelvin AAP ytelse", false),
+    KELVIN_AAP("Nav AAP ytelse", false),
     KRRSTUB("Kontakt- og reservasjonsregister-stub", false),
     MEDL("Medlemskap (MEDL)", false),
     NOM("Nav-ansatt (NOM)", false),

--- a/libs/data-transfer-objects/src/main/java/no/nav/testnav/libs/dto/dollysearchservice/v1/SearchRequest.java
+++ b/libs/data-transfer-objects/src/main/java/no/nav/testnav/libs/dto/dollysearchservice/v1/SearchRequest.java
@@ -1,6 +1,5 @@
 package no.nav.testnav.libs.dto.dollysearchservice.v1;
 
-import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -14,16 +13,11 @@ import java.util.List;
 @AllArgsConstructor
 public class SearchRequest {
 
-    @Schema(description = "Sidenummer")
     private Integer side;
-    @Schema(description = "Antall resultater per side")
     private Integer antall;
-    @Schema(description = "Seed for paginering")
     private Integer seed;
 
-    @Schema(description = "Hvilke miljøer")
     private List<String> miljoer;
 
-    @Schema(description = "Persondetaljer")
     private PersonRequest personRequest;
 }

--- a/libs/security-core/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/libs/security-core/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -3,12 +3,12 @@
     {
       "name": "AZURE_APP_CLIENT_ID",
       "type": "java.lang.String",
-      "description": "Satt av NAIS i pod. Se ClientCredentialConfig#azureNavClientCredential. Kan erstattes med ${sm\://azure-app-client-id} for lokal kjøring."
+      "description": "Satt av NAIS i pod. Se ClientCredentialConfig#azureNavClientCredential. Kan erstattes med ${sm@azure-app-client-id} for lokal kjøring."
     },
     {
       "name": "AZURE_APP_CLIENT_SECRET",
       "type": "java.lang.String",
-      "description": "Satt av NAIS i pod. Se ClientCredentialConfig#azureNavClientCredential. Kan erstattes med ${sm\://azure-app-client-secret} for lokal kjøring."
+      "description": "Satt av NAIS i pod. Se ClientCredentialConfig#azureNavClientCredential. Kan erstattes med ${sm@azure-app-client-secret} for lokal kjøring."
     },
     {
       "name": "AZURE_TRYGDEETATEN_OPENID_CONFIG_TOKEN_ENDPOINT",

--- a/libs/security-core/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/libs/security-core/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -3,12 +3,12 @@
     {
       "name": "AZURE_APP_CLIENT_ID",
       "type": "java.lang.String",
-      "description": "Satt av NAIS i pod. Se ClientCredentialConfig#azureNavClientCredential. Kan erstattes med ${sm@azure-app-client-id} for lokal kjøring."
+      "description": "Satt av NAIS i pod. Se ClientCredentialConfig#azureNavClientCredential. Kan erstattes med ${sm\://azure-app-client-id} for lokal kjøring."
     },
     {
       "name": "AZURE_APP_CLIENT_SECRET",
       "type": "java.lang.String",
-      "description": "Satt av NAIS i pod. Se ClientCredentialConfig#azureNavClientCredential. Kan erstattes med ${sm@azure-app-client-secret} for lokal kjøring."
+      "description": "Satt av NAIS i pod. Se ClientCredentialConfig#azureNavClientCredential. Kan erstattes med ${sm\://azure-app-client-secret} for lokal kjøring."
     },
     {
       "name": "AZURE_TRYGDEETATEN_OPENID_CONFIG_TOKEN_ENDPOINT",

--- a/proxies/dolly-proxy/src/main/java/no/nav/dolly/proxy/route/KelvinAap.java
+++ b/proxies/dolly-proxy/src/main/java/no/nav/dolly/proxy/route/KelvinAap.java
@@ -1,0 +1,35 @@
+package no.nav.dolly.proxy.route;
+
+import lombok.RequiredArgsConstructor;
+import no.nav.dolly.proxy.auth.AuthenticationFilterService;
+import org.springframework.cloud.gateway.route.Route;
+import org.springframework.cloud.gateway.route.builder.Buildable;
+import org.springframework.cloud.gateway.route.builder.PredicateSpec;
+import org.springframework.stereotype.Component;
+
+import java.util.function.Function;
+
+@Component
+@RequiredArgsConstructor
+class KelvinAap {
+
+    private static final String CLUSTER = "dev-gcp";
+    private static final String NAMESPACE = "aap";
+    private static final String NAME = "behandlingsflyt";
+
+    private final Targets targets;
+    private final AuthenticationFilterService authenticationFilterService;
+
+    Function<PredicateSpec, Buildable<Route>> build() {
+
+        var bearerAuthenticationFilter = authenticationFilterService
+                .getTrygdeetatenAuthenticationFilter(CLUSTER, NAMESPACE,
+                        NAME, targets.getKelvinAap());
+
+        return spec -> spec
+                .path("/kelvin-aap/**")
+                .filters(f -> f.stripPrefix(1)
+                        .filter(bearerAuthenticationFilter))
+                .uri(targets.kelvinAap);
+    }
+}

--- a/proxies/dolly-proxy/src/main/java/no/nav/dolly/proxy/route/RouteLocatorConfig.java
+++ b/proxies/dolly-proxy/src/main/java/no/nav/dolly/proxy/route/RouteLocatorConfig.java
@@ -21,6 +21,7 @@ class RouteLocatorConfig {
     private final Histark histark;
     private final Inntektstub inntektstub;
     private final Inst inst;
+    private final KelvinAap kelvinAap;
     private final Kontoregister kontoregister;
     private final Skattekort skattekort;
     private final Krrstub krrstub;
@@ -60,6 +61,7 @@ class RouteLocatorConfig {
                 .route("histark", histark.build())
                 .route("inntektstub", inntektstub.build())
                 .route("inst", inst.build())
+                .route("kelvin-aap", kelvinAap.build())
                 .route("kontoregister", kontoregister.build())
                 .route("skattekort", skattekort.build())
                 .route("krrstub", krrstub.build())

--- a/proxies/dolly-proxy/src/main/java/no/nav/dolly/proxy/route/Targets.java
+++ b/proxies/dolly-proxy/src/main/java/no/nav/dolly/proxy/route/Targets.java
@@ -27,6 +27,7 @@ class Targets {
     String histark;
     String inntektstub;
     String inst;
+    String kelvinAap;
     String kontoregister;
     String skattekort;
     String krrstub;

--- a/proxies/dolly-proxy/src/main/resources/application.yml
+++ b/proxies/dolly-proxy/src/main/resources/application.yml
@@ -47,6 +47,7 @@ app:
     histark: https://histarkimport.dev.intern.nav.no
     inntektstub: http://inntektstub.team-inntekt
     inst: http://opphold-testdata.team-rocket.svc.nais.local
+    kelvin-aap: https://aap-behandlingsflyt.intern.dev.nav.no
     kontoregister: https://sokos-kontoregister-person.intern.dev.nav.no
     skattekort: https://sokos-skattekort.intern.dev.nav.no
     krrstub: https://digdir-krr-stub.intern.dev.nav.no

--- a/proxies/dolly-proxy/src/test/java/no/nav/dolly/proxy/route/RouteLocatorConfigTest.java
+++ b/proxies/dolly-proxy/src/test/java/no/nav/dolly/proxy/route/RouteLocatorConfigTest.java
@@ -95,6 +95,7 @@ class RouteLocatorConfigTest {
         registry.add("app.targets.histark", () -> wireMockServer.baseUrl());
         registry.add("app.targets.inntektstub", () -> wireMockServer.baseUrl());
         registry.add("app.targets.inst", () -> wireMockServer.baseUrl());
+        registry.add("app.targets.kelvin-aap", () -> wireMockServer.baseUrl());
         registry.add("app.targets.kontoregister", () -> wireMockServer.baseUrl());
         registry.add("app.targets.skattekort", () -> wireMockServer.baseUrl());
         registry.add("app.targets.krrstub", () -> wireMockServer.baseUrl());

--- a/proxies/dolly-proxy/src/test/java/no/nav/dolly/proxy/route/RouteLocatorConfigTest.java
+++ b/proxies/dolly-proxy/src/test/java/no/nav/dolly/proxy/route/RouteLocatorConfigTest.java
@@ -46,7 +46,7 @@ import static org.mockito.Mockito.when;
 @AutoConfigureWebTestClient(timeout = "30000")
 class RouteLocatorConfigTest {
 
-    private static final String jwt = JWT
+    private static final String TOKEN = JWT
             .create()
             .withExpiresAt(Date.from(Instant.now().plusSeconds(TimeUnit.MINUTES.toSeconds(5))))
             .sign(Algorithm.none());
@@ -68,15 +68,15 @@ class RouteLocatorConfigTest {
     private WebTestClient webClient;
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         when(tokenExchange.exchange(any()))
-                .thenReturn(Mono.just(new AccessToken(jwt)));
+                .thenReturn(Mono.just(new AccessToken(TOKEN)));
         when(navTokenService.exchange(any()))
-                .thenReturn(Mono.just(new AccessToken(jwt)));
+                .thenReturn(Mono.just(new AccessToken(TOKEN)));
         when(trygdeetatenTokenService.exchange(any()))
-                .thenReturn(Mono.just(new AccessToken(jwt)));
+                .thenReturn(Mono.just(new AccessToken(TOKEN)));
         when(tokenXService.exchange(any(), any()))
-                .thenReturn(Mono.just(new AccessToken(jwt)));
+                .thenReturn(Mono.just(new AccessToken(TOKEN)));
     }
 
     @DynamicPropertySource
@@ -145,7 +145,7 @@ class RouteLocatorConfigTest {
                     .expectBody(String.class).isEqualTo(responseBody);
 
             wireMockServer.verify(1, postRequestedFor(urlEqualTo(downstreamPath))
-                    .withHeader(HttpHeaders.AUTHORIZATION, matching("Bearer " + jwt)));
+                    .withHeader(HttpHeaders.AUTHORIZATION, matching("Bearer " + TOKEN)));
             wireMockServer.verify(0, getRequestedFor(urlEqualTo(downstreamPath)));
 
         } else {
@@ -165,7 +165,7 @@ class RouteLocatorConfigTest {
                     .expectBody(String.class).isEqualTo(responseBody);
 
             wireMockServer.verify(1, getRequestedFor(urlEqualTo(downstreamPath))
-                    .withHeader(HttpHeaders.AUTHORIZATION, matching("Bearer " + jwt)));
+                    .withHeader(HttpHeaders.AUTHORIZATION, matching("Bearer " + TOKEN)));
             wireMockServer.verify(0, postRequestedFor(urlEqualTo(downstreamPath)));
 
         }
@@ -294,7 +294,7 @@ class RouteLocatorConfigTest {
                 .expectBody(String.class).isEqualTo(responseBody);
 
         wireMockServer.verify(1, getRequestedFor(urlEqualTo(servedPath))
-                .withHeader(HttpHeaders.AUTHORIZATION, matching("Bearer " + jwt)));
+                .withHeader(HttpHeaders.AUTHORIZATION, matching("Bearer " + TOKEN)));
 
     }
 
@@ -351,7 +351,7 @@ class RouteLocatorConfigTest {
                 .expectBody(String.class).isEqualTo(responseBody);
 
         wireMockServer.verify(1, getRequestedFor(urlEqualTo(downstreamPath))
-                .withHeader(HttpHeaders.AUTHORIZATION, matching("Bearer " + jwt)));
+                .withHeader(HttpHeaders.AUTHORIZATION, matching("Bearer " + TOKEN)));
 
     }
 
@@ -424,7 +424,57 @@ class RouteLocatorConfigTest {
                 .expectBody(String.class).isEqualTo(responseBody);
 
         wireMockServer.verify(1, getRequestedFor(urlEqualTo(downstreamPath))
-                .withHeader(HttpHeaders.AUTHORIZATION, matching("Bearer " + jwt)));
+                .withHeader(HttpHeaders.AUTHORIZATION, matching("Bearer " + TOKEN)));
+
+    }
+
+    @Test
+    void testKelvinAapGet() {
+
+        var downstreamPath = "/api/test/behandlingStatus";
+        var responseBody = "Success from mocked kelvin-aap";
+
+        wireMockServer.stubFor(get(urlEqualTo(downstreamPath))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(responseBody)));
+
+        webClient
+                .get()
+                .uri("/kelvin-aap" + downstreamPath)
+                .exchange()
+                .expectStatus().isOk()
+                .expectHeader().contentType("application/json")
+                .expectBody(String.class).isEqualTo(responseBody);
+
+        wireMockServer.verify(1, getRequestedFor(urlEqualTo(downstreamPath))
+                .withHeader(HttpHeaders.AUTHORIZATION, matching("Bearer " + TOKEN)));
+
+    }
+
+    @Test
+    void testKelvinAapPost() {
+
+        var downstreamPath = "/api/test/opprettOgFullfoerBehandling";
+        var responseBody = "{\"saksnummer\": \"SAK-123456\"}";
+
+        wireMockServer.stubFor(post(urlEqualTo(downstreamPath))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(responseBody)));
+
+        webClient
+                .post()
+                .uri("/kelvin-aap" + downstreamPath)
+                .exchange()
+                .expectStatus().isOk()
+                .expectHeader().contentType("application/json")
+                .expectBody(String.class).isEqualTo(responseBody);
+
+        wireMockServer.verify(1, postRequestedFor(urlEqualTo(downstreamPath))
+                .withHeader(HttpHeaders.AUTHORIZATION, matching("Bearer " + TOKEN)));
 
     }
 
@@ -449,7 +499,7 @@ class RouteLocatorConfigTest {
                 .expectBody(String.class).isEqualTo(responseBody);
 
         wireMockServer.verify(1, getRequestedFor(urlEqualTo(downstreamPath))
-                .withHeader(HttpHeaders.AUTHORIZATION, matching("Bearer " + jwt)));
+                .withHeader(HttpHeaders.AUTHORIZATION, matching("Bearer " + TOKEN)));
 
     }
 
@@ -474,7 +524,7 @@ class RouteLocatorConfigTest {
                 .expectBody(String.class).isEqualTo(responseBody);
 
         wireMockServer.verify(1, getRequestedFor(urlEqualTo(downstreamPath))
-                .withHeader(HttpHeaders.AUTHORIZATION, matching("Bearer " + jwt)));
+                .withHeader(HttpHeaders.AUTHORIZATION, matching("Bearer " + TOKEN)));
 
     }
 
@@ -500,7 +550,7 @@ class RouteLocatorConfigTest {
                 .expectBody(String.class).isEqualTo(responseBody);
 
         wireMockServer.verify(1, getRequestedFor(urlEqualTo(downstreamPath))
-                .withHeader(HttpHeaders.AUTHORIZATION, matching("Bearer " + jwt)));
+                .withHeader(HttpHeaders.AUTHORIZATION, matching("Bearer " + TOKEN)));
 
     }
 
@@ -525,7 +575,7 @@ class RouteLocatorConfigTest {
                 .expectBody(String.class).isEqualTo(responseBody);
 
         wireMockServer.verify(1, getRequestedFor(urlEqualTo(downstreamPath))
-                .withHeader(HttpHeaders.AUTHORIZATION, matching("Bearer " + jwt)));
+                .withHeader(HttpHeaders.AUTHORIZATION, matching("Bearer " + TOKEN)));
 
     }
 
@@ -578,7 +628,7 @@ class RouteLocatorConfigTest {
                         .expectBody(String.class).isEqualTo(responseBody);
 
                 wireMockServer.verify(1, getRequestedFor(urlEqualTo(url))
-                        .withHeader(HttpHeaders.AUTHORIZATION, matching("Bearer " + jwt)));
+                        .withHeader(HttpHeaders.AUTHORIZATION, matching("Bearer " + TOKEN)));
 
             }
 
@@ -599,7 +649,7 @@ class RouteLocatorConfigTest {
                         .expectBody(String.class).isEqualTo(responseBody);
 
                 wireMockServer.verify(1, getRequestedFor(urlEqualTo(url))
-                        .withHeader(HttpHeaders.AUTHORIZATION, matching("Bearer " + jwt)));
+                        .withHeader(HttpHeaders.AUTHORIZATION, matching("Bearer " + TOKEN)));
 
             }
 
@@ -641,7 +691,7 @@ class RouteLocatorConfigTest {
                         .expectBody(String.class).isEqualTo(responseBody);
 
                 wireMockServer.verify(1, getRequestedFor(urlEqualTo(url))
-                        .withHeader(HttpHeaders.AUTHORIZATION, matching("Bearer " + jwt)));
+                        .withHeader(HttpHeaders.AUTHORIZATION, matching("Bearer " + TOKEN)));
 
             }
 
@@ -696,7 +746,7 @@ class RouteLocatorConfigTest {
                 .expectBody(String.class).isEqualTo(responseBody);
 
         wireMockServer.verify(1, getRequestedFor(urlEqualTo(downstreamPath))
-                .withHeader(HttpHeaders.AUTHORIZATION, matching("Bearer " + jwt)));
+                .withHeader(HttpHeaders.AUTHORIZATION, matching("Bearer " + TOKEN)));
 
     }
 
@@ -722,7 +772,7 @@ class RouteLocatorConfigTest {
                 .expectBody(String.class).isEqualTo(responseBody);
 
         wireMockServer.verify(1, getRequestedFor(urlEqualTo(downstreamPath))
-                .withHeader(HttpHeaders.AUTHORIZATION, matching("Bearer " + jwt)));
+                .withHeader(HttpHeaders.AUTHORIZATION, matching("Bearer " + TOKEN)));
 
     }
 
@@ -748,7 +798,7 @@ class RouteLocatorConfigTest {
                 .expectBody(String.class).isEqualTo(responseBody);
 
         wireMockServer.verify(1, getRequestedFor(urlEqualTo(downstreamPath))
-                .withHeader(HttpHeaders.AUTHORIZATION, matching("Bearer " + jwt)));
+                .withHeader(HttpHeaders.AUTHORIZATION, matching("Bearer " + TOKEN)));
 
 
     }
@@ -798,7 +848,7 @@ class RouteLocatorConfigTest {
                 .expectBody(String.class).isEqualTo(responseBody);
 
         wireMockServer.verify(1, getRequestedFor(urlEqualTo(downstreamPath))
-                .withHeader(HttpHeaders.AUTHORIZATION, matching("Bearer " + jwt)));
+                .withHeader(HttpHeaders.AUTHORIZATION, matching("Bearer " + TOKEN)));
 
     }
 
@@ -823,7 +873,7 @@ class RouteLocatorConfigTest {
                 .expectBody(String.class).isEqualTo(responseBody);
 
         wireMockServer.verify(1, getRequestedFor(urlEqualTo(downstreamPath))
-                .withHeader(HttpHeaders.AUTHORIZATION, matching("Bearer " + jwt)));
+                .withHeader(HttpHeaders.AUTHORIZATION, matching("Bearer " + TOKEN)));
 
     }
 


### PR DESCRIPTION
This pull request introduces integration with the Kelvin AAP (Arbeidsavklaringspenger) service to the Dolly backend, enabling creation and status retrieval of AAP test data. The main changes include the addition of client, consumer, command, and domain classes for Kelvin AAP, updates to the data model to support new request types, and configuration changes for service discovery and dependency management.

**Kelvin AAP Integration:**

* Added `KelvinAapClient`, `KelvinAapConsumer`, and command classes to handle creation and status checking of AAP test data via the Kelvin AAP API. These classes use reactive programming and include error handling and retry logic. [[1]](diffhunk://#diff-70a407dd50abe8f81d495f072dfaf6b47a7b875e954e9555304923555160bac4R1-R82) [[2]](diffhunk://#diff-316312f595c7470fe2d2887d2865a1a20f42981af0ae7f579883fc8fc275427bR1-R54) [[3]](diffhunk://#diff-513865b62752fa33fc4a3d3391988af37012a04dfbd92fcbcc12d3f32dd0cfefR1-R56) [[4]](diffhunk://#diff-cd5433f67846c5ba0b41043d0efb4d2e22a3cbbff0e70e961658f2116f966343R1-R57)
* Introduced domain classes for request and response payloads: `AapOpprettRequest`, `AapOpprettResponse`, `AapStatusRequest`, and `AapStatusResponse`. [[1]](diffhunk://#diff-f654be2f47ec3ce496d541eb174c1d1ce59cacd328973cac6884437756a2b3c7R1-R60) [[2]](diffhunk://#diff-3bf6107199dd56652d5d955581f136b98195df53e3e8cdaae9f1f052c9195a1dR1-R19) [[3]](diffhunk://#diff-c66ac93feb4278ff679bdd5a4ee5311c5cfcdeaea69862fd3fb1bc46e87df271R1-R15) [[4]](diffhunk://#diff-37243bc8d35fbafff1b3893144730a4e0216f56a1bcdc36546b209f6e6a66d7eR1-R78)
* Added a custom Orika mapping strategy (`KelvinAapMappingStrategy`) to map between frontend DTOs and backend request objects.

**Data Model and API Changes:**

* Extended `BestilteKriterier` and `RsDollyBestilling` to support the new `kelvinAap` field, allowing users to request Kelvin AAP data in test person orders. [[1]](diffhunk://#diff-d2fc011102650df485cbd1ce0edb57ec06c91aceeba4b9bec5f067849b39329cR19) [[2]](diffhunk://#diff-d2fc011102650df485cbd1ce0edb57ec06c91aceeba4b9bec5f067849b39329cR76) [[3]](diffhunk://#diff-0cbecb5fa1b2638700efb8fe03ebdd10d5e483b5f0b7c79340a3c8dd7796951eR21) [[4]](diffhunk://#diff-0cbecb5fa1b2638700efb8fe03ebdd10d5e483b5f0b7c79340a3c8dd7796951eR93)
* Updated `BestillingProgress` to track the status of Kelvin AAP operations.

**Configuration and Dependency Updates:**

* Registered the Kelvin AAP service in `apioversikt.yml` for service discovery, and added the Skattekort service as well. [[1]](diffhunk://#diff-1f97b1b15e6206c6944fea72120fc21bbdd907bafe79cd5dae92051c5cadc298R79-R86) [[2]](diffhunk://#diff-1f97b1b15e6206c6944fea72120fc21bbdd907bafe79cd5dae92051c5cadc298R172-R177)
* Added the Flyway database migration dependency to `build.gradle` for database schema management.

These changes collectively enable Dolly to orchestrate test data creation and status management for Kelvin AAP, enhancing its coverage of test scenarios.