### PR TITLE
Bugfix/pdl-forvalter problemer

### DIFF
--- a/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/service/ForelderBarnRelasjonService.java
+++ b/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/service/ForelderBarnRelasjonService.java
@@ -149,11 +149,14 @@ public class ForelderBarnRelasjonService implements BiValidation<ForelderBarnRel
                                         .then(Mono.just((person))))
                                 .flatMap(person -> addForelderBarnRelasjon(forelderRelasjon, hovedperson)
                                         .thenReturn(person))
-                                .doOnNext(dbPerson ->
-                                        forelderRelasjon.setId(hovedperson.getForelderBarnRelasjon().stream()
-                                                                       .map(ForelderBarnRelasjonDTO::getId)
-                                                                       .findFirst()
-                                                                       .orElse(0) + 1))
+                                .doOnNext(dbPerson -> {
+                                    forelderRelasjon.setId(hovedperson.getForelderBarnRelasjon().stream()
+                                                                   .map(ForelderBarnRelasjonDTO::getId)
+                                                                   .findFirst()
+                                                                   .orElse(0) + 1);
+                                    forelderRelasjon.setMaster(getMaster(forelderRelasjon, hovedperson));
+                                    forelderRelasjon.setKilde(getKilde(forelderRelasjon));
+                                })
                                 .flatMap(personRepository::save)
                                 .doOnNext(type -> hovedperson.getForelderBarnRelasjon().addFirst(forelderRelasjon))
                                 .thenReturn(forelderRelasjon);
@@ -189,10 +192,12 @@ public class ForelderBarnRelasjonService implements BiValidation<ForelderBarnRel
                     .map(foedselsdato -> getPartnerIdent(partnere, foedselsdato))
                     .flatMap(personRepository::findByIdent)
                     .flatMap(partnerPerson -> addForelderBarnRelasjon(request, partnerPerson.getPerson())
-                            .doOnNext(forelderBarnRelasjon ->
-                                    partnerPerson.getPerson().getForelderBarnRelasjon()
-                                            .addFirst(forelderBarnRelasjon))
-                            .thenReturn(partnerPerson))
+                            .doOnNext(forelderBarnRelasjon -> {
+                                forelderBarnRelasjon.setMaster(getMaster(forelderBarnRelasjon, partnerPerson.getPerson()));
+                                forelderBarnRelasjon.setKilde(getKilde(forelderBarnRelasjon));
+                                partnerPerson.getPerson().getForelderBarnRelasjon()
+                                        .addFirst(forelderBarnRelasjon);
+                            }).thenReturn(partnerPerson))
                     .flatMap(personRepository::save)
                     .then();
         }
@@ -342,6 +347,8 @@ public class ForelderBarnRelasjonService implements BiValidation<ForelderBarnRel
                     val relatertFamilierelasjon = mapperFacade.map(relasjon, ForelderBarnRelasjonDTO.class);
                     relatertFamilierelasjon.setRelatertPerson(hovedperson);
                     swapRoller(relatertFamilierelasjon);
+                    relatertFamilierelasjon.setMaster(getMaster(relatertFamilierelasjon, relatertPerson.getPerson()));
+                    relatertFamilierelasjon.setKilde(getKilde(relatertFamilierelasjon));
                     relatertFamilierelasjon.setId(relatertPerson.getPerson().getForelderBarnRelasjon().stream().findFirst()
                                                           .map(ForelderBarnRelasjonDTO::getId)
                                                           .orElse(0) + 1);

--- a/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/service/OppholdService.java
+++ b/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/service/OppholdService.java
@@ -58,14 +58,21 @@ public class OppholdService implements Validation<OppholdDTO> {
 
         for (var i = 0; i < opphold.size(); i++) {
             if (i + 1 < opphold.size()) {
-                if (isNull(opphold.get(i + 1).getOppholdTil()) &&
-                        !opphold.get(i).getOppholdFra().isAfter(opphold.get(i + 1).getOppholdFra().plusDays(1)) ||
-                        (nonNull(opphold.get(i + 1).getOppholdTil()) &&
-                                !opphold.get(i).getOppholdFra().isAfter(opphold.get(i + 1).getOppholdTil()))) {
+                var current = opphold.get(i);
+                var next = opphold.get(i + 1);
+
+                if (isNull(current.getOppholdFra())) {
+                    continue;
+                }
+
+                if ((isNull(next.getOppholdTil()) && nonNull(next.getOppholdFra()) &&
+                        !current.getOppholdFra().isAfter(next.getOppholdFra().plusDays(1))) ||
+                        (nonNull(next.getOppholdTil()) &&
+                                !current.getOppholdFra().isAfter(next.getOppholdTil()))) {
                     return Mono.error(new InvalidRequestException(VALIDATION_OPPHOLD_OVELAP_ERROR));
                 }
-                if (isNull(opphold.get(i + 1).getOppholdTil())) {
-                    opphold.get(i + 1).setOppholdTil(opphold.get(i).getOppholdFra().minusDays(1));
+                if (isNull(next.getOppholdTil())) {
+                    next.setOppholdTil(current.getOppholdFra().minusDays(1));
                 }
             }
         }

--- a/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/service/SivilstandService.java
+++ b/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/service/SivilstandService.java
@@ -176,6 +176,8 @@ public class SivilstandService implements BiValidation<SivilstandDTO, PersonDTO>
                                                      .max(Comparator.comparing(SivilstandDTO::getId))
                                                      .map(SivilstandDTO::getId)
                                                      .orElse(0) + 1);
+                    relatertSivilstand.setKilde(getKilde(relatertSivilstand));
+                    relatertSivilstand.setMaster(getMaster(relatertSivilstand, relatertPerson.getPerson()));
 
                     relatertPerson.getPerson().getSivilstand().addFirst(relatertSivilstand);
 

--- a/apps/pdl-forvalter/src/test/java/no/nav/pdl/forvalter/service/ForelderBarnRelasjonServiceTest.java
+++ b/apps/pdl-forvalter/src/test/java/no/nav/pdl/forvalter/service/ForelderBarnRelasjonServiceTest.java
@@ -1,5 +1,6 @@
 package no.nav.pdl.forvalter.service;
 
+import no.nav.pdl.forvalter.database.model.DbPerson;
 import no.nav.pdl.forvalter.database.repository.PersonRepository;
 import no.nav.testnav.libs.dto.pdlforvalter.v1.DeltBostedDTO;
 import no.nav.testnav.libs.dto.pdlforvalter.v1.ForelderBarnRelasjonDTO;
@@ -16,22 +17,30 @@ import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 import static no.nav.testnav.libs.dto.pdlforvalter.v1.ForelderBarnRelasjonDTO.Rolle.BARN;
 import static no.nav.testnav.libs.dto.pdlforvalter.v1.ForelderBarnRelasjonDTO.Rolle.FAR;
 import static no.nav.testnav.libs.dto.pdlforvalter.v1.ForelderBarnRelasjonDTO.Rolle.FORELDER;
+import static no.nav.testnav.libs.dto.pdlforvalter.v1.ForelderBarnRelasjonDTO.Rolle.MEDMOR;
 import static no.nav.testnav.libs.dto.pdlforvalter.v1.ForelderBarnRelasjonDTO.Rolle.MOR;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class ForelderBarnRelasjonServiceTest {
 
     private static final String IDENT = "12345678901";
+    private static final String TESTNORGE_IDENT = "12895678901";
+    private static final String RELATERT_IDENT = "02026512345";
 
     @Mock
     private PersonRepository personRepository;
@@ -181,5 +190,228 @@ class ForelderBarnRelasjonServiceTest {
         }
         assertThat(request.getFirst().getId(), is(equalTo(2)));
         assertThat(request.get(1).getId(), is(equalTo(1)));
+    }
+
+    // ---- validate: happy path ----
+
+    @Test
+    void shouldValidateSuccessfullyForMorBarnRelasjon() {
+
+        var request = ForelderBarnRelasjonDTO.builder()
+                .minRolleForPerson(MOR)
+                .relatertPersonsRolle(BARN)
+                .isNew(true)
+                .build();
+
+        StepVerifier.create(forelderBarnRelasjonService.validate(request, PersonDTO.builder()
+                        .ident(IDENT)
+                        .build()))
+                .verifyComplete();
+    }
+
+    @Test
+    void shouldValidateSuccessfullyForBarnFarRelasjon() {
+
+        var request = ForelderBarnRelasjonDTO.builder()
+                .minRolleForPerson(BARN)
+                .relatertPersonsRolle(FAR)
+                .isNew(true)
+                .build();
+
+        StepVerifier.create(forelderBarnRelasjonService.validate(request, PersonDTO.builder()
+                        .ident(IDENT)
+                        .build()))
+                .verifyComplete();
+    }
+
+    @Test
+    void shouldValidateSuccessfullyForForelderBarnRelasjon() {
+
+        var request = ForelderBarnRelasjonDTO.builder()
+                .minRolleForPerson(FORELDER)
+                .relatertPersonsRolle(BARN)
+                .isNew(true)
+                .build();
+
+        StepVerifier.create(forelderBarnRelasjonService.validate(request, PersonDTO.builder()
+                        .ident(IDENT)
+                        .build()))
+                .verifyComplete();
+    }
+
+    @Test
+    void shouldValidateSuccessfullyForBarnMedmorRelasjon() {
+
+        var request = ForelderBarnRelasjonDTO.builder()
+                .minRolleForPerson(BARN)
+                .relatertPersonsRolle(MEDMOR)
+                .isNew(true)
+                .build();
+
+        StepVerifier.create(forelderBarnRelasjonService.validate(request, PersonDTO.builder()
+                        .ident(IDENT)
+                        .build()))
+                .verifyComplete();
+    }
+
+    // ---- validate: existing relatert person passes ----
+
+    @Test
+    void shouldValidateSuccessfullyWhenRelatertPersonExists() {
+
+        var request = ForelderBarnRelasjonDTO.builder()
+                .minRolleForPerson(MOR)
+                .relatertPersonsRolle(BARN)
+                .relatertPerson(RELATERT_IDENT)
+                .isNew(true)
+                .build();
+
+        when(personRepository.existsByIdent(RELATERT_IDENT)).thenReturn(Mono.just(true));
+
+        StepVerifier.create(forelderBarnRelasjonService.validate(request, PersonDTO.builder()
+                        .ident(IDENT)
+                        .build()))
+                .verifyComplete();
+    }
+
+    // ---- validate: testnorge ident skips person check ----
+
+    @Test
+    void shouldSkipPersonCheckForTestnorgeIdent() {
+
+        var request = ForelderBarnRelasjonDTO.builder()
+                .minRolleForPerson(MOR)
+                .relatertPersonsRolle(BARN)
+                .relatertPerson(RELATERT_IDENT)
+                .isNew(true)
+                .build();
+
+        StepVerifier.create(forelderBarnRelasjonService.validate(request, PersonDTO.builder()
+                        .ident(TESTNORGE_IDENT)
+                        .build()))
+                .verifyComplete();
+
+        verify(personRepository, never()).existsByIdent(anyString());
+    }
+
+    // ---- validate: blank relatert skips person check ----
+
+    @Test
+    void shouldSkipPersonCheckWhenRelatertPersonIsBlank() {
+
+        var request = ForelderBarnRelasjonDTO.builder()
+                .minRolleForPerson(FAR)
+                .relatertPersonsRolle(BARN)
+                .isNew(true)
+                .build();
+
+        StepVerifier.create(forelderBarnRelasjonService.validate(request, PersonDTO.builder()
+                        .ident(IDENT)
+                        .build()))
+                .verifyComplete();
+
+        verify(personRepository, never()).existsByIdent(anyString());
+    }
+
+    // ---- validate: delt bosted single adresse passes ----
+
+    @Test
+    void shouldValidateSuccessfullyWithDeltBostedSingleAdresse() {
+
+        var request = ForelderBarnRelasjonDTO.builder()
+                .minRolleForPerson(FORELDER)
+                .relatertPersonsRolle(BARN)
+                .deltBosted(DeltBostedDTO.builder()
+                        .vegadresse(new VegadresseDTO())
+                        .startdatoForKontrakt(LocalDateTime.now())
+                        .isNew(true)
+                        .build())
+                .build();
+
+        StepVerifier.create(forelderBarnRelasjonService.validate(request, PersonDTO.builder()
+                        .ident(IDENT)
+                        .build()))
+                .verifyComplete();
+    }
+
+    // ---- validate: only relatertPersonUtenFolkeregisteridentifikator passes ----
+
+    @Test
+    void shouldValidateSuccessfullyWhenOnlyRelatertPersonUtenIdentifikator() {
+
+        var request = ForelderBarnRelasjonDTO.builder()
+                .minRolleForPerson(FAR)
+                .relatertPersonsRolle(BARN)
+                .relatertPersonUtenFolkeregisteridentifikator(new RelatertBiPersonDTO())
+                .isNew(true)
+                .build();
+
+        StepVerifier.create(forelderBarnRelasjonService.validate(request, PersonDTO.builder()
+                        .ident(IDENT)
+                        .build()))
+                .verifyComplete();
+    }
+
+    // ---- validate: ambiguous FORELDER-FORELDER ----
+
+    @Test
+    void shouldRejectForelderForelderRelasjon() {
+
+        var request = ForelderBarnRelasjonDTO.builder()
+                .minRolleForPerson(FAR)
+                .relatertPersonsRolle(MOR)
+                .isNew(true)
+                .build();
+
+        StepVerifier.create(forelderBarnRelasjonService.validate(request, PersonDTO.builder()
+                        .ident(IDENT)
+                        .build()))
+                .verifyErrorSatisfies(throwable ->
+                        assertThat(throwable.getMessage(), containsString("må være av type barn -- forelder, eller forelder -- barn")));
+    }
+
+    // ---- convert: empty relasjon list ----
+
+    @Test
+    void shouldConvertSuccessfullyWhenRelasjonListIsEmpty() {
+
+        var dbPerson = DbPerson.builder()
+                .person(PersonDTO.builder()
+                        .ident(IDENT)
+                        .forelderBarnRelasjon(new ArrayList<>())
+                        .build())
+                .build();
+
+        StepVerifier.create(forelderBarnRelasjonService.convert(dbPerson))
+                .assertNext(result -> assertThat(result.getPerson().getForelderBarnRelasjon().isEmpty(), is(true)))
+                .verifyComplete();
+    }
+
+    // ---- convert: isNew=false skipped ----
+
+    @Test
+    void shouldSkipItemsNotMarkedAsNew() {
+
+        var dbPerson = DbPerson.builder()
+                .person(PersonDTO.builder()
+                        .ident(IDENT)
+                        .forelderBarnRelasjon(new ArrayList<>(List.of(
+                                ForelderBarnRelasjonDTO.builder()
+                                        .minRolleForPerson(MOR)
+                                        .relatertPersonsRolle(BARN)
+                                        .relatertPerson(RELATERT_IDENT)
+                                        .isNew(false)
+                                        .id(1)
+                                        .build())))
+                        .build())
+                .build();
+
+        StepVerifier.create(forelderBarnRelasjonService.convert(dbPerson))
+                .assertNext(result -> {
+                    var relasjon = result.getPerson().getForelderBarnRelasjon().getFirst();
+                    assertThat(relasjon.getKilde(), is(nullValue()));
+                    assertThat(relasjon.getMaster(), is(nullValue()));
+                })
+                .verifyComplete();
     }
 }

--- a/apps/pdl-forvalter/src/test/java/no/nav/pdl/forvalter/service/OppholdServiceTest.java
+++ b/apps/pdl-forvalter/src/test/java/no/nav/pdl/forvalter/service/OppholdServiceTest.java
@@ -1,6 +1,7 @@
 package no.nav.pdl.forvalter.service;
 
 import no.nav.pdl.forvalter.database.model.DbPerson;
+import no.nav.testnav.libs.dto.pdlforvalter.v1.DbVersjonDTO;
 import no.nav.testnav.libs.dto.pdlforvalter.v1.OppholdDTO;
 import no.nav.testnav.libs.dto.pdlforvalter.v1.PersonDTO;
 import org.junit.jupiter.api.Test;
@@ -18,6 +19,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 
 @ExtendWith(MockitoExtension.class)
 class OppholdServiceTest {
@@ -148,6 +150,159 @@ class OppholdServiceTest {
                     assertThat(target.getPerson().getOpphold().get(1).getOppholdTil(),
                             is(equalTo(LocalDate.of(2020, 2, 3).atStartOfDay())));
                 })
+                .verifyComplete();
+    }
+
+    @Test
+    void shouldValidateSuccessfullyWhenRequestIsValid() {
+
+        var request = OppholdDTO.builder()
+                .oppholdFra(LocalDate.of(2020, 1, 1).atStartOfDay())
+                .oppholdTil(LocalDate.of(2020, 6, 1).atStartOfDay())
+                .type(MIDLERTIDIG)
+                .isNew(true)
+                .build();
+
+        StepVerifier.create(oppholdService.validate(request))
+                .verifyComplete();
+    }
+
+    @Test
+    void shouldThrowWhenOppholdFraEqualsOppholdTil() {
+
+        var request = OppholdDTO.builder()
+                .oppholdFra(LocalDate.of(2020, 1, 1).atStartOfDay())
+                .oppholdTil(LocalDate.of(2020, 1, 1).atStartOfDay())
+                .type(MIDLERTIDIG)
+                .isNew(true)
+                .build();
+
+        StepVerifier.create(oppholdService.validate(request))
+                .verifyErrorSatisfies(throwable ->
+                        assertThat(throwable.getMessage(), containsString("Ugyldig datointervall")));
+    }
+
+    @Test
+    void shouldValidateSuccessfullyWhenOnlyOppholdFraIsProvided() {
+
+        var request = OppholdDTO.builder()
+                .oppholdFra(LocalDate.of(2020, 1, 1).atStartOfDay())
+                .type(MIDLERTIDIG)
+                .isNew(true)
+                .build();
+
+        StepVerifier.create(oppholdService.validate(request))
+                .verifyComplete();
+    }
+
+    @Test
+    void shouldConvertSuccessfullyWhenOppholdListIsEmpty() {
+
+        var request = DbPerson.builder()
+                .person(PersonDTO.builder()
+                        .ident(IDENT)
+                        .opphold(List.of())
+                        .build())
+                .build();
+
+        StepVerifier.create(oppholdService.convert(request))
+                .assertNext(target -> assertThat(target.getPerson().getOpphold().isEmpty(), is(true)))
+                .verifyComplete();
+    }
+
+    @Test
+    void shouldSkipItemsNotMarkedAsNew() {
+
+        var request = DbPerson.builder()
+                .person(PersonDTO.builder()
+                        .ident(IDENT)
+                        .opphold(List.of(OppholdDTO.builder()
+                                .oppholdFra(LocalDate.of(2020, 1, 1).atStartOfDay())
+                                .type(MIDLERTIDIG)
+                                .isNew(false)
+                                .build()))
+                        .build())
+                .build();
+
+        StepVerifier.create(oppholdService.convert(request))
+                .assertNext(target -> {
+                    var opphold = target.getPerson().getOpphold().getFirst();
+                    assertThat(opphold.getKilde(), is(nullValue()));
+                    assertThat(opphold.getMaster(), is(nullValue()));
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void shouldSetKildeAndMasterOnNewItems() {
+
+        var request = DbPerson.builder()
+                .person(PersonDTO.builder()
+                        .ident(IDENT)
+                        .opphold(List.of(OppholdDTO.builder()
+                                .oppholdFra(LocalDate.of(2020, 1, 1).atStartOfDay())
+                                .type(MIDLERTIDIG)
+                                .isNew(true)
+                                .build()))
+                        .build())
+                .build();
+
+        StepVerifier.create(oppholdService.convert(request))
+                .assertNext(target -> {
+                    var opphold = target.getPerson().getOpphold().getFirst();
+                    assertThat(opphold.getKilde(), is(equalTo("Dolly")));
+                    assertThat(opphold.getMaster(), is(equalTo(DbVersjonDTO.Master.PDL)));
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void shouldSkipOverlapCheckWhenCurrentOppholdFraIsNull() {
+
+        var request = DbPerson.builder()
+                .person(PersonDTO.builder()
+                        .ident(IDENT)
+                        .opphold(List.of(
+                                OppholdDTO.builder()
+                                        .type(OPPLYSNING_MANGLER)
+                                        .isNew(true)
+                                        .build(),
+                                OppholdDTO.builder()
+                                        .oppholdFra(LocalDate.of(2020, 1, 1).atStartOfDay())
+                                        .type(MIDLERTIDIG)
+                                        .isNew(true)
+                                        .build()))
+                        .build())
+                .build();
+
+        StepVerifier.create(oppholdService.convert(request))
+                .assertNext(target -> assertThat(target.getPerson().getOpphold().size(), is(equalTo(2))))
+                .verifyComplete();
+    }
+
+    @Test
+    void shouldAcceptNonOverlappingEntries() {
+
+        var request = DbPerson.builder()
+                .person(PersonDTO.builder()
+                        .ident(IDENT)
+                        .opphold(List.of(
+                                OppholdDTO.builder()
+                                        .oppholdFra(LocalDate.of(2021, 1, 1).atStartOfDay())
+                                        .type(OPPLYSNING_MANGLER)
+                                        .isNew(true)
+                                        .build(),
+                                OppholdDTO.builder()
+                                        .oppholdFra(LocalDate.of(2020, 1, 1).atStartOfDay())
+                                        .oppholdTil(LocalDate.of(2020, 6, 1).atStartOfDay())
+                                        .type(MIDLERTIDIG)
+                                        .isNew(true)
+                                        .build()))
+                        .build())
+                .build();
+
+        StepVerifier.create(oppholdService.convert(request))
+                .assertNext(target -> assertThat(target.getPerson().getOpphold().size(), is(equalTo(2))))
                 .verifyComplete();
     }
 }

--- a/apps/pdl-forvalter/src/test/java/no/nav/pdl/forvalter/service/SivilstandServiceTest.java
+++ b/apps/pdl-forvalter/src/test/java/no/nav/pdl/forvalter/service/SivilstandServiceTest.java
@@ -30,6 +30,7 @@ import static no.nav.testnav.libs.dto.pdlforvalter.v1.SivilstandDTO.Sivilstand.G
 import static no.nav.testnav.libs.dto.pdlforvalter.v1.SivilstandDTO.Sivilstand.REGISTRERT_PARTNER;
 import static no.nav.testnav.libs.dto.pdlforvalter.v1.SivilstandDTO.Sivilstand.SAMBOER;
 import static no.nav.testnav.libs.dto.pdlforvalter.v1.SivilstandDTO.Sivilstand.SEPARERT;
+import static no.nav.testnav.libs.dto.pdlforvalter.v1.SivilstandDTO.Sivilstand.SEPARERT_PARTNER;
 import static no.nav.testnav.libs.dto.pdlforvalter.v1.SivilstandDTO.Sivilstand.SKILT;
 import static no.nav.testnav.libs.dto.pdlforvalter.v1.SivilstandDTO.Sivilstand.SKILT_PARTNER;
 import static no.nav.testnav.libs.dto.pdlforvalter.v1.SivilstandDTO.Sivilstand.UGIFT;
@@ -1007,6 +1008,78 @@ class SivilstandServiceTest {
 
         StepVerifier.create(sivilstandService.convert(dbPerson))
                 .assertNext(result -> assertThat(result, is(dbPerson)))
+                .verifyComplete();
+    }
+
+    // ---- validate: SEPARERT_PARTNER with non-existing relatert ----
+
+    @Test
+    void shouldRejectSeparertPartnerWithNonExistingRelatertPerson() {
+
+        var request = SivilstandDTO.builder()
+                .type(SEPARERT_PARTNER)
+                .relatertVedSivilstand(PARTNER_IDENT)
+                .isNew(true)
+                .build();
+
+        when(personRepository.existsByIdent(PARTNER_IDENT)).thenReturn(Mono.just(false));
+
+        StepVerifier.create(sivilstandService.validate(request, PersonDTO.builder().ident(IDENT).build()))
+                .verifyErrorSatisfies(throwable ->
+                        assertThat(throwable.getMessage(), containsString("Relatert person finnes ikke")));
+    }
+
+    // ---- convert: sets kilde and master ----
+
+    @Test
+    void shouldSetKildeAndMasterOnNewSivilstand() {
+
+        var dbPerson = DbPerson.builder()
+                .person(PersonDTO.builder()
+                        .ident(IDENT)
+                        .foedselsdato(new ArrayList<>(List.of(FoedselsdatoDTO.builder()
+                                .foedselsdato(LocalDate.of(1980, 1, 1).atStartOfDay())
+                                .build())))
+                        .sivilstand(new ArrayList<>(List.of(
+                                SivilstandDTO.builder()
+                                        .type(UGIFT)
+                                        .sivilstandsdato(LocalDate.of(1980, 1, 1).atStartOfDay())
+                                        .isNew(true)
+                                        .id(1)
+                                        .build())))
+                        .build())
+                .build();
+
+        when(personRepository.save(any(DbPerson.class))).thenAnswer(inv -> Mono.just(inv.getArgument(0)));
+
+        StepVerifier.create(sivilstandService.convert(dbPerson))
+                .assertNext(result -> {
+                    var sivilstand = result.getPerson().getSivilstand().getFirst();
+                    assertThat(sivilstand.getKilde(), is(equalTo("Dolly")));
+                    assertThat(sivilstand.getMaster(), is(equalTo(no.nav.testnav.libs.dto.pdlforvalter.v1.DbVersjonDTO.Master.PDL)));
+                })
+                .verifyComplete();
+    }
+
+    // ---- convert: empty sivilstand list ----
+
+    @Test
+    void shouldConvertSuccessfullyWhenSivilstandListIsEmpty() {
+
+        var dbPerson = DbPerson.builder()
+                .person(PersonDTO.builder()
+                        .ident(IDENT)
+                        .foedselsdato(new ArrayList<>(List.of(FoedselsdatoDTO.builder()
+                                .foedselsdato(LocalDate.of(1980, 1, 1).atStartOfDay())
+                                .build())))
+                        .sivilstand(new ArrayList<>())
+                        .build())
+                .build();
+
+        when(personRepository.save(any(DbPerson.class))).thenAnswer(inv -> Mono.just(inv.getArgument(0)));
+
+        StepVerifier.create(sivilstandService.convert(dbPerson))
+                .assertNext(result -> assertThat(result.getPerson().getSivilstand().isEmpty(), is(true)))
                 .verifyComplete();
     }
 }


### PR DESCRIPTION
This pull request focuses on improving the consistency and correctness of data enrichment for relationship and residence entities in the service layer. The main changes involve ensuring that the `master` and `kilde` (source) fields are properly set when creating or updating `ForelderBarnRelasjonDTO` (parent-child relationship) and `SivilstandDTO` (marital status) objects, as well as enhancing the integrity checks for residence periods (`OppholdDTO`).

**Relationship Data Enrichment:**

* Ensured that `master` and `kilde` fields are set for new or updated `ForelderBarnRelasjonDTO` objects in the following methods:
  - [`handle`](diffhunk://#diff-a12206706d0b1cf61061e835ac91ed7c2c8c12dc8e17d63a6b524373cddbc4b8L152-R159): Sets `master` and `kilde` after adding the relationship to the main person (`hovedperson`).
  - [`setForelderBarnRelasjon`](diffhunk://#diff-a12206706d0b1cf61061e835ac91ed7c2c8c12dc8e17d63a6b524373cddbc4b8L192-R200): Sets `master` and `kilde` for the relationship when adding it to a partner person.
  - [`createMotsattRelasjon`](diffhunk://#diff-a12206706d0b1cf61061e835ac91ed7c2c8c12dc8e17d63a6b524373cddbc4b8R350-R351): Sets `master` and `kilde` when creating the inverse relationship for the related person.
  - [`createRelatertSivilstand`](diffhunk://#diff-35898d8fe8d73278056eda87993ef25784f50a8ee451ba6538fd2b36b15c74ecR179-R180): Sets `master` and `kilde` when creating a related marital status.

**Residence Period Integrity:**

* Improved validation logic in `OppholdService.enforceIntegrity` to better handle null values and ensure correct overlap checks for residence periods, making the code more robust and readable.