### PR TITLE
Fix: Update label from 'Nav AAP ytelse' to 'AAP-ytelse' across multip…

### DIFF
--- a/apps/dolly-backend/src/main/java/no/nav/dolly/domain/resultset/SystemTyper.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/domain/resultset/SystemTyper.java
@@ -24,7 +24,7 @@ public enum SystemTyper {
     INNTK("Inntektstub (INNTK)"),
     INNTKMELD("Inntektsmelding (ALTINN/JOARK)"),
     INST2("Institusjonsopphold (INST2)"),
-    KELVIN_AAP("Nav AAP ytelse"),
+    KELVIN_AAP("AAP-ytelse"),
     KONTOREGISTER("Bankkontoregister"),
     KRRSTUB("Digital kontaktinformasjon (DKIF)"),
     MEDL("Medlemskap (MEDL)"),

--- a/apps/dolly-frontend/src/main/js/src/components/bestillingsveileder/stegVelger/steg/steg1/paneler/Arena.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/bestillingsveileder/stegVelger/steg/steg1/paneler/Arena.tsx
@@ -145,7 +145,7 @@ ArenaPanel.initialValues = ({ set, opts, setMulti, del, has }) => {
 
 	return {
 		kelvinAap: {
-			label: 'Nav AAP ytelse',
+			label: 'AAP-ytelse',
 			checked: has('kelvinAap'),
 			add() {
 				set('kelvinAap', { ...initialKelvinAap, harMedlemskap: harMedlemskap })

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/kelvin/bestilling/KelvinAap.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/kelvin/bestilling/KelvinAap.tsx
@@ -16,7 +16,7 @@ export const KelvinAap = ({ kelvinAap }: { kelvinAap: KelvinAapTypes }) => {
 	return (
 		<div className="bestilling-visning">
 			<ErrorBoundary>
-				<BestillingTitle>Nav AAP ytelse</BestillingTitle>
+				<BestillingTitle>AAP-ytelse</BestillingTitle>
 				<div className="bestilling-blokk">
 					<h3>Generelt</h3>
 					<BestillingData>

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/kelvin/form/Form.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/kelvin/form/Form.tsx
@@ -44,7 +44,7 @@ export const KelvinAapForm = () => {
 	return (
 		<Vis attributt={kelvinAapPath}>
 			<Panel
-				heading="Nav AAP ytelse"
+				heading="AAP-ytelse"
 				hasErrors={usePanelError(kelvinAapPath)}
 				iconType="arena"
 				startOpen={erForsteEllerTest(formMethods.getValues(), [kelvinAapPath])}

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/kelvin/visning/KelvinAapVisning.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/kelvin/visning/KelvinAapVisning.tsx
@@ -13,7 +13,7 @@ export const KelvinAapVisning = ({
 	harKelvinAapBestilling,
 }: KelvinAapVisningTypes) => {
 	if (loading) {
-		return <Loading label="Laster Nav AAP ytelse ..." />
+		return <Loading label="Laster AAP-ytelse ..." />
 	}
 
 	if (!data && !harKelvinAapBestilling) {
@@ -24,10 +24,10 @@ export const KelvinAapVisning = ({
 
 	return (
 		<div>
-			<SubOverskrift label="Nav AAP ytelse" iconKind="arena" isWarning={manglerFagsystemdata} />
+			<SubOverskrift label="AAP-ytelse" iconKind="arena" isWarning={manglerFagsystemdata} />
 			{manglerFagsystemdata ? (
 				<Alert variant={'warning'} size={'small'} inline style={{ marginBottom: '20px' }}>
-					Fant ikke Nav AAP ytelse på person
+					Fant ikke AAP-ytelse på person
 				</Alert>
 			) : (
 				<ErrorBoundary>

--- a/libs/data-transfer-objects/src/main/java/no/nav/testnav/libs/dto/dollysearchservice/v1/ElasticTyper.java
+++ b/libs/data-transfer-objects/src/main/java/no/nav/testnav/libs/dto/dollysearchservice/v1/ElasticTyper.java
@@ -26,7 +26,7 @@ public enum ElasticTyper {
     INNTK("Inntektskomponenten/stub (INNTK)", false),
     INNTKMELD("Inntektsmelding (ALTINN/JOARK)", true),
     INST("Institusjonsopphold (INST2)", true),
-    KELVIN_AAP("Nav AAP ytelse", false),
+    KELVIN_AAP("AAP-ytelse", false),
     KRRSTUB("Kontakt- og reservasjonsregister-stub", false),
     MEDL("Medlemskap (MEDL)", false),
     NOM("Nav-ansatt (NOM)", false),


### PR DESCRIPTION
This pull request standardizes the naming of "Nav AAP ytelse" to "AAP-ytelse" across both backend and frontend codebases. The changes ensure consistency in how the AAP-ytelse system is referenced in enums, UI labels, headings, and loading messages.

**Backend enum updates:**

* Updated the `KELVIN_AAP` entry in the `SystemTyper` enum to use "AAP-ytelse" instead of "Nav AAP ytelse".
* Updated the `KELVIN_AAP` entry in the `ElasticTyper` enum to use "AAP-ytelse" instead of "Nav AAP ytelse".

**Frontend UI consistency:**

* Changed all UI labels, headings, and loading messages from "Nav AAP ytelse" to "AAP-ytelse" in `Arena.tsx`, `KelvinAap.tsx`, `Form.tsx`, and `KelvinAapVisning.tsx`. [[1]](diffhunk://#diff-6dd77a2ee967c938ab546c89174d389839d65d4ef9386e5f905dd12693f54d8eL148-R148) [[2]](diffhunk://#diff-f107cbaec74341dad2a09980f21c20b01df77764c4be52d324429e6c3d584779L19-R19) [[3]](diffhunk://#diff-d294938494acb945cef8222d823844b839bbf7f1d18c6f5919a12de71bd45231L47-R47) [[4]](diffhunk://#diff-d26d0e4bf1ef5a36d0826b7d353a6deac6e99aa2ebef3ce3d35ea72dc8d28dfbL16-R16) [[5]](diffhunk://#diff-d26d0e4bf1ef5a36d0826b7d353a6deac6e99aa2ebef3ce3d35ea72dc8d28dfbL27-R30)…le components