### PR TITLE
Fix: Set default value for journalfoerendeEnhet to MASKINELL_ENHET if…

### DIFF
--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/dokarkiv/mapper/DokarkivMappingStrategy.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/dokarkiv/mapper/DokarkivMappingStrategy.java
@@ -30,6 +30,7 @@ public class DokarkivMappingStrategy implements MappingStrategy {
     private static final String KANAL = "SKAN_IM";
     private static final String PDFA = "PDFA";
     private static final String ARKIV = "ARKIV";
+    private static final String MASKINELL_ENHET = "9999";
 
     @Override
     public void register(MapperFactory factory) {
@@ -43,7 +44,7 @@ public class DokarkivMappingStrategy implements MappingStrategy {
 
                         dokarkivRequest.setEksternReferanseId(UUID.randomUUID().toString());
                         dokarkivRequest.setTittel(rsDokarkiv.getTittel());
-                        dokarkivRequest.setJournalfoerendeEnhet(isBlank(rsDokarkiv.getJournalfoerendeEnhet()) ? null : rsDokarkiv.getJournalfoerendeEnhet());
+                        dokarkivRequest.setJournalfoerendeEnhet(isBlank(rsDokarkiv.getJournalfoerendeEnhet()) ? MASKINELL_ENHET : rsDokarkiv.getJournalfoerendeEnhet());
                         dokarkivRequest.setTema(rsDokarkiv.getTema());
 
                         dokarkivRequest.setKanal(isBlank(rsDokarkiv.getKanal()) ? KANAL : rsDokarkiv.getKanal());


### PR DESCRIPTION
This pull request makes a targeted change to the `DokarkivMappingStrategy` to improve how the `journalfoerendeEnhet` field is handled during mapping. Instead of setting this field to `null` when it is blank, it now defaults to a specific machine unit value.

Key changes:

Field mapping improvements:

* When mapping `journalfoerendeEnhet`, if the source value is blank, it now defaults to `"9999"` (represented by the new constant `MASKINELL_ENHET`) instead of `null`. This ensures a valid value is always set for machine-generated entries.
* Introduced the `MASKINELL_ENHET` constant to hold the default value for machine unit entries.