### PR TITLE
Bugfix/visning av feilmelding bestillingskategorier

### DIFF
--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/aareg/form/Form.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/aareg/form/Form.tsx
@@ -1,6 +1,6 @@
 import { Vis } from '@/components/bestillingsveileder/VisAttributt'
 import Panel from '@/components/ui/panel/Panel'
-import { erForsteEllerTest, panelError } from '@/components/ui/form/formUtils'
+import { erForsteEllerTest, usePanelError } from '@/components/ui/form/formUtils'
 import { validation } from './validation'
 import { ArbeidsforholdToggle } from '@/components/shared/ArbeidsforholdToggle/ArbeidsforholdToggle'
 import { useFormContext } from 'react-hook-form'
@@ -32,7 +32,7 @@ export const AaregForm = () => {
 		<Vis attributt={aaregAttributt}>
 			<Panel
 				heading="Arbeidsforhold (Aareg)"
-				hasErrors={panelError(aaregAttributt)}
+				hasErrors={usePanelError(aaregAttributt)}
 				iconType="arbeid"
 				startOpen={erForsteEllerTest(formMethods.getValues(), [aaregAttributt])}
 			>

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/afpOffentlig/form/Form.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/afpOffentlig/form/Form.tsx
@@ -1,7 +1,7 @@
 import { Vis } from '@/components/bestillingsveileder/VisAttributt'
 import { useFormContext } from 'react-hook-form'
 import Panel from '@/components/ui/panel/Panel'
-import { erForsteEllerTest, panelError } from '@/components/ui/form/formUtils'
+import { erForsteEllerTest, usePanelError } from '@/components/ui/form/formUtils'
 import { FormDollyFieldArray } from '@/components/ui/form/fieldArray/DollyFieldArray'
 import { initialMocksvar } from '@/components/fagsystem/afpOffentlig/initialValues'
 import { useMuligeDirektekall, useTpOrdningKodeverk } from '@/utils/hooks/usePensjon'
@@ -41,7 +41,7 @@ export const AfpOffentligForm = () => {
 		<Vis attributt={afpOffentligPath}>
 			<Panel
 				heading="AFP offentlig"
-				hasErrors={panelError(afpOffentligPath)}
+				hasErrors={usePanelError(afpOffentligPath)}
 				iconType="pensjon"
 				startOpen={erForsteEllerTest(formMethods.getValues(), [afpOffentligPath])}
 			>

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/alderspensjon/form/AlderspensjonNyUttaksgradForm.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/alderspensjon/form/AlderspensjonNyUttaksgradForm.tsx
@@ -1,5 +1,5 @@
 import { Vis } from '@/components/bestillingsveileder/VisAttributt'
-import { erForsteEllerTest, panelError } from '@/components/ui/form/formUtils'
+import { erForsteEllerTest, usePanelError } from '@/components/ui/form/formUtils'
 import Panel from '@/components/ui/panel/Panel'
 import { useFormContext } from 'react-hook-form'
 import { SelectOptionsManager as Options } from '@/service/SelectOptions'
@@ -33,7 +33,7 @@ export const AlderspensjonNyUttaksgradForm = () => {
 		<Vis attributt={alderspensjonNyUttaksgradPath}>
 			<Panel
 				heading="Alderspensjon: Ny uttaksgrad"
-				hasErrors={panelError(alderspensjonNyUttaksgradPath)}
+				hasErrors={usePanelError(alderspensjonNyUttaksgradPath)}
 				iconType="pensjon"
 				startOpen={erForsteEllerTest(formMethods.getValues(), [alderspensjonNyUttaksgradPath])}
 			>

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/alderspensjon/form/Form.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/alderspensjon/form/Form.tsx
@@ -1,5 +1,5 @@
 import { Vis } from '@/components/bestillingsveileder/VisAttributt'
-import { erForsteEllerTest, panelError } from '@/components/ui/form/formUtils'
+import { erForsteEllerTest, usePanelError } from '@/components/ui/form/formUtils'
 import Panel from '@/components/ui/panel/Panel'
 import { FormSelect } from '@/components/ui/form/inputs/select/Select'
 import React, { useContext, useEffect, useState } from 'react'
@@ -208,7 +208,7 @@ export const AlderspensjonForm = () => {
 		<Vis attributt={alderspensjonPath}>
 			<Panel
 				heading="Alderspensjon"
-				hasErrors={panelError(alderspensjonPath)}
+				hasErrors={usePanelError(alderspensjonPath)}
 				iconType="pensjon"
 				startOpen={erForsteEllerTest(formMethods.getValues(), [alderspensjonPath])}
 			>

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/arbeidsplassen/form/Form.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/arbeidsplassen/form/Form.tsx
@@ -1,5 +1,5 @@
 import { ArbeidserfaringForm } from '@/components/fagsystem/arbeidsplassen/form/partials/ArbeidserfaringForm'
-import { erForsteEllerTest, panelError } from '@/components/ui/form/formUtils'
+import { erForsteEllerTest, usePanelError } from '@/components/ui/form/formUtils'
 import React, { useContext } from 'react'
 import { Vis } from '@/components/bestillingsveileder/VisAttributt'
 import Panel from '@/components/ui/panel/Panel'
@@ -35,7 +35,7 @@ export const ArbeidsplassenForm = () => {
 		<Vis attributt={arbeidsplassenAttributt}>
 			<Panel
 				heading="Nav CV"
-				hasErrors={panelError(arbeidsplassenAttributt)}
+				hasErrors={usePanelError(arbeidsplassenAttributt)}
 				iconType="cv"
 				startOpen={erForsteEllerTest(formMethods.getValues(), [arbeidsplassenAttributt])}
 			>

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/arbeidssoekerregisteret/form/Form.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/arbeidssoekerregisteret/form/Form.tsx
@@ -1,7 +1,7 @@
 import { Vis } from '@/components/bestillingsveileder/VisAttributt'
 import { useFormContext } from 'react-hook-form'
 import Panel from '@/components/ui/panel/Panel'
-import { erForsteEllerTest, panelError } from '@/components/ui/form/formUtils'
+import { erForsteEllerTest, usePanelError } from '@/components/ui/form/formUtils'
 import { FormSelect } from '@/components/ui/form/inputs/select/Select'
 import { useArbeidssoekerTyper } from '@/utils/hooks/useArbeidssoekerregisteret'
 import { FormTextInput } from '@/components/ui/form/inputs/textInput/TextInput'
@@ -38,7 +38,7 @@ export const ArbeidssoekerregisteretForm = () => {
 		<Vis attributt={arbeidssoekerregisteretAttributt}>
 			<Panel
 				heading="Arbeidssøkerregisteret"
-				hasErrors={panelError(arbeidssoekerregisteretAttributt)}
+				hasErrors={usePanelError(arbeidssoekerregisteretAttributt)}
 				iconType="cv"
 				informasjonstekst="Informasjonen i arbeidssøkerregisteret har en levetid på 21 dager fra innsending. Denne kan fornyes ved innsending på ny (gjenopprett)."
 				startOpen={erForsteEllerTest(formMethods.getValues(), [arbeidssoekerregisteretAttributt])}

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/arena/form/Form.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/arena/form/Form.tsx
@@ -3,7 +3,7 @@ import * as _ from 'lodash-es'
 import { ifPresent } from '@/utils/YupValidations'
 import { Vis } from '@/components/bestillingsveileder/VisAttributt'
 import Panel from '@/components/ui/panel/Panel'
-import { erForsteEllerTest, panelError } from '@/components/ui/form/formUtils'
+import { erForsteEllerTest, usePanelError } from '@/components/ui/form/formUtils'
 import { FormDatepicker } from '@/components/ui/form/inputs/datepicker/Datepicker'
 import { MedServicebehov } from './partials/MedServicebehov'
 import { AlertInntektskomponentenRequired } from '@/components/ui/brukerAlert/AlertInntektskomponentenRequired'
@@ -36,7 +36,7 @@ export const ArenaForm = () => {
 		<Vis attributt={arenaPath}>
 			<Panel
 				heading="Arbeidsytelser"
-				hasErrors={panelError(arenaPath)}
+				hasErrors={usePanelError(arenaPath)}
 				iconType="arena"
 				startOpen={erForsteEllerTest(formMethods.getValues(), [arenaPath])}
 			>

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/arena/form/partials/MedServicebehov.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/arena/form/partials/MedServicebehov.tsx
@@ -9,6 +9,7 @@ import {
 	BestillingsveilederContextType,
 	useBestillingsveileder,
 } from '@/components/bestillingsveileder/BestillingsveilederContext'
+import StyledAlert from '@/components/ui/alert/StyledAlert'
 
 const errorPaths = [
 	`arenaforvalter.aap115[0].fraDato`,
@@ -46,9 +47,9 @@ export const MedServicebehov = ({ formMethods, path }: { formMethods: any; path:
 	return (
 		<React.Fragment>
 			{!opts?.is?.leggTil && !opts?.is?.importTestnorge && feilmelding && (
-				<Alert variant={'warning'} style={{ marginBottom: '20px' }}>
+				<StyledAlert variant={'warning'} size={'small'}>
 					{feilmelding}
-				</Alert>
+				</StyledAlert>
 			)}
 			<div className="flexbox--flex-wrap">
 				<FormSelect

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/arena/form/partials/MedServicebehov.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/arena/form/partials/MedServicebehov.tsx
@@ -4,7 +4,6 @@ import { SelectOptionsManager as Options } from '@/service/SelectOptions'
 import { FormSelect } from '@/components/ui/form/inputs/select/Select'
 import { FormDatepicker } from '@/components/ui/form/inputs/datepicker/Datepicker'
 import * as _ from 'lodash-es'
-import { Alert } from '@navikt/ds-react'
 import {
 	BestillingsveilederContextType,
 	useBestillingsveileder,

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/bankkonto/form/NorskBankkonto.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/bankkonto/form/NorskBankkonto.tsx
@@ -6,7 +6,7 @@ import { generateValidKontoOptions } from '@/utils/GenererGyldigNorskBankkonto'
 import { FormCheckbox } from '@/components/ui/form/inputs/checbox/Checkbox'
 import { UseFormReturn } from 'react-hook-form/dist/types'
 import Panel from '@/components/ui/panel/Panel'
-import { erForsteEllerTest, panelError } from '@/components/ui/form/formUtils'
+import { erForsteEllerTest, usePanelError } from '@/components/ui/form/formUtils'
 
 export const NorskBankkonto = ({ formMethods }: { formMethods: UseFormReturn }) => {
 	const [validKontoOptions, setValidKontoOptions] = useState([])
@@ -23,7 +23,7 @@ export const NorskBankkonto = ({ formMethods }: { formMethods: UseFormReturn }) 
 			<Panel
 				heading={'Norsk bankkonto'}
 				iconType="bankkonto"
-				hasErrors={panelError(path)}
+				hasErrors={usePanelError(path)}
 				startOpen={erForsteEllerTest(formMethods.getValues(), [path])}
 			>
 				<FormSelect

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/bankkonto/form/UtenlandskBankkonto.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/bankkonto/form/UtenlandskBankkonto.tsx
@@ -7,7 +7,7 @@ import { FormCheckbox } from '@/components/ui/form/inputs/checbox/Checkbox'
 import * as _ from 'lodash-es'
 import { landkodeIsoMapping } from '@/service/services/kontoregister/landkoder'
 import Panel from '@/components/ui/panel/Panel'
-import { erForsteEllerTest, panelError } from '@/components/ui/form/formUtils'
+import { erForsteEllerTest, usePanelError } from '@/components/ui/form/formUtils'
 
 const path = 'bankkonto.utenlandskBankkonto'
 
@@ -40,7 +40,7 @@ export const UtenlandskBankkonto = ({ formMethods }: any) => {
 			<Panel
 				heading={'Utenlandsk bankkonto'}
 				iconType="bankkonto"
-				hasErrors={panelError(path)}
+				hasErrors={usePanelError(path)}
 				startOpen={erForsteEllerTest(formMethods.getValues(), [path])}
 			>
 				<div className="flexbox--flex-wrap">

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/brregstub/form/Form.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/brregstub/form/Form.tsx
@@ -3,7 +3,7 @@ import { ifPresent, requiredDate, requiredNumber, requiredString } from '@/utils
 import { Vis } from '@/components/bestillingsveileder/VisAttributt'
 import { FormSelect } from '@/components/ui/form/inputs/select/Select'
 import Panel from '@/components/ui/panel/Panel'
-import { erForsteEllerTest, panelError } from '@/components/ui/form/formUtils'
+import { erForsteEllerTest, usePanelError } from '@/components/ui/form/formUtils'
 import { EnheterForm } from './partials/enheterForm'
 import { useFormContext } from 'react-hook-form'
 import { useBrregUnderstatuser } from '@/utils/hooks/useBrreg'
@@ -22,7 +22,7 @@ export const BrregstubForm = () => {
 		<Vis attributt={brregAttributt}>
 			<Panel
 				heading="Brønnøysundregistrene"
-				hasErrors={panelError(brregAttributt)}
+				hasErrors={usePanelError(brregAttributt)}
 				iconType="brreg"
 				startOpen={erForsteEllerTest(formMethods.getValues(), [brregAttributt])}
 			>

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/dokarkiv/form/DokarkivForm.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/dokarkiv/form/DokarkivForm.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { Vis } from '@/components/bestillingsveileder/VisAttributt'
 import { Kategori } from '@/components/ui/form/kategori/Kategori'
 import Panel from '@/components/ui/panel/Panel'
-import { erForsteEllerTest, panelError } from '@/components/ui/form/formUtils'
+import { erForsteEllerTest, usePanelError } from '@/components/ui/form/formUtils'
 import { useFormContext } from 'react-hook-form'
 import { FormDollyFieldArray } from '@/components/ui/form/fieldArray/DollyFieldArray'
 import {
@@ -33,7 +33,7 @@ const DokarkivForm = () => {
 		<Vis attributt={dokarkivAttributt}>
 			<Panel
 				heading="Dokumenter (Joark)"
-				hasErrors={panelError(dokarkivAttributt)}
+				hasErrors={usePanelError(dokarkivAttributt)}
 				iconType="dokarkiv"
 				// @ts-ignore
 				startOpen={erForsteEllerTest(formMethods.getValues(), [dokarkivAttributt])}

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/fullmakt/form/FullmaktForm.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/fullmakt/form/FullmaktForm.tsx
@@ -13,7 +13,7 @@ import {
 import { SelectOptionsManager as Options } from '@/service/SelectOptions'
 import { Vis } from '@/components/bestillingsveileder/VisAttributt'
 import Panel from '@/components/ui/panel/Panel'
-import { erForsteEllerTest, panelError } from '@/components/ui/form/formUtils'
+import { erForsteEllerTest, usePanelError } from '@/components/ui/form/formUtils'
 import { useFormContext } from 'react-hook-form'
 import { useFullmaktOmraader } from '@/utils/hooks/useFullmakt'
 import { Omraade } from '@/components/fagsystem/fullmakt/FullmaktType'
@@ -192,7 +192,7 @@ export const FullmaktForm = () => {
 		<Vis attributt={fullmaktAttributter}>
 			<Panel
 				heading="Fullmakt"
-				hasErrors={panelError(fullmaktAttributter)}
+				hasErrors={usePanelError(fullmaktAttributter)}
 				iconType="fullmakt"
 				startOpen={erForsteEllerTest(formMethods.getValues(), fullmaktAttributter)}
 			>

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/histark/form/HistarkForm.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/histark/form/HistarkForm.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { Vis } from '@/components/bestillingsveileder/VisAttributt'
 import { Kategori } from '@/components/ui/form/kategori/Kategori'
 import Panel from '@/components/ui/panel/Panel'
-import { erForsteEllerTest, panelError } from '@/components/ui/form/formUtils'
+import { erForsteEllerTest, usePanelError } from '@/components/ui/form/formUtils'
 import { FormDollyFieldArray } from '@/components/ui/form/fieldArray/DollyFieldArray'
 import { useFormContext } from 'react-hook-form'
 import { initialHistark } from '@/components/fagsystem/histark/form/initialValues'
@@ -21,7 +21,7 @@ const HistarkForm = () => {
 		<Vis attributt={histarkAttributt}>
 			<Panel
 				heading="Dokumenter (Histark)"
-				hasErrors={panelError(histarkAttributt)}
+				hasErrors={usePanelError(histarkAttributt)}
 				iconType="dokarkiv"
 				// @ts-ignore
 				startOpen={erForsteEllerTest(formMethods.getValues(), [histarkAttributt])}

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/inntektsmelding/form/Form.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/inntektsmelding/form/Form.tsx
@@ -3,7 +3,7 @@ import * as Yup from 'yup'
 import * as _ from 'lodash-es'
 import Panel from '@/components/ui/panel/Panel'
 import { Vis } from '@/components/bestillingsveileder/VisAttributt'
-import { erForsteEllerTest, panelError } from '@/components/ui/form/formUtils'
+import { erForsteEllerTest, usePanelError } from '@/components/ui/form/formUtils'
 import { Kategori } from '@/components/ui/form/kategori/Kategori'
 import { DollySelect } from '@/components/ui/form/inputs/select/Select'
 import { FormDatepicker } from '@/components/ui/form/inputs/datepicker/Datepicker'
@@ -111,7 +111,7 @@ export const InntektsmeldingForm = () => {
 		<Vis attributt={inntektsmeldingAttributt}>
 			<Panel
 				heading="Inntektsmelding (fra Altinn)"
-				hasErrors={panelError(inntektsmeldingAttributt)}
+				hasErrors={usePanelError(inntektsmeldingAttributt)}
 				iconType="inntektsmelding"
 				informasjonstekst={informasjonstekst}
 				startOpen={erForsteEllerTest(formMethods.getValues(), [inntektsmeldingAttributt])}

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/inntektstub/form/Form.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/inntektstub/form/Form.tsx
@@ -1,6 +1,6 @@
 import { Vis } from '@/components/bestillingsveileder/VisAttributt'
 import Panel from '@/components/ui/panel/Panel'
-import { erForsteEllerTest, panelError } from '@/components/ui/form/formUtils'
+import { erForsteEllerTest, usePanelError } from '@/components/ui/form/formUtils'
 import { validation } from './validation'
 import { FormDollyFieldArray } from '@/components/ui/form/fieldArray/DollyFieldArray'
 import InntektsinformasjonForm from './partials/inntektsinformasjonForm'
@@ -39,7 +39,7 @@ export const InntektstubForm = () => {
 		<Vis attributt={inntektstubAttributt}>
 			<Panel
 				heading="A-ordningen (Inntektstub)"
-				hasErrors={panelError(inntektstubAttributt)}
+				hasErrors={usePanelError(inntektstubAttributt)}
 				iconType="inntektstub"
 				startOpen={erForsteEllerTest(formMethods.getValues(), [inntektstubAttributt])}
 			>

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/inst/form/Form.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/inst/form/Form.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Vis } from '@/components/bestillingsveileder/VisAttributt'
-import { erForsteEllerTest, panelError } from '@/components/ui/form/formUtils'
+import { erForsteEllerTest, usePanelError } from '@/components/ui/form/formUtils'
 import Panel from '@/components/ui/panel/Panel'
 import { FormDatepicker } from '@/components/ui/form/inputs/datepicker/Datepicker'
 import { FormSelect } from '@/components/ui/form/inputs/select/Select'
@@ -40,7 +40,7 @@ export const InstForm = () => {
 		<Vis attributt={instAttributt}>
 			<Panel
 				heading="Institusjonsopphold"
-				hasErrors={panelError(instAttributt)}
+				hasErrors={usePanelError(instAttributt)}
 				iconType="institusjon"
 				startOpen={erForsteEllerTest(formMethods.getValues(), [instAttributt])}
 			>

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/krrstub/form/KrrForm.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/krrstub/form/KrrForm.tsx
@@ -4,7 +4,7 @@ import { DollySelect, FormSelect } from '@/components/ui/form/inputs/select/Sele
 import { DollyTextInput, FormTextInput } from '@/components/ui/form/inputs/textInput/TextInput'
 import { SelectOptionsManager as Options } from '@/service/SelectOptions'
 import Panel from '@/components/ui/panel/Panel'
-import { erForsteEllerTest, panelError } from '@/components/ui/form/formUtils'
+import { erForsteEllerTest, usePanelError } from '@/components/ui/form/formUtils'
 import { Kategori } from '@/components/ui/form/kategori/Kategori'
 import { Option, SelectOptionsOppslag } from '@/service/SelectOptionsOppslag'
 import { SelectOptionsFormat } from '@/service/SelectOptionsFormat'
@@ -80,7 +80,7 @@ export const KrrstubForm = () => {
 		<Vis attributt={krrAttributt}>
 			<Panel
 				heading="Kontakt- og reservasjonsregisteret"
-				hasErrors={panelError(krrAttributt)}
+				hasErrors={usePanelError(krrAttributt)}
 				iconType="krr"
 				startOpen={erForsteEllerTest(formMethods.getValues(), [krrAttributt])}
 			>

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/medl/form/MedlForm.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/medl/form/MedlForm.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import { Vis } from '@/components/bestillingsveileder/VisAttributt'
 import { Kategori } from '@/components/ui/form/kategori/Kategori'
 import Panel from '@/components/ui/panel/Panel'
-import { erForsteEllerTest, panelError } from '@/components/ui/form/formUtils'
+import { erForsteEllerTest, usePanelError } from '@/components/ui/form/formUtils'
 import { FormCheckbox } from '@/components/ui/form/inputs/checbox/Checkbox'
 import { SelectOptionsManager as Options } from '@/service/SelectOptions'
 import { FormDatepicker } from '@/components/ui/form/inputs/datepicker/Datepicker'
@@ -44,7 +44,7 @@ export const MedlForm = () => {
 		<Vis attributt={MedlAttributt}>
 			<Panel
 				heading="Medlemskap (MEDL)"
-				hasErrors={panelError(MedlAttributt)}
+				hasErrors={usePanelError(MedlAttributt)}
 				iconType="calendar"
 				// @ts-ignore
 				startOpen={erForsteEllerTest(getValues(), [MedlAttributt])}

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/nom/form/NavAnsattForm.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/nom/form/NavAnsattForm.tsx
@@ -1,6 +1,6 @@
 import { Vis } from '@/components/bestillingsveileder/VisAttributt'
 import Panel from '@/components/ui/panel/Panel'
-import { erForsteEllerTest, panelError } from '@/components/ui/form/formUtils'
+import { erForsteEllerTest, usePanelError } from '@/components/ui/form/formUtils'
 import { NomForm } from '@/components/fagsystem/nom/form/NomForm'
 import { Kategori } from '@/components/ui/form/kategori/Kategori'
 import React from 'react'
@@ -18,7 +18,7 @@ export const NavAnsatt = () => {
 		<Vis attributt={panelPaths}>
 			<Panel
 				heading="Nav-ansatt"
-				hasErrors={panelError(panelPaths)}
+				hasErrors={usePanelError(panelPaths)}
 				iconType="nav"
 				startOpen={
 					erForsteEllerTest(formMethods.getValues(), nomdataPath) ||

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/organisasjoner/form/Form.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/organisasjoner/form/Form.tsx
@@ -4,7 +4,7 @@ import { Detaljer } from './partials/Detaljer'
 import { Vis } from '@/components/bestillingsveileder/VisAttributt'
 import { adressePaths, kontaktPaths, organisasjonPaths } from './paths'
 import Panel from '@/components/ui/panel/Panel'
-import { erForsteEllerTest, panelError } from '@/components/ui/form/formUtils'
+import { erForsteEllerTest, usePanelError } from '@/components/ui/form/formUtils'
 import { useFormContext } from 'react-hook-form'
 
 const detaljerPaths = [organisasjonPaths, kontaktPaths, adressePaths].flat()
@@ -17,7 +17,7 @@ export const OrganisasjonForm = () => {
 			<Vis attributt={detaljerPaths}>
 				<Panel
 					heading="Detaljer"
-					hasErrors={panelError('organisasjon')}
+					hasErrors={usePanelError('organisasjon')}
 					iconType={'personinformasjon'}
 					startOpen={erForsteEllerTest(formMethods.getValues(), detaljerPaths)}
 				>

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/form/partials/adresser/Adresser.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/form/partials/adresser/Adresser.tsx
@@ -4,7 +4,7 @@ import { Vis } from '@/components/bestillingsveileder/VisAttributt'
 import { Kontaktadresse } from '@/components/fagsystem/pdlf/form/partials/adresser/kontaktadresse/Kontaktadresse'
 import { Adressebeskyttelse } from '@/components/fagsystem/pdlf/form/partials/adresser/adressebeskyttelse/Adressebeskyttelse'
 import Panel from '@/components/ui/panel/Panel'
-import { erForsteEllerTest, panelError } from '@/components/ui/form/formUtils'
+import { erForsteEllerTest, usePanelError } from '@/components/ui/form/formUtils'
 import { UseFormReturn } from 'react-hook-form/dist/types'
 import { DeltBosted } from '@/components/fagsystem/pdlf/form/partials/familierelasjoner/forelderBarnRelasjon/DeltBosted'
 
@@ -25,7 +25,7 @@ export const Adresser = ({ formMethods }: AdresserValues) => {
 		<Vis attributt={adresseAttributter}>
 			<Panel
 				heading="Adresser"
-				hasErrors={panelError(adresseAttributter)}
+				hasErrors={usePanelError(adresseAttributter)}
 				iconType="adresse"
 				startOpen={erForsteEllerTest(formMethods.getValues(), adresseAttributter)}
 			>

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/form/partials/familierelasjoner/Familierelasjoner.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/form/partials/familierelasjoner/Familierelasjoner.tsx
@@ -1,6 +1,6 @@
 import Panel from '@/components/ui/panel/Panel'
 import { Vis } from '@/components/bestillingsveileder/VisAttributt'
-import { erForsteEllerTest, panelError } from '@/components/ui/form/formUtils'
+import { erForsteEllerTest, usePanelError } from '@/components/ui/form/formUtils'
 import { Kategori } from '@/components/ui/form/kategori/Kategori'
 import { DoedfoedtBarn } from '@/components/fagsystem/pdlf/form/partials/familierelasjoner/doedfoedtBarn/DoedfoedtBarn'
 import { ForelderBarnRelasjon } from '@/components/fagsystem/pdlf/form/partials/familierelasjoner/forelderBarnRelasjon/ForelderBarnRelasjon'
@@ -20,7 +20,7 @@ export const Familierelasjoner = ({ formMethods }: { formMethods: UseFormReturn 
 		<Vis attributt={relasjonerAttributter}>
 			<Panel
 				heading="Familierelasjoner"
-				hasErrors={panelError(relasjonerAttributter)}
+				hasErrors={usePanelError(relasjonerAttributter)}
 				iconType={'relasjoner'}
 				startOpen={erForsteEllerTest(formMethods.getValues(), relasjonerAttributter)}
 				checkAttributeArray={undefined}

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/form/partials/identifikasjon/Identifikasjon.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/form/partials/identifikasjon/Identifikasjon.tsx
@@ -1,6 +1,6 @@
 import { Vis } from '@/components/bestillingsveileder/VisAttributt'
 import Panel from '@/components/ui/panel/Panel'
-import { erForsteEllerTest, panelError } from '@/components/ui/form/formUtils'
+import { erForsteEllerTest, usePanelError } from '@/components/ui/form/formUtils'
 import { Kategori } from '@/components/ui/form/kategori/Kategori'
 import { FalskIdentitet } from '@/components/fagsystem/pdlf/form/partials/identifikasjon/falskIdentitet/FalskIdentitet'
 import { UtenlandsId } from '@/components/fagsystem/pdlf/form/partials/identifikasjon/utenlandsId/UtenlandsId'
@@ -25,7 +25,7 @@ export const Identifikasjon = ({ formMethods }: IdentifikasjonValues) => {
 		<Vis attributt={identifikasjonAttributter}>
 			<Panel
 				heading="Identifikasjon"
-				hasErrors={panelError(identifikasjonAttributter)}
+				hasErrors={usePanelError(identifikasjonAttributter)}
 				iconType="identifikasjon"
 				startOpen={erForsteEllerTest(formMethods.getValues(), identifikasjonAttributter)}
 			>

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/form/partials/kontaktinformasjonForDoedsbo/KontaktinformasjonForDoedsbo.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/form/partials/kontaktinformasjonForDoedsbo/KontaktinformasjonForDoedsbo.tsx
@@ -7,7 +7,7 @@ import { FormDollyFieldArray } from '@/components/ui/form/fieldArray/DollyFieldA
 import { AvansertForm } from '@/components/fagsystem/pdlf/form/partials/avansert/AvansertForm'
 import { initialKontaktinfoForDoedebo } from '@/components/fagsystem/pdlf/form/initialValues'
 import Panel from '@/components/ui/panel/Panel'
-import { erForsteEllerTest, panelError } from '@/components/ui/form/formUtils'
+import { erForsteEllerTest, usePanelError } from '@/components/ui/form/formUtils'
 import { Vis } from '@/components/bestillingsveileder/VisAttributt'
 import React from 'react'
 
@@ -39,7 +39,7 @@ export const KontaktinformasjonForDoedsbo = ({ formMethods }) => {
 		<Vis attributt={doedsboAttributt}>
 			<Panel
 				heading="Kontaktinformasjon for dødsbo"
-				hasErrors={panelError(doedsboAttributt)}
+				hasErrors={usePanelError(doedsboAttributt)}
 				iconType="doedsbo"
 				startOpen={erForsteEllerTest(formMethods.getValues(), [doedsboAttributt])}
 			>

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/form/partials/personinformasjon/Personinformasjon.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/pdlf/form/partials/personinformasjon/Personinformasjon.tsx
@@ -1,7 +1,7 @@
 import React, { useContext } from 'react'
 import Panel from '@/components/ui/panel/Panel'
 import { Vis } from '@/components/bestillingsveileder/VisAttributt'
-import { erForsteEllerTest, panelError } from '@/components/ui/form/formUtils'
+import { erForsteEllerTest, usePanelError } from '@/components/ui/form/formUtils'
 import { Kategori } from '@/components/ui/form/kategori/Kategori'
 import { Sikkerhetstiltak } from '@/components/fagsystem/pdlf/form/partials/sikkerhetstiltak/Sikkerhetstiltak'
 import {
@@ -73,7 +73,7 @@ export const Personinformasjon = ({ formMethods }) => {
 		<Vis attributt={panelPaths}>
 			<Panel
 				heading="Personinformasjon"
-				hasErrors={panelError(panelPaths)}
+				hasErrors={usePanelError(panelPaths)}
 				iconType={'personinformasjon'}
 				startOpen={erForsteEllerTest(formMethods.getValues(), panelPaths)}
 			>

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/pensjon/form/Form.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/pensjon/form/Form.tsx
@@ -1,6 +1,6 @@
 import { Vis } from '@/components/bestillingsveileder/VisAttributt'
 import Panel from '@/components/ui/panel/Panel'
-import { erForsteEllerTest, panelError } from '@/components/ui/form/formUtils'
+import { erForsteEllerTest, usePanelError } from '@/components/ui/form/formUtils'
 import { getAlder, validation } from '@/components/fagsystem/pensjon/form/validation'
 import React, { useContext, useState } from 'react'
 import StyledAlert from '@/components/ui/alert/StyledAlert'
@@ -55,7 +55,7 @@ export const PensjonForm = () => {
 		<Vis attributt={[pensjonPath, pensjonGenererPath]}>
 			<Panel
 				heading="Pensjonsgivende inntekt (POPP)"
-				hasErrors={panelError(pensjonPath) || panelError(pensjonGenererPath)}
+				hasErrors={usePanelError([pensjonPath, pensjonGenererPath])}
 				iconType="pensjon"
 				startOpen={erForsteEllerTest(formMethods.watch(), [pensjonPath, pensjonGenererPath])}
 				informasjonstekst={hjelpetekst}

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/pensjonsavtale/form/Form.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/pensjonsavtale/form/Form.tsx
@@ -3,7 +3,7 @@ import { validation } from '@/components/fagsystem/pensjonsavtale/form/validatio
 import { useFormContext } from 'react-hook-form'
 import { Vis } from '@/components/bestillingsveileder/VisAttributt'
 import Panel from '@/components/ui/panel/Panel'
-import { erForsteEllerTest, panelError } from '@/components/ui/form/formUtils'
+import { erForsteEllerTest, usePanelError } from '@/components/ui/form/formUtils'
 import { FormTextInput } from '@/components/ui/form/inputs/textInput/TextInput'
 import { FormSelect } from '@/components/ui/form/inputs/select/Select'
 import { SelectOptionsManager as Options } from '@/service/SelectOptions'
@@ -21,7 +21,7 @@ export const PensjonsavtaleForm = () => {
 		<Vis attributt={avtalePath}>
 			<Panel
 				heading="Pensjonsavtale"
-				hasErrors={panelError(avtalePath)}
+				hasErrors={usePanelError(avtalePath)}
 				iconType="pensjon"
 				startOpen={erForsteEllerTest(formMethods.getValues(), [avtalePath])}
 				informasjonstekst={hjelpetekst}

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/sigrunstubPensjonsgivende/form/Form.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/sigrunstubPensjonsgivende/form/Form.tsx
@@ -1,6 +1,6 @@
 import { Vis } from '@/components/bestillingsveileder/VisAttributt'
 import Panel from '@/components/ui/panel/Panel'
-import { erForsteEllerTest, panelError } from '@/components/ui/form/formUtils'
+import { erForsteEllerTest, usePanelError } from '@/components/ui/form/formUtils'
 import { FormDollyFieldArray } from '@/components/ui/form/fieldArray/DollyFieldArray'
 import React, { useEffect } from 'react'
 import { FormSelect } from '@/components/ui/form/inputs/select/Select'
@@ -61,7 +61,7 @@ export const SigrunstubPensjonsgivendeForm = () => {
 		<Vis attributt={sigrunstubPensjonsgivendeAttributt}>
 			<Panel
 				heading="Pensjonsgivende inntekt (Sigrun)"
-				hasErrors={panelError(sigrunstubPensjonsgivendeAttributt)}
+				hasErrors={usePanelError(sigrunstubPensjonsgivendeAttributt)}
 				iconType="sigrun"
 				startOpen={erForsteEllerTest(formMethods.getValues(), [sigrunstubPensjonsgivendeAttributt])}
 			>

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/sigrunstubSummertSkattegrunnlag/form/Form.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/sigrunstubSummertSkattegrunnlag/form/Form.tsx
@@ -1,6 +1,6 @@
 import { Vis } from '@/components/bestillingsveileder/VisAttributt'
 import Panel from '@/components/ui/panel/Panel'
-import { erForsteEllerTest, panelError } from '@/components/ui/form/formUtils'
+import { erForsteEllerTest, usePanelError } from '@/components/ui/form/formUtils'
 import { FormDollyFieldArray } from '@/components/ui/form/fieldArray/DollyFieldArray'
 import React from 'react'
 import { ErrorBoundary } from '@/components/ui/appError/ErrorBoundary'
@@ -60,7 +60,7 @@ export const SigrunstubSummertSkattegrunnlagForm = () => {
 		<Vis attributt={sigrunstubSummertSkattegrunnlagAttributt}>
 			<Panel
 				heading="Summert skattegrunnlag (Sigrun)"
-				hasErrors={panelError(sigrunstubSummertSkattegrunnlagAttributt)}
+				hasErrors={usePanelError(sigrunstubSummertSkattegrunnlagAttributt)}
 				iconType="sigrun"
 				startOpen={erForsteEllerTest(formMethods.getValues(), [
 					sigrunstubSummertSkattegrunnlagAttributt,

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/skattekort/form/Form.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/skattekort/form/Form.tsx
@@ -1,5 +1,5 @@
 import { Vis } from '@/components/bestillingsveileder/VisAttributt'
-import { erForsteEllerTest, panelError } from '@/components/ui/form/formUtils'
+import { erForsteEllerTest, usePanelError } from '@/components/ui/form/formUtils'
 import { useFormContext } from 'react-hook-form'
 import { ErrorBoundary } from '@/components/ui/appError/ErrorBoundary'
 import React, { useContext } from 'react'
@@ -105,7 +105,7 @@ export const SkattekortForm = () => {
 		<Vis attributt={skattekortAttributt}>
 			<Panel
 				heading="Nav skattekort"
-				hasErrors={panelError(skattekortAttributt)}
+				hasErrors={usePanelError(skattekortAttributt)}
 				iconType="skattekort"
 				startOpen={erForsteEllerTest(formMethods.getValues(), [skattekortAttributt])}
 			>

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/sykdom/form/Form.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/sykdom/form/Form.tsx
@@ -1,6 +1,6 @@
 import { Vis } from '@/components/bestillingsveileder/VisAttributt'
 import Panel from '@/components/ui/panel/Panel'
-import { erForsteEllerTest, panelError } from '@/components/ui/form/formUtils'
+import { erForsteEllerTest, usePanelError } from '@/components/ui/form/formUtils'
 import { validation } from './validation'
 import React from 'react'
 import { useFormContext } from 'react-hook-form'
@@ -18,7 +18,7 @@ const SykdomForm = () => {
 		<Vis attributt={[sykemeldingAttributt]}>
 			<Panel
 				heading="Sykemelding"
-				hasErrors={panelError([sykemeldingAttributt])}
+				hasErrors={usePanelError([sykemeldingAttributt])}
 				iconType="sykdom"
 				startOpen={erForsteEllerTest(formMethods.getValues(), [sykemeldingAttributt])}
 			>

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/tjenestepensjon/form/Form.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/tjenestepensjon/form/Form.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react'
 import { Vis } from '@/components/bestillingsveileder/VisAttributt'
 import Panel from '@/components/ui/panel/Panel'
-import { erForsteEllerTest, panelError } from '@/components/ui/form/formUtils'
+import { erForsteEllerTest, usePanelError } from '@/components/ui/form/formUtils'
 import { validation } from '@/components/fagsystem/tjenestepensjon/form/validation'
 import { FormDollyFieldArray } from '@/components/ui/form/fieldArray/DollyFieldArray'
 import { YtelseForm } from '@/components/fagsystem/tjenestepensjon/form/partials/ytelseForm'
@@ -47,7 +47,7 @@ export const TjenestepensjonForm = () => {
 		<Vis attributt={tpPath}>
 			<Panel
 				heading="Tjenestepensjon"
-				hasErrors={panelError(tpPath)}
+				hasErrors={usePanelError(tpPath)}
 				iconType="pensjon"
 				startOpen={erForsteEllerTest(formMethods.getValues(), [tpPath])}
 				informasjonstekst={hjelpetekst}

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/udistub/form/Form.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/udistub/form/Form.tsx
@@ -1,7 +1,7 @@
 import { Vis } from '@/components/bestillingsveileder/VisAttributt'
 import { Kategori } from '@/components/ui/form/kategori/Kategori'
 import Panel from '@/components/ui/panel/Panel'
-import { erForsteEllerTest, panelError } from '@/components/ui/form/formUtils'
+import { erForsteEllerTest, usePanelError } from '@/components/ui/form/formUtils'
 import { validation } from './validation'
 import { Oppholdsstatus } from './partials/Oppholdsstatus'
 import { Arbeidsadgang } from './partials/Arbeidsadgang'
@@ -23,7 +23,7 @@ export const UdistubForm = () => {
 		<Vis attributt={attrPaths}>
 			<Panel
 				heading="UDI"
-				hasErrors={panelError(attrPaths)}
+				hasErrors={usePanelError(attrPaths)}
 				iconType="udi"
 				startOpen={erForsteEllerTest(formMethods.getValues(), [udiAttributt])}
 			>

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/uforetrygd/form/Form.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/uforetrygd/form/Form.tsx
@@ -1,4 +1,4 @@
-import { erForsteEllerTest, panelError } from '@/components/ui/form/formUtils'
+import { erForsteEllerTest, usePanelError } from '@/components/ui/form/formUtils'
 import React, { useEffect, useState } from 'react'
 import { Vis } from '@/components/bestillingsveileder/VisAttributt'
 import Panel from '@/components/ui/panel/Panel'
@@ -33,7 +33,7 @@ export const UforetrygdForm = () => {
 		<Vis attributt={uforetrygdPath}>
 			<Panel
 				heading="Uføretrygd"
-				hasErrors={panelError(uforetrygdPath)}
+				hasErrors={usePanelError(uforetrygdPath)}
 				iconType="pensjon"
 				startOpen={erForsteEllerTest(formMethods.getValues(), [uforetrygdPath])}
 			>

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/yrkesskader/form/Form.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/yrkesskader/form/Form.tsx
@@ -2,7 +2,7 @@ import { useFormContext } from 'react-hook-form'
 import React from 'react'
 import { Vis } from '@/components/bestillingsveileder/VisAttributt'
 import Panel from '@/components/ui/panel/Panel'
-import { erForsteEllerTest, panelError } from '@/components/ui/form/formUtils'
+import { erForsteEllerTest, usePanelError } from '@/components/ui/form/formUtils'
 import {
 	initialYrkesskade,
 	initialYrkesskadePeriode,
@@ -122,7 +122,7 @@ export const YrkesskaderForm = () => {
 		<Vis attributt={yrkesskaderAttributt}>
 			<Panel
 				heading="Yrkesskader"
-				hasErrors={panelError(yrkesskaderAttributt)}
+				hasErrors={usePanelError(yrkesskaderAttributt)}
 				// @ts-ignore
 				iconType="sykdom"
 				startOpen={erForsteEllerTest(formMethods.getValues(), [yrkesskaderAttributt])}

--- a/apps/dolly-frontend/src/main/js/src/components/ui/form/formUtils.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/ui/form/formUtils.tsx
@@ -6,17 +6,15 @@ import { sigrunstubPensjonsgivendeAttributt } from '@/components/fagsystem/sigru
 import { sigrunstubSummertSkattegrunnlagAttributt } from '@/components/fagsystem/sigrunstubSummertSkattegrunnlag/form/Form'
 import { sykemeldingAttributt } from '@/components/fagsystem/sykdom/form/constants'
 
-export const panelError = (attributtPath) => {
+export const usePanelError = (attributtPath) => {
+	'use no memo'
 	const {
 		formState: { errors },
 	} = useFormContext()
 	// Ignore if values ikke er satt
 	if (_.isNil(attributtPath)) return false
-
-	// Strings er akseptert, men konverter til Array
-	if (!Array.isArray(attributtPath)) attributtPath = [attributtPath]
-
-	return attributtPath.some((attr) => _.has(errors, attr) || _.has(errors, `manual.${attr}`))
+	const paths = Array.isArray(attributtPath) ? attributtPath : [attributtPath]
+	return paths.some((attr) => _.has(errors, attr) || _.has(errors, `manual.${attr}`))
 }
 
 export const SyntEvent = (name, value) => ({ target: { name, value } })

--- a/apps/dolly-frontend/src/main/js/src/components/ui/panel/Panel.less
+++ b/apps/dolly-frontend/src/main/js/src/components/ui/panel/Panel.less
@@ -39,18 +39,6 @@
       height: 36px;
     }
 
-    &_error {
-      color: @color-error;
-      display: flex;
-      align-items: center;
-      margin: 0 10px;
-      font-size: 0.9rem;
-
-      svg {
-        margin-right: 5px;
-      }
-    }
-
     &_buttons {
       margin-left: auto;
       display: flex;

--- a/apps/dolly-frontend/src/main/js/src/components/ui/panel/Panel.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/ui/panel/Panel.tsx
@@ -11,6 +11,7 @@ import {
 	ShowErrorContextType,
 } from '@/components/bestillingsveileder/ShowErrorContext'
 import { useContext } from 'react'
+import { InlineMessage } from '@navikt/ds-react'
 
 export default function Panel({
 	startOpen = false,
@@ -66,10 +67,9 @@ export default function Panel({
 
 				{informasjonstekst && <Hjelpetekst>{informasjonstekst}</Hjelpetekst>}
 				{hasErrors && errorContext.showError && (
-					<div className="dolly-panel-heading_error">
-						<Icon size={16} kind="report-problem-triangle" />
+					<InlineMessage status="error" size="small" style={{ marginLeft: '10px' }}>
 						Feil i felter
-					</div>
+					</InlineMessage>
 				)}
 				<span className="dolly-panel-heading_buttons">
 					{checkAttributeArray && (


### PR DESCRIPTION
This pull request refactors how form error handling is implemented across multiple form components in the frontend. The main change is replacing the direct use of the `panelError` function with a new custom hook, `usePanelError`, to determine if a form panel has errors. This update standardizes error handling and prepares the codebase for more advanced or React-specific error logic in the future. Additionally, there is a minor UI improvement in the `MedServicebehov` component, switching to a styled alert for better consistency.

**Form error handling improvements:**

* All usages of the `panelError` function in form components are replaced with the `usePanelError` hook, affecting components such as `AaregForm`, `AfpOffentligForm`, `AlderspensjonForm`, `AlderspensjonNyUttaksgradForm`, `ArbeidsplassenForm`, `ArbeidssoekerregisteretForm`, `ArenaForm`, `NorskBankkonto`, `UtenlandskBankkonto`, `BrregstubForm`, `DokarkivForm`, `FullmaktForm`, `HistarkForm`, and `InntektsmeldingForm`. This change ensures a more React-idiomatic and potentially more performant approach to error detection in panels. [[1]](diffhunk://#diff-2a82c67555e81547bd439e8262167c3a889334e0c2dc5952748be0231fac40f3L3-R3) [[2]](diffhunk://#diff-2a82c67555e81547bd439e8262167c3a889334e0c2dc5952748be0231fac40f3L35-R35) [[3]](diffhunk://#diff-33e31fda61716003550b04289a0ac8067016be38fdc84690c62863b811677e96L4-R4) [[4]](diffhunk://#diff-33e31fda61716003550b04289a0ac8067016be38fdc84690c62863b811677e96L44-R44) [[5]](diffhunk://#diff-3d070041093cce0002c85fb5606b55da6c377c388171743d87e7a40a62864800L2-R2) [[6]](diffhunk://#diff-3d070041093cce0002c85fb5606b55da6c377c388171743d87e7a40a62864800L36-R36) [[7]](diffhunk://#diff-8ce826f5bbecb86d538eeff6f31dc17a37fa86066df2198800cf489263ce700aL2-R2) [[8]](diffhunk://#diff-8ce826f5bbecb86d538eeff6f31dc17a37fa86066df2198800cf489263ce700aL211-R211) [[9]](diffhunk://#diff-6564d2091535b05846cb97a429445af590733eb5666d42f729a015397a1d1bbeL2-R2) [[10]](diffhunk://#diff-6564d2091535b05846cb97a429445af590733eb5666d42f729a015397a1d1bbeL38-R38) [[11]](diffhunk://#diff-b03e5c77da528f4e7d3cb0a939d659f3b634f967ca04bf6182161f325d741de9L4-R4) [[12]](diffhunk://#diff-b03e5c77da528f4e7d3cb0a939d659f3b634f967ca04bf6182161f325d741de9L41-R41) [[13]](diffhunk://#diff-40c9bef94006f27c6565348b6d8085ab3b3a1bb7443dcaa4dcdfbea4f873fde8L6-R6) [[14]](diffhunk://#diff-40c9bef94006f27c6565348b6d8085ab3b3a1bb7443dcaa4dcdfbea4f873fde8L39-R39) [[15]](diffhunk://#diff-eaca238b08f20cfd69c521e01524f07d7275f5fc1db1cd7d18d1c6340116bd72L9-R9) [[16]](diffhunk://#diff-eaca238b08f20cfd69c521e01524f07d7275f5fc1db1cd7d18d1c6340116bd72L26-R26) [[17]](diffhunk://#diff-68d4e067e2a8ec539e0842bfb02ad09785f3b2f9946b0b16070feb261e8be8e9L10-R10) [[18]](diffhunk://#diff-68d4e067e2a8ec539e0842bfb02ad09785f3b2f9946b0b16070feb261e8be8e9L43-R43) [[19]](diffhunk://#diff-4823b6da654e977fe546fbc901d248283838d722d332dd187d8ebf94dc26924dL6-R6) [[20]](diffhunk://#diff-4823b6da654e977fe546fbc901d248283838d722d332dd187d8ebf94dc26924dL25-R25) [[21]](diffhunk://#diff-29e0341cd79403eadf0738ece3ed7cb6bc7379874b3638489e60d10cecac395bL5-R5) [[22]](diffhunk://#diff-29e0341cd79403eadf0738ece3ed7cb6bc7379874b3638489e60d10cecac395bL36-R36) [[23]](diffhunk://#diff-316d176fce94b4f6eac361fdc31fbd8fcaafe6982d666a972c09402801c7b2faL16-R16) [[24]](diffhunk://#diff-316d176fce94b4f6eac361fdc31fbd8fcaafe6982d666a972c09402801c7b2faL195-R195) [[25]](diffhunk://#diff-af7e15b9a64c4bbfdd6c4c6b91a90210d5b039b516d8c4f623a0d6ff63fa52f4L5-R5) [[26]](diffhunk://#diff-af7e15b9a64c4bbfdd6c4c6b91a90210d5b039b516d8c4f623a0d6ff63fa52f4L24-R24) [[27]](diffhunk://#diff-d24bccaf7c83518b288b0eefc957984306fea99c33487ec3c8b6e82fee16122cL6-R6) [[28]](diffhunk://#diff-d24bccaf7c83518b288b0eefc957984306fea99c33487ec3c8b6e82fee16122cL114-R114)

**UI consistency:**

* The `MedServicebehov` component now uses `StyledAlert` instead of the default `Alert` for warning messages, improving visual consistency across the application. [[1]](diffhunk://#diff-0492f295a29bab46c106a2907e658db49d17ec77daa76c2ff4e41933aef75c0dR12) [[2]](diffhunk://#diff-0492f295a29bab46c106a2907e658db49d17ec77daa76c2ff4e41933aef75c0dL49-R52)