### PR TITLE
Configure JsonMapper to exclude null values in property inclusion

### DIFF
--- a/apps/dolly-backend/src/main/java/no/nav/dolly/config/JsonMapperConfig.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/config/JsonMapperConfig.java
@@ -1,5 +1,6 @@
 package no.nav.dolly.config;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
@@ -35,6 +36,7 @@ public class JsonMapperConfig {
     @Primary
     public JsonMapper jsonMapper() {
         return JsonMapper.builder()
+                .changeDefaultPropertyInclusion(incl -> incl.withValueInclusion(JsonInclude.Include.NON_NULL))
                 .configure(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES, false)
                 .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
                 .configure(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT, true)

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/util/JacksonExchangeStrategyUtil.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/util/JacksonExchangeStrategyUtil.java
@@ -1,5 +1,6 @@
 package no.nav.dolly.util;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.codec.json.JacksonJsonDecoder;
@@ -55,6 +56,7 @@ public final class JacksonExchangeStrategyUtil {
 
     private static JsonMapper createDefaultJsonMapper() {
         return JsonMapper.builder()
+                .changeDefaultPropertyInclusion(incl -> incl.withValueInclusion(JsonInclude.Include.NON_NULL))
                 .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
                 .configure(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES, false)
                 .configure(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT, true)

--- a/libs/reactive-core/src/main/java/no/nav/testnav/libs/reactivecore/web/WebClientAutoConfiguration.java
+++ b/libs/reactive-core/src/main/java/no/nav/testnav/libs/reactivecore/web/WebClientAutoConfiguration.java
@@ -1,5 +1,6 @@
 package no.nav.testnav.libs.reactivecore.web;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.micrometer.observation.ObservationRegistry;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.epoll.EpollChannelOption;
@@ -30,6 +31,7 @@ class WebClientAutoConfiguration {
 
     private static JsonMapper createDefaultJsonMapper() {
         return JsonMapper.builder()
+                .changeDefaultPropertyInclusion(incl -> incl.withValueInclusion(JsonInclude.Include.NON_NULL))
                 .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
                 .configure(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES, false)
                 .configure(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT, true)


### PR DESCRIPTION
Ser ut som dette problemet har dukket opp downstream fra oss, antageligvis når pensjon gikk til spring boot 4. Vi sender en null som de ikke godtar på samme måte som vi gjør, sender derfor bare non-null verdier videre fra oss.


This pull request updates JSON serialization settings across multiple components to exclude properties with null values by default. This change ensures that null fields are omitted from JSON output, resulting in cleaner and more concise API responses and payloads.

**Jackson configuration updates:**

* Updated the `JsonMapper` builder in `JsonMapperConfig.java` to set the default property inclusion to `NON_NULL`, so that null values are not serialized.
* Applied the same `NON_NULL` property inclusion setting in the `createDefaultJsonMapper` method of `JacksonExchangeStrategyUtil.java`.
* Set the default property inclusion to `NON_NULL` in the `createDefaultJsonMapper` method of `WebClientAutoConfiguration.java`.

**Dependency updates:**

* Added imports for `JsonInclude` where necessary to support the new configuration. [[1]](diffhunk://#diff-7c408670bafb75257abdb6dcb142ef929edd5945eac7ee096bd60f19b2e31a14R3) [[2]](diffhunk://#diff-552b62b2acd40ae72573e469ec1f05c37a40a38ea37a3920774ba157fb13e03cR3) [[3]](diffhunk://#diff-c2ef20daa1e9231ea5267eb93ca79c3957bb947526122a208d704c64e0cb9362R3)