### PR TITLE
Feature/auto import av summert skattegrunnlag

### DIFF
--- a/apps/api-oversikt-service/src/main/resources/data/apioversikt.yml
+++ b/apps/api-oversikt-service/src/main/resources/data/apioversikt.yml
@@ -176,13 +176,12 @@ system:
     write:
       url: https://sigrun-skd-stub.intern.dev.nav.no/swagger-ui/index.html?urls.primaryName=Endepunkter+for+testdata
   - register: sykemelding
-    kubernetes-name: syfosmregler
-    namespace: teamsykmelding
+    kubernetes-name: tsm-input-dolly
+    namespace: tsm
     cluster: dev-gcp
     write:
-      url:
-      - https://syfosmregler.intern.dev.nav.no/openapi
-      - QA.Q1_SYFOSMMOTTAK.INPUT
+      url: https://tsm-input-dolly.intern.dev.nav.no
+      description: https://tsm-input-dolly.intern.dev.nav.no/swagger-ui
   - register: udistub
     kubernetes-name: testnav-udi-stub
     namespace: dolly
@@ -192,5 +191,6 @@ system:
   - register: yrkesskade
     kubernetes-name: yrkesskade-datagenerator-service
     namespace: yrkesskade
-    url: https://yrkesskade-datagenerator-service.intern.dev.nav.no/swagger-ui/index.html
+    url: https://yrkesskade-datagenerator-service.intern.dev.nav.no
+    description: https://yrkesskade-datagenerator-service.intern.dev.nav.no/swagger-ui/index.html
     cluster: dev-gcp

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/sigrunstub/SigrunStubClient.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/sigrunstub/SigrunStubClient.java
@@ -31,9 +31,9 @@ import static no.nav.dolly.util.TestnorgeIdentUtility.isTestnorgeIdent;
 public class SigrunStubClient implements ClientRegister {
 
     private static final String IDENT = "ident";
-    private static final String SIGRUNSTUB_SUMMERT = "SIGRUN_SUMMERT: %s";
-    private static final String SIGRUNSTUB_PENSJONSGIVENDE = "SIGRUN_PENSJONSGIVENDE: %s";
-    private static final String SIGRUNSTUB_LIGNET = "SIGRUN_LIGNET: %s ";
+    private static final String SIGRUNSTUB_SUMMERT = "SIGRUN_SUMMERT:%s";
+    private static final String SIGRUNSTUB_PENSJONSGIVENDE = "SIGRUN_PENSJONSGIVENDE:%s";
+    private static final String SIGRUNSTUB_LIGNET = "SIGRUN_LIGNET:%s ";
 
     private final SigrunStubConsumer sigrunStubConsumer;
     private final ErrorStatusDecoder errorStatusDecoder;

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/sigrunstub/SigrunStubClient.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/sigrunstub/SigrunStubClient.java
@@ -33,7 +33,7 @@ public class SigrunStubClient implements ClientRegister {
     private static final String IDENT = "ident";
     private static final String SIGRUNSTUB_SUMMERT = "SIGRUN_SUMMERT:%s";
     private static final String SIGRUNSTUB_PENSJONSGIVENDE = "SIGRUN_PENSJONSGIVENDE:%s";
-    private static final String SIGRUNSTUB_LIGNET = "SIGRUN_LIGNET:%s ";
+    private static final String SIGRUNSTUB_LIGNET = "SIGRUN_LIGNET:%s";
 
     private final SigrunStubConsumer sigrunStubConsumer;
     private final ErrorStatusDecoder errorStatusDecoder;
@@ -57,9 +57,10 @@ public class SigrunStubClient implements ClientRegister {
                     if (isTestnorgeIdent(dollyPerson.getIdent())) {
                         return sigrunStubConsumer.importCheckSummertSkattegrunnlag(dollyPerson.getIdent())
                                 .filter(SigrunstubResponse::isOK)
-                                .then(sigrunStubConsumer.importSummertSkattegrunnlag(dollyPerson.getIdent()))
-                                .map(this::getStatus)
-                                .map(SIGRUNSTUB_SUMMERT::formatted);
+                                .flatMap(status ->
+                                        sigrunStubConsumer.importSummertSkattegrunnlag(dollyPerson.getIdent())
+                                                .map(this::getStatus)
+                                                .map(SIGRUNSTUB_SUMMERT::formatted));
                     } else {
                         return Mono.empty();
                     }
@@ -90,7 +91,7 @@ public class SigrunStubClient implements ClientRegister {
                     if (isTestnorgeIdent(dollyPerson.getIdent())) {
                         return sigrunStubConsumer.importCheckPensjonsgivendeInntektForFolketrygden(dollyPerson.getIdent())
                                 .filter(SigrunstubResponse::isOK)
-                                .then(sigrunStubConsumer.importPensjonsgivendeInntektForFolketrygden(dollyPerson.getIdent()))
+                                .flatMap(status -> sigrunStubConsumer.importPensjonsgivendeInntektForFolketrygden(dollyPerson.getIdent()))
                                 .map(this::getStatus)
                                 .map(SIGRUNSTUB_PENSJONSGIVENDE::formatted);
                     } else {
@@ -99,20 +100,20 @@ public class SigrunStubClient implements ClientRegister {
                 }),
 
                 Mono.just(bestilling)
-                .filter(bestilling2 -> !bestilling2.getSigrunstubPensjonsgivende().isEmpty())
-                .map(RsDollyUtvidetBestilling::getSigrunstubPensjonsgivende)
-                .flatMap(pensjonsgivende -> {
+                        .filter(bestilling2 -> !bestilling2.getSigrunstubPensjonsgivende().isEmpty())
+                        .map(RsDollyUtvidetBestilling::getSigrunstubPensjonsgivende)
+                        .flatMap(pensjonsgivende -> {
 
-                    var context = MappingContextUtils.getMappingContext();
-                    context.setProperty(IDENT, dollyPerson.getIdent());
+                            var context = MappingContextUtils.getMappingContext();
+                            context.setProperty(IDENT, dollyPerson.getIdent());
 
-                    var skattegrunnlag =
-                            mapperFacade.mapAsList(pensjonsgivende, SigrunstubPensjonsgivendeInntektRequest.class, context);
+                            var skattegrunnlag =
+                                    mapperFacade.mapAsList(pensjonsgivende, SigrunstubPensjonsgivendeInntektRequest.class, context);
 
-                    return sigrunStubConsumer.updatePensjonsgivendeInntekt(skattegrunnlag)
-                            .map(this::getStatus)
-                            .map(SIGRUNSTUB_PENSJONSGIVENDE::formatted);
-                }));
+                            return sigrunStubConsumer.updatePensjonsgivendeInntekt(skattegrunnlag)
+                                    .map(this::getStatus)
+                                    .map(SIGRUNSTUB_PENSJONSGIVENDE::formatted);
+                        }));
     }
 
     private Flux<String> doLignetInntekt(RsDollyUtvidetBestilling bestilling, DollyPerson dollyPerson) {

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/sigrunstub/SigrunStubClient.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/sigrunstub/SigrunStubClient.java
@@ -15,7 +15,6 @@ import no.nav.dolly.domain.resultset.dolly.DollyPerson;
 import no.nav.dolly.errorhandling.ErrorStatusDecoder;
 import no.nav.dolly.mapper.MappingContextUtils;
 import no.nav.dolly.service.TransactionHelperService;
-import org.reactivestreams.Publisher;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -24,6 +23,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static java.util.Objects.isNull;
+import static no.nav.dolly.util.TestnorgeIdentUtility.isTestnorgeIdent;
 
 @Log4j2
 @Service
@@ -31,6 +31,9 @@ import static java.util.Objects.isNull;
 public class SigrunStubClient implements ClientRegister {
 
     private static final String IDENT = "ident";
+    private static final String SIGRUNSTUB_SUMMERT = "SIGRUN_SUMMERT: %s";
+    private static final String SIGRUNSTUB_PENSJONSGIVENDE = "SIGRUN_PENSJONSGIVENDE: %s";
+    private static final String SIGRUNSTUB_LIGNET = "SIGRUN_LIGNET: %s ";
 
     private final SigrunStubConsumer sigrunStubConsumer;
     private final ErrorStatusDecoder errorStatusDecoder;
@@ -48,30 +51,54 @@ public class SigrunStubClient implements ClientRegister {
                 .flatMap(resultat -> oppdaterStatus(progress, resultat));
     }
 
-    private Publisher<String> doSummertSkattegrunnlag(RsDollyUtvidetBestilling bestilling, DollyPerson dollyPerson) {
+    private Flux<String> doSummertSkattegrunnlag(RsDollyUtvidetBestilling bestilling, DollyPerson dollyPerson) {
 
-        return Flux.just(bestilling)
-                .filter(bestilling1 -> !bestilling1.getSigrunstubSummertSkattegrunnlag().isEmpty())
-                .map(RsDollyUtvidetBestilling::getSigrunstubSummertSkattegrunnlag)
-                .flatMap(summertSkattegrunnlag -> {
+        return Flux.merge(Mono.defer(() -> {
+                    if (isTestnorgeIdent(dollyPerson.getIdent())) {
+                        return sigrunStubConsumer.importCheckSummertSkattegrunnlag(dollyPerson.getIdent())
+                                .filter(SigrunstubResponse::isOK)
+                                .then(sigrunStubConsumer.importSummertSkattegrunnlag(dollyPerson.getIdent()))
+                                .map(this::getStatus)
+                                .map(SIGRUNSTUB_SUMMERT::formatted);
+                    } else {
+                        return Mono.empty();
+                    }
+                }),
 
-                    var context = MappingContextUtils.getMappingContext();
-                    context.setProperty(IDENT, dollyPerson.getIdent());
+                Mono.just(bestilling)
+                        .filter(bestilling1 -> !bestilling1.getSigrunstubSummertSkattegrunnlag().isEmpty())
+                        .map(RsDollyUtvidetBestilling::getSigrunstubSummertSkattegrunnlag)
+                        .flatMap(summertSkattegrunnlag -> {
 
-                    var skattegrunnlag = SigrunstubSummertskattegrunnlagRequest.builder()
-                            .summertskattegrunnlag(
-                                    mapperFacade.mapAsList(summertSkattegrunnlag, Summertskattegrunnlag.class, context)
-                            ).build();
+                            var context = MappingContextUtils.getMappingContext();
+                            context.setProperty(IDENT, dollyPerson.getIdent());
 
-                    return sigrunStubConsumer.createSigrunstubSummertSkattegrunnlag(skattegrunnlag)
-                            .map(this::getStatus)
-                            .map(status -> "SIGRUN_SUMMERT:" + status);
-                });
+                            var skattegrunnlag = SigrunstubSummertskattegrunnlagRequest.builder()
+                                    .summertskattegrunnlag(
+                                            mapperFacade.mapAsList(summertSkattegrunnlag, Summertskattegrunnlag.class, context)
+                                    ).build();
+
+                            return sigrunStubConsumer.createSigrunstubSummertSkattegrunnlag(skattegrunnlag)
+                                    .map(this::getStatus)
+                                    .map(SIGRUNSTUB_SUMMERT::formatted);
+                        }));
     }
 
     private Flux<String> doPensjonsgivendeInntekt(RsDollyUtvidetBestilling bestilling, DollyPerson dollyPerson) {
 
-        return Flux.just(bestilling)
+        return Flux.merge(Mono.defer(() -> {
+                    if (isTestnorgeIdent(dollyPerson.getIdent())) {
+                        return sigrunStubConsumer.importCheckPensjonsgivendeInntektForFolketrygden(dollyPerson.getIdent())
+                                .filter(SigrunstubResponse::isOK)
+                                .then(sigrunStubConsumer.importPensjonsgivendeInntektForFolketrygden(dollyPerson.getIdent()))
+                                .map(this::getStatus)
+                                .map(SIGRUNSTUB_PENSJONSGIVENDE::formatted);
+                    } else {
+                        return Mono.empty();
+                    }
+                }),
+
+                Mono.just(bestilling)
                 .filter(bestilling2 -> !bestilling2.getSigrunstubPensjonsgivende().isEmpty())
                 .map(RsDollyUtvidetBestilling::getSigrunstubPensjonsgivende)
                 .flatMap(pensjonsgivende -> {
@@ -84,8 +111,8 @@ public class SigrunStubClient implements ClientRegister {
 
                     return sigrunStubConsumer.updatePensjonsgivendeInntekt(skattegrunnlag)
                             .map(this::getStatus)
-                            .map(status -> "SIGRUN_PENSJONSGIVENDE:" + status);
-                });
+                            .map(SIGRUNSTUB_PENSJONSGIVENDE::formatted);
+                }));
     }
 
     private Flux<String> doLignetInntekt(RsDollyUtvidetBestilling bestilling, DollyPerson dollyPerson) {
@@ -103,7 +130,7 @@ public class SigrunStubClient implements ClientRegister {
 
                     return sigrunStubConsumer.updateLignetInntekt(skattegrunnlag)
                             .map(this::getStatus)
-                            .map(status -> "SIGRUN_LIGNET:" + status);
+                            .map(SIGRUNSTUB_LIGNET::formatted);
                 });
     }
 

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/sigrunstub/SigrunStubConsumer.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/sigrunstub/SigrunStubConsumer.java
@@ -31,12 +31,14 @@ import static no.nav.dolly.util.JacksonExchangeStrategyUtil.getJacksonStrategy;
 @Component
 public class SigrunStubConsumer extends ConsumerStatus {
 
-    private static final String SIGRUNSTUB_LIGNET_INNTEKT_URL = "/sigrunstub/api/v1/lignetinntekt";
-    private static final String SIGRUNSTUB_PENSJONSGIVENDE_INNTEKT_URL = "/sigrunstub/api/v1/pensjonsgivendeinntektforfolketrygden";
-    private static final String SIGRUNSTUB_IMPORT_SUMMERT_SKATTEGRUNNLAG_URL = "/sigrunstub/api/v1/summertskattegrunnlag/import";
-    private static final String SIGRUNSTUB_IMPORT_PENSJONSGIVENDE_INNTEKT_URL = "/sigrunstub/api/v1/pensjonsgivendeinntektforfolketrygden/import";
-    private static final String SIGRUNSTUB_IMPORT_CHECK_SUMMERT_SKATTEGRUNNLAG_URL = "/sigrunstub/api/v1/summertskattegrunnlag/import/check";
-    private static final String SIGRUNSTUB_IMPORT_CHECK_PENSJONSGIVENDE_INNTEKT_URL = "/sigrunstub/api/v1/pensjonsgivendeinntektforfolketrygden/import/check";
+    private static final String PREFIX = "/sigrunstub";
+    private static final String PREFIX_V1 = PREFIX + "/api/v1";
+    private static final String LIGNET_INNTEKT_URL = PREFIX_V1 + "/lignetinntekt";
+    private static final String PENSJONSGIVENDE_INNTEKT_URL = PREFIX_V1 + "/pensjonsgivendeinntektforfolketrygden";
+    private static final String IMPORT_SUMMERT_SKATTEGRUNNLAG_URL = PREFIX_V1 + "/summertskattegrunnlag/import";
+    private static final String IMPORT_PENSJONSGIVENDE_INNTEKT_URL = PREFIX_V1 + "/pensjonsgivendeinntektforfolketrygden/import";
+    private static final String IMPORT_CHECK_SUMMERT_SKATTEGRUNNLAG_URL = PREFIX_V1 + "/summertskattegrunnlag/import/check";
+    private static final String IMPORT_CHECK_PENSJONSGIVENDE_INNTEKT_URL = PREFIX_V1 + "/pensjonsgivendeinntektforfolketrygden/import/check";
     private final TokenExchange tokenService;
     private final WebClient webClient;
     private final ServerProperties serverProperties;
@@ -92,7 +94,7 @@ public class SigrunStubConsumer extends ConsumerStatus {
         log.info("Put lignet inntekt til Sigrunstub med data {}", request);
 
         return tokenService.exchange(serverProperties)
-                .flatMap(token -> new SigurunstubPutCommand(webClient, SIGRUNSTUB_LIGNET_INNTEKT_URL, request, token.getTokenValue()).call());
+                .flatMap(token -> new SigurunstubPutCommand(webClient, LIGNET_INNTEKT_URL, request, token.getTokenValue()).call());
     }
 
     @Timed(name = "providers", tags = {"operation", "sigrun_createPensjonsgivendeInntekt"})
@@ -101,7 +103,7 @@ public class SigrunStubConsumer extends ConsumerStatus {
         log.info("Put pensjonsgivende inntekt til Sigrunstub med data {}", request);
 
         return tokenService.exchange(serverProperties)
-                .flatMap(token -> new SigurunstubPutCommand(webClient, SIGRUNSTUB_PENSJONSGIVENDE_INNTEKT_URL,
+                .flatMap(token -> new SigurunstubPutCommand(webClient, PENSJONSGIVENDE_INNTEKT_URL,
                         request, token.getTokenValue()).call());
     }
 
@@ -122,7 +124,7 @@ public class SigrunStubConsumer extends ConsumerStatus {
 
         return tokenService.exchange(serverProperties)
                 .flatMap(token ->
-                        new SigurunstubPostImportCommand(webClient, SIGRUNSTUB_IMPORT_PENSJONSGIVENDE_INNTEKT_URL, ident, token.getTokenValue()).call());
+                        new SigurunstubPostImportCommand(webClient, IMPORT_PENSJONSGIVENDE_INNTEKT_URL, ident, token.getTokenValue()).call());
     }
 
     @Timed(name = "providers", tags = {"operation", "sigrun_importSummertSkattegrunnlag"})
@@ -132,7 +134,7 @@ public class SigrunStubConsumer extends ConsumerStatus {
 
         return tokenService.exchange(serverProperties)
                 .flatMap(token ->
-                        new SigurunstubPostImportCommand(webClient, SIGRUNSTUB_IMPORT_SUMMERT_SKATTEGRUNNLAG_URL, ident, token.getTokenValue()).call());
+                        new SigurunstubPostImportCommand(webClient, IMPORT_SUMMERT_SKATTEGRUNNLAG_URL, ident, token.getTokenValue()).call());
     }
 
     @Timed(name = "providers", tags = {"operation", "sigrun_importPensjonsgivendeForFolketrygden"})
@@ -142,7 +144,7 @@ public class SigrunStubConsumer extends ConsumerStatus {
 
         return tokenService.exchange(serverProperties)
                 .flatMap(token ->
-                        new SigurunstubPostImportCommand(webClient, SIGRUNSTUB_IMPORT_CHECK_PENSJONSGIVENDE_INNTEKT_URL, ident, token.getTokenValue()).call());
+                        new SigurunstubPostImportCommand(webClient, IMPORT_CHECK_PENSJONSGIVENDE_INNTEKT_URL, ident, token.getTokenValue()).call());
     }
 
     @Timed(name = "providers", tags = {"operation", "sigrun_importSummertSkattegrunnlag"})
@@ -152,7 +154,7 @@ public class SigrunStubConsumer extends ConsumerStatus {
 
         return tokenService.exchange(serverProperties)
                 .flatMap(token ->
-                        new SigurunstubPostImportCommand(webClient, SIGRUNSTUB_IMPORT_CHECK_SUMMERT_SKATTEGRUNNLAG_URL, ident, token.getTokenValue()).call());
+                        new SigurunstubPostImportCommand(webClient, IMPORT_CHECK_SUMMERT_SKATTEGRUNNLAG_URL, ident, token.getTokenValue()).call());
     }
 
     @Override

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/sigrunstub/SigrunStubConsumer.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/sigrunstub/SigrunStubConsumer.java
@@ -5,6 +5,7 @@ import no.nav.dolly.bestilling.ConsumerStatus;
 import no.nav.dolly.bestilling.sigrunstub.command.SigrunstubLignetDeleteCommand;
 import no.nav.dolly.bestilling.sigrunstub.command.SigrunstubPensjonsgivendeDeleteCommand;
 import no.nav.dolly.bestilling.sigrunstub.command.SigrunstubSummertSkattgrunnlagDeleteCommand;
+import no.nav.dolly.bestilling.sigrunstub.command.SigurunstubPostImportCommand;
 import no.nav.dolly.bestilling.sigrunstub.command.SigurunstubPostSummertSkattegrunnlagCommand;
 import no.nav.dolly.bestilling.sigrunstub.command.SigurunstubPutCommand;
 import no.nav.dolly.bestilling.sigrunstub.dto.SigrunstubLignetInntektRequest;
@@ -30,8 +31,12 @@ import static no.nav.dolly.util.JacksonExchangeStrategyUtil.getJacksonStrategy;
 @Component
 public class SigrunStubConsumer extends ConsumerStatus {
 
-    private static final String SIGRUN_STUB_LIGNET_INNTEKT_URL = "/sigrunstub/api/v1/lignetinntekt";
-    private static final String SIGRUN_STUB_PENSJONSGIVENDE_INNTEKT_URL = "/sigrunstub/api/v1/pensjonsgivendeinntektforfolketrygden";
+    private static final String SIGRUNSTUB_LIGNET_INNTEKT_URL = "/sigrunstub/api/v1/lignetinntekt";
+    private static final String SIGRUNSTUB_PENSJONSGIVENDE_INNTEKT_URL = "/sigrunstub/api/v1/pensjonsgivendeinntektforfolketrygden";
+    private static final String SIGRUNSTUB_IMPORT_SUMMERT_SKATTEGRUNNLAG_URL = "/sigrunstub/api/v1/summertskattegrunnlag/import";
+    private static final String SIGRUNSTUB_IMPORT_PENSJONSGIVENDE_INNTEKT_URL = "/sigrunstub/api/v1/pensjonsgivendeinntektforfolketrygden/import";
+    private static final String SIGRUNSTUB_IMPORT_CHECK_SUMMERT_SKATTEGRUNNLAG_URL = "/sigrunstub/api/v1/summertskattegrunnlag/import/check";
+    private static final String SIGRUNSTUB_IMPORT_CHECK_PENSJONSGIVENDE_INNTEKT_URL = "/sigrunstub/api/v1/pensjonsgivendeinntektforfolketrygden/import/check";
     private final TokenExchange tokenService;
     private final WebClient webClient;
     private final ServerProperties serverProperties;
@@ -87,7 +92,7 @@ public class SigrunStubConsumer extends ConsumerStatus {
         log.info("Put lignet inntekt til Sigrunstub med data {}", request);
 
         return tokenService.exchange(serverProperties)
-                .flatMap(token -> new SigurunstubPutCommand(webClient, SIGRUN_STUB_LIGNET_INNTEKT_URL, request, token.getTokenValue()).call());
+                .flatMap(token -> new SigurunstubPutCommand(webClient, SIGRUNSTUB_LIGNET_INNTEKT_URL, request, token.getTokenValue()).call());
     }
 
     @Timed(name = "providers", tags = {"operation", "sigrun_createPensjonsgivendeInntekt"})
@@ -96,7 +101,7 @@ public class SigrunStubConsumer extends ConsumerStatus {
         log.info("Put pensjonsgivende inntekt til Sigrunstub med data {}", request);
 
         return tokenService.exchange(serverProperties)
-                .flatMap(token -> new SigurunstubPutCommand(webClient, SIGRUN_STUB_PENSJONSGIVENDE_INNTEKT_URL,
+                .flatMap(token -> new SigurunstubPutCommand(webClient, SIGRUNSTUB_PENSJONSGIVENDE_INNTEKT_URL,
                         request, token.getTokenValue()).call());
     }
 
@@ -108,6 +113,46 @@ public class SigrunStubConsumer extends ConsumerStatus {
         return tokenService.exchange(serverProperties)
                 .flatMap(token ->
                         new SigurunstubPostSummertSkattegrunnlagCommand(webClient, request, token.getTokenValue()).call());
+    }
+
+    @Timed(name = "providers", tags = {"operation", "sigrun_importPensjonsgivendeForFolketrygden"})
+    public Mono<SigrunstubResponse> importPensjonsgivendeInntektForFolketrygden(String ident) {
+
+        log.info("Import pensjonsgivendeInnetekt for folketrygden for {}", ident);
+
+        return tokenService.exchange(serverProperties)
+                .flatMap(token ->
+                        new SigurunstubPostImportCommand(webClient, SIGRUNSTUB_IMPORT_PENSJONSGIVENDE_INNTEKT_URL, ident, token.getTokenValue()).call());
+    }
+
+    @Timed(name = "providers", tags = {"operation", "sigrun_importSummertSkattegrunnlag"})
+    public Mono<SigrunstubResponse> importSummertSkattegrunnlag(String ident) {
+
+        log.info("Import summert skattegrunnlag for {}", ident);
+
+        return tokenService.exchange(serverProperties)
+                .flatMap(token ->
+                        new SigurunstubPostImportCommand(webClient, SIGRUNSTUB_IMPORT_SUMMERT_SKATTEGRUNNLAG_URL, ident, token.getTokenValue()).call());
+    }
+
+    @Timed(name = "providers", tags = {"operation", "sigrun_importPensjonsgivendeForFolketrygden"})
+    public Mono<SigrunstubResponse> importCheckPensjonsgivendeInntektForFolketrygden(String ident) {
+
+        log.info("Import-check pensjonsgivendeInnetekt for folketrygden for {}", ident);
+
+        return tokenService.exchange(serverProperties)
+                .flatMap(token ->
+                        new SigurunstubPostImportCommand(webClient, SIGRUNSTUB_IMPORT_CHECK_PENSJONSGIVENDE_INNTEKT_URL, ident, token.getTokenValue()).call());
+    }
+
+    @Timed(name = "providers", tags = {"operation", "sigrun_importSummertSkattegrunnlag"})
+    public Mono<SigrunstubResponse> importCheckSummertSkattegrunnlag(String ident) {
+
+        log.info("Import-check summert skattegrunnlag for {}", ident);
+
+        return tokenService.exchange(serverProperties)
+                .flatMap(token ->
+                        new SigurunstubPostImportCommand(webClient, SIGRUNSTUB_IMPORT_CHECK_SUMMERT_SKATTEGRUNNLAG_URL, ident, token.getTokenValue()).call());
     }
 
     @Override

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/sigrunstub/SigrunStubConsumer.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/sigrunstub/SigrunStubConsumer.java
@@ -137,7 +137,7 @@ public class SigrunStubConsumer extends ConsumerStatus {
                         new SigurunstubPostImportCommand(webClient, IMPORT_SUMMERT_SKATTEGRUNNLAG_URL, ident, token.getTokenValue()).call());
     }
 
-    @Timed(name = "providers", tags = {"operation", "sigrun_importPensjonsgivendeForFolketrygden"})
+    @Timed(name = "providers", tags = {"operation", "sigrun_importCheckPensjonsgivendeForFolketrygden"})
     public Mono<SigrunstubResponse> importCheckPensjonsgivendeInntektForFolketrygden(String ident) {
 
         log.info("Import-check pensjonsgivendeInnetekt for folketrygden for {}", ident);
@@ -147,7 +147,7 @@ public class SigrunStubConsumer extends ConsumerStatus {
                         new SigurunstubPostImportCommand(webClient, IMPORT_CHECK_PENSJONSGIVENDE_INNTEKT_URL, ident, token.getTokenValue()).call());
     }
 
-    @Timed(name = "providers", tags = {"operation", "sigrun_importSummertSkattegrunnlag"})
+    @Timed(name = "providers", tags = {"operation", "sigrun_importCheckSummertSkattegrunnlag"})
     public Mono<SigrunstubResponse> importCheckSummertSkattegrunnlag(String ident) {
 
         log.info("Import-check summert skattegrunnlag for {}", ident);

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/sigrunstub/SigrunStubConsumer.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/sigrunstub/SigrunStubConsumer.java
@@ -120,7 +120,7 @@ public class SigrunStubConsumer extends ConsumerStatus {
     @Timed(name = "providers", tags = {"operation", "sigrun_importPensjonsgivendeForFolketrygden"})
     public Mono<SigrunstubResponse> importPensjonsgivendeInntektForFolketrygden(String ident) {
 
-        log.info("Import pensjonsgivendeInnetekt for folketrygden for {}", ident);
+        log.info("Import pensjonsgivendeInntekt for folketrygden for {}", ident);
 
         return tokenService.exchange(serverProperties)
                 .flatMap(token ->
@@ -140,7 +140,7 @@ public class SigrunStubConsumer extends ConsumerStatus {
     @Timed(name = "providers", tags = {"operation", "sigrun_importCheckPensjonsgivendeForFolketrygden"})
     public Mono<SigrunstubResponse> importCheckPensjonsgivendeInntektForFolketrygden(String ident) {
 
-        log.info("Import-check pensjonsgivendeInnetekt for folketrygden for {}", ident);
+        log.info("Import-check pensjonsgivendeInntekt for folketrygden for {}", ident);
 
         return tokenService.exchange(serverProperties)
                 .flatMap(token ->

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/sigrunstub/command/SigurunstubPostImportCommand.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/sigrunstub/command/SigurunstubPostImportCommand.java
@@ -49,6 +49,6 @@ public class SigurunstubPostImportCommand implements Callable<Mono<SigrunstubRes
                         .build())
                 .doOnError(WebClientError.logTo(log))
                 .retryWhen(WebClientError.is5xxException())
-                .onErrorResume(error -> SigrunstubResponse.of(WebClientError.describe(error), null));
+                .onErrorResume(error -> SigrunstubResponse.of(WebClientError.describe(error), ident));
     }
 }

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/sigrunstub/command/SigurunstubPostImportCommand.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/sigrunstub/command/SigurunstubPostImportCommand.java
@@ -1,0 +1,54 @@
+package no.nav.dolly.bestilling.sigrunstub.command;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import no.nav.dolly.bestilling.sigrunstub.dto.SigrunstubImportRequest;
+import no.nav.dolly.bestilling.sigrunstub.dto.SigrunstubResponse;
+import no.nav.dolly.util.RequestHeaderUtil;
+import no.nav.testnav.libs.reactivecore.web.WebClientError;
+import no.nav.testnav.libs.reactivecore.web.WebClientHeader;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.Callable;
+
+import static no.nav.dolly.domain.CommonKeysAndUtils.CONSUMER;
+import static no.nav.dolly.domain.CommonKeysAndUtils.HEADER_NAV_CALL_ID;
+import static no.nav.dolly.domain.CommonKeysAndUtils.HEADER_NAV_CONSUMER_ID;
+import static org.springframework.http.HttpHeaders.ACCEPT;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+@RequiredArgsConstructor
+@Slf4j
+public class SigurunstubPostImportCommand implements Callable<Mono<SigrunstubResponse>> {
+
+    private final WebClient webClient;
+    private final String importUrl;
+    private final String ident;
+    private final String token;
+
+    @Override
+    public Mono<SigrunstubResponse> call() {
+        return webClient
+                .post()
+                .uri(uriBuilder -> uriBuilder.path(importUrl).build())
+                .header(ACCEPT, APPLICATION_JSON_VALUE)
+                .header(HEADER_NAV_CALL_ID, RequestHeaderUtil.getNavCallId())
+                .header(HEADER_NAV_CONSUMER_ID, CONSUMER)
+                .headers(WebClientHeader.bearer(token))
+                .body(BodyInserters.fromValue(SigrunstubImportRequest.builder()
+                        .norskident(ident)
+                        .build()))
+                .retrieve()
+                .toBodilessEntity()
+                .map(response -> SigrunstubResponse.builder()
+                        .ident(ident)
+                        .status(HttpStatus.valueOf(response.getStatusCode().value()))
+                        .build())
+                .doOnError(WebClientError.logTo(log))
+                .retryWhen(WebClientError.is5xxException())
+                .onErrorResume(error -> SigrunstubResponse.of(WebClientError.describe(error), null));
+    }
+}

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/sigrunstub/dto/SigrunstubImportRequest.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/sigrunstub/dto/SigrunstubImportRequest.java
@@ -1,0 +1,15 @@
+package no.nav.dolly.bestilling.sigrunstub.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SigrunstubImportRequest {
+
+    private String norskident;
+}


### PR DESCRIPTION
This pull request introduces significant enhancements to the SigrunStub client and consumer logic, primarily to support new "import" and "import check" operations for summert skattegrunnlag and pensjonsgivende inntekt, as well as standardizing request formatting and endpoint usage. Additionally, there are minor updates to API metadata and code cleanup.

**SigrunStub client and consumer improvements:**

* Added support for importing and checking summert skattegrunnlag and pensjonsgivende inntekt for Testnorge identities by introducing new methods in `SigrunStubConsumer` and updating the corresponding logic in `SigrunStubClient`. This leverages new endpoints and ensures only relevant identities trigger imports. [[1]](diffhunk://#diff-9557e62129ce5b42bc750ebd0040f0a4baede61e656cffdfbe1596c898d8a04bL51-R68) [[2]](diffhunk://#diff-9557e62129ce5b42bc750ebd0040f0a4baede61e656cffdfbe1596c898d8a04bL68-R101) [[3]](diffhunk://#diff-9557e62129ce5b42bc750ebd0040f0a4baede61e656cffdfbe1596c898d8a04bL87-R115) [[4]](diffhunk://#diff-542a96125484f103d39891631718465b3cd6c2f3cc093689a7ff19f7e27a763dR120-R159)
* Introduced the `SigurunstubPostImportCommand` class and the `SigrunstubImportRequest` DTO to encapsulate and standardize the import request structure and execution. [[1]](diffhunk://#diff-1b46c52c68606abcc76033b380001bbc322112011128e9fb55459ab148ca5aacR1-R54) [[2]](diffhunk://#diff-ba5ec3216b48fd09142b7eccc3d25d851359bcade123e39309566eddd5528316R1-R15)
* Refactored endpoint constants in `SigrunStubConsumer` to use a common prefix and updated method implementations to use the new constants, improving maintainability and clarity. [[1]](diffhunk://#diff-542a96125484f103d39891631718465b3cd6c2f3cc093689a7ff19f7e27a763dL33-R41) [[2]](diffhunk://#diff-542a96125484f103d39891631718465b3cd6c2f3cc093689a7ff19f7e27a763dL90-R97) [[3]](diffhunk://#diff-542a96125484f103d39891631718465b3cd6c2f3cc093689a7ff19f7e27a763dL99-R106)

**Code quality and consistency:**

* Standardized status message formatting in `SigrunStubClient` by introducing constants for status prefixes and using `String::formatted` for message construction. [[1]](diffhunk://#diff-9557e62129ce5b42bc750ebd0040f0a4baede61e656cffdfbe1596c898d8a04bR26-R36) [[2]](diffhunk://#diff-9557e62129ce5b42bc750ebd0040f0a4baede61e656cffdfbe1596c898d8a04bL68-R101) [[3]](diffhunk://#diff-9557e62129ce5b42bc750ebd0040f0a4baede61e656cffdfbe1596c898d8a04bL87-R115) [[4]](diffhunk://#diff-9557e62129ce5b42bc750ebd0040f0a4baede61e656cffdfbe1596c898d8a04bL106-R133)
* Removed an unused import (`Publisher`) from `SigrunStubClient` for code cleanliness.

**API metadata updates:**

* Updated URLs and descriptions for the `sykemelding` and `yrkesskade` systems in `apioversikt.yml` to reflect new endpoints and provide more accurate documentation. [[1]](diffhunk://#diff-1f97b1b15e6206c6944fea72120fc21bbdd907bafe79cd5dae92051c5cadc298L179-R184) [[2]](diffhunk://#diff-1f97b1b15e6206c6944fea72120fc21bbdd907bafe79cd5dae92051c5cadc298L195-R195)