### PR TITLE
Filtrer ut duplikat-identer fra finn person

### DIFF
--- a/apps/dolly-frontend/src/main/js/src/pages/gruppeOversikt/FinnPerson.tsx
+++ b/apps/dolly-frontend/src/main/js/src/pages/gruppeOversikt/FinnPerson.tsx
@@ -148,10 +148,24 @@ export const usePersonSearch = () => {
 			setPdlIdenter(state.pdlIdenter)
 			setPdlAktoerer(state.pdlAktoerer)
 		})
+
+		// Sjekk hvilke identer som blir returnert baade fra pdl og pdlf
+		const duplicateValues = new Set(
+			personer
+				?.filter((person) => personer.filter((p) => p.value === person.value).length > 1)
+				.map((person) => person.value),
+		)
+
+		// Filtrer ut personer som returneres fra baade pdl og pdlf, og har mangelfulle data
+		const filtrertePersoner =
+			personer?.filter(
+				(person) => !(person.label?.includes('UKJENT') && duplicateValues.has(person.value)),
+			) || []
+
 		return {
 			label: 'Personer',
 			options:
-				personer?.map((person) => ({
+				filtrertePersoner?.map((person) => ({
 					value: person.value as string,
 					label: person.label?.length > 39 ? `${person.label?.substring(0, 36)}...` : person.label,
 					type: SoekTypeValg.PERSON,


### PR DESCRIPTION
This pull request improves the person search functionality by filtering out duplicate search results that have incomplete data. Specifically, it identifies persons returned from both PDL and PDLF sources with missing information and removes them from the search results, ensuring users see only relevant and complete entries.

Enhancements to person search results:

* Added logic to detect duplicate persons returned from both PDL and PDLF by checking for repeated `value` fields in the `personer` array.
* Filtered out persons with labels containing "UKJENT" (indicating incomplete data) if they are duplicates, resulting in cleaner and more accurate search results.