### PR TITLE
Fix timeout, address missing address issue, and set bestKriterier

### DIFF
--- a/apps/dolly-backend/src/main/java/no/nav/dolly/service/BestillingService.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/service/BestillingService.java
@@ -8,7 +8,6 @@ import no.nav.dolly.domain.jpa.BestillingKontroll;
 import no.nav.dolly.domain.jpa.BestillingProgress;
 import no.nav.dolly.domain.jpa.Dokument;
 import no.nav.dolly.domain.jpa.Dokument.DokumentType;
-import no.nav.dolly.domain.projection.GruppeBestillingIdent;
 import no.nav.dolly.domain.projection.RsBestillingFragment;
 import no.nav.dolly.domain.resultset.BestilteKriterier;
 import no.nav.dolly.domain.resultset.RsDollyBestilling;
@@ -34,9 +33,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import tools.jackson.core.JacksonException;
 import tools.jackson.databind.ObjectMapper;
-import tools.jackson.databind.node.ObjectNode;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
@@ -351,7 +348,7 @@ public class BestillingService {
                             .sistOppdatert(now())
                             .miljoer(filterAvailable(isNotBlank(miljoer) ? miljoer : tuple.getT1().getMiljoer(), tuple.getT3()))
                             .opprettetFraId(bestillingId)
-                            .bestKriterier(tuple.getT1().getBestKriterier())
+                            .bestKriterier("{}")
                             .bruker(tuple.getT2())
                             .brukerId(tuple.getT2().getId())
                             .build());
@@ -373,16 +370,12 @@ public class BestillingService {
                 .flatMap(testident -> Mono.zip(
                         Mono.just(testident),
                         brukerService.fetchOrCreateBruker(),
-                        miljoerConsumer.getMiljoer(),
-                        identRepository.getBestillingerByIdent(ident)
-                                .map(GruppeBestillingIdent::getBestkriterier)
-                                .collectList()
-                                .map(this::mergeBestKriterier)))
+                        miljoerConsumer.getMiljoer()))
                 .map(tuple -> Bestilling.builder()
                         .gruppeId(tuple.getT1().getGruppeId())
                         .ident(ident)
                         .antallIdenter(1)
-                        .bestKriterier(tuple.getT4())
+                        .bestKriterier("{}")
                         .sistOppdatert(now())
                         .miljoer(filterAvailable(miljoer, tuple.getT3()))
                         .gjenopprettetFraIdent(ident)
@@ -407,11 +400,7 @@ public class BestillingService {
                         brukerService.fetchOrCreateBruker(),
                         identRepository.findByGruppeId(gruppeId, Pageable.unpaged())
                                 .collectList(),
-                        miljoerConsumer.getMiljoer(),
-                        identRepository.getBestillingerFromGruppe(gruppeId)
-                                .map(GruppeBestillingIdent::getBestkriterier)
-                                .collectList()
-                                .map(this::mergeBestKriterier)))
+                        miljoerConsumer.getMiljoer()))
                 .flatMap(tuple -> {
                     if (tuple.getT2().isEmpty()) {
                         return Mono.error(new NotFoundException(format("Ingen testpersoner funnet i gruppe: %d", gruppeId)));
@@ -422,7 +411,7 @@ public class BestillingService {
                 .map(tuple -> Bestilling.builder()
                         .gruppeId(gruppeId)
                         .antallIdenter(tuple.getT2().size())
-                        .bestKriterier(tuple.getT4())
+                        .bestKriterier("{}")
                         .sistOppdatert(now())
                         .miljoer(filterAvailable(miljoer, tuple.getT3()))
                         .opprettetFraGruppeId(gruppeId)
@@ -696,26 +685,6 @@ public class BestillingService {
 
         return bestillingProgressRepository.findAllByBestillingId(bestilling.getId())
                 .collectList();
-    }
-
-    private String mergeBestKriterier(List<String> kriterierList) {
-
-        var merged = objectMapper.createObjectNode();
-        for (var kriterier : kriterierList) {
-            try {
-                var node = objectMapper.readTree(kriterier);
-                if (node instanceof ObjectNode objectNode) {
-                    objectNode.properties().forEach(entry -> {
-                        if (!merged.has(entry.getKey())) {
-                            merged.set(entry.getKey(), entry.getValue());
-                        }
-                    });
-                }
-            } catch (JacksonException e) {
-                log.warn("Kunne ikke parse bestKriterier: {}", kriterier, e);
-            }
-        }
-        return merged.isEmpty() ? "{}" : merged.toString();
     }
 
     private static void fixAaregAbstractClassProblem(List<RsAareg> aaregdata) {

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/util/JacksonExchangeStrategyUtil.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/util/JacksonExchangeStrategyUtil.java
@@ -2,7 +2,6 @@ package no.nav.dolly.util;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.experimental.UtilityClass;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.codec.json.JacksonJsonDecoder;
 import org.springframework.http.codec.json.JacksonJsonEncoder;
 import org.springframework.web.reactive.function.client.ExchangeStrategies;
@@ -11,7 +10,8 @@ import tools.jackson.databind.MapperFeature;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.json.JsonMapper;
 
-@Slf4j
+import static java.util.Objects.nonNull;
+
 @UtilityClass
 public final class JacksonExchangeStrategyUtil {
 
@@ -23,9 +23,8 @@ public final class JacksonExchangeStrategyUtil {
     }
 
     public static ExchangeStrategies getJacksonStrategy(JsonMapper jsonMapper) {
-        log.info("JacksonExchangeStrategyUtil: Bruker JsonMapper: {}", 
-                jsonMapper != null ? jsonMapper.getClass().getName() : "null");
-        var mapper = jsonMapper != null ? jsonMapper : createDefaultJsonMapper();
+
+        var mapper = nonNull(jsonMapper) ? jsonMapper : createDefaultJsonMapper();
         return ExchangeStrategies.builder()
                 .codecs(config -> {
                     config.defaultCodecs().maxInMemorySize(32 * 1024 * 1024);
@@ -36,15 +35,8 @@ public final class JacksonExchangeStrategyUtil {
     }
 
     public static ExchangeStrategies getJacksonStrategy(ObjectMapper objectMapper) {
-        JsonMapper jsonMapper;
-        if (objectMapper instanceof JsonMapper jm) {
-            jsonMapper = jm;
-            log.info("JacksonExchangeStrategyUtil: Bruker eksisterende JsonMapper: {}", objectMapper.getClass().getName());
-        } else {
-            jsonMapper = createDefaultJsonMapper();
-            log.info("JacksonExchangeStrategyUtil: ObjectMapper er ikke JsonMapper ({}), oppretter ny JsonMapper med standard konfigurasjon", 
-                    objectMapper != null ? objectMapper.getClass().getName() : "null");
-        }
+
+        var jsonMapper = objectMapper instanceof JsonMapper jm ? jm : createDefaultJsonMapper();
         return ExchangeStrategies.builder()
                 .codecs(config -> {
                     config.defaultCodecs().maxInMemorySize(32 * 1024 * 1024);

--- a/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/service/BostedAdresseService.java
+++ b/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/service/BostedAdresseService.java
@@ -126,9 +126,7 @@ public class BostedAdresseService extends AdresseService<BostedadresseDTO, Perso
                             }
                         }
 
-                    } else if (bostedadresse.countAdresser() == 0 &&
-                               person.getOppholdsadresse().isEmpty() &&
-                               person.getKontaktadresse().isEmpty()) {
+                    } else if (bostedadresse.countAdresser() == 0) {
 
                         bostedadresse.setUtenlandskAdresse(new UtenlandskAdresseDTO());
                     }

--- a/libs/data-transfer-objects/src/main/java/no/nav/testnav/libs/dto/pdlforvalter/v1/PersonDTO.java
+++ b/libs/data-transfer-objects/src/main/java/no/nav/testnav/libs/dto/pdlforvalter/v1/PersonDTO.java
@@ -37,7 +37,7 @@ public class PersonDTO implements Serializable {
 
     private String ident;
     private Identtype identtype;
-    private boolean id2032;
+    private Boolean id2032;
     private Boolean standalone;
 
     @JsonIgnore
@@ -346,8 +346,5 @@ public class PersonDTO implements Serializable {
         final int beregnetRestSifferK1 = (vektetK1 + Character.getNumericValue(ident.charAt(9))) % 11;
 
         return VALIDS.contains(beregnetRestSifferK1);
-    }
-
-    public void getFol() {
     }
 }

--- a/libs/reactive-core/src/main/java/no/nav/testnav/libs/reactivecore/web/WebClientAutoConfiguration.java
+++ b/libs/reactive-core/src/main/java/no/nav/testnav/libs/reactivecore/web/WebClientAutoConfiguration.java
@@ -88,7 +88,7 @@ class WebClientAutoConfiguration {
                                 .option(EpollChannelOption.TCP_KEEPIDLE, 300)
                                 .option(EpollChannelOption.TCP_KEEPINTVL, 60)
                                 .option(EpollChannelOption.TCP_KEEPCNT, 8)
-                                .responseTimeout(Duration.ofSeconds(10))
+                                .responseTimeout(Duration.ofSeconds(15))
                 ))
                 .build();
 


### PR DESCRIPTION
This pull request primarily focuses on simplifying and cleaning up code in the `BestillingService` and related utility classes, as well as making minor adjustments to data transfer objects and configuration. The most significant changes are the removal of merging logic for `bestKriterier` fields in the bestilling creation flows, and various code cleanups to improve maintainability and consistency.

**BestillingService logic simplification:**

* The logic for merging `bestKriterier` from previous bestillinger has been removed from the methods `createBestillingForGjenopprettFraBestilling`, `createBestillingForGjenopprettFraIdent`, and `createBestillingForGjenopprettFraGruppe`. These methods now always set `bestKriterier` to an empty JSON object (`"{}"`), and the `mergeBestKriterier` method and related code have been deleted. [[1]](diffhunk://#diff-b1e9313d3d8c145724abb970751701e666554c5a2a5df4f9210be1b750045c52L354-R351) [[2]](diffhunk://#diff-b1e9313d3d8c145724abb970751701e666554c5a2a5df4f9210be1b750045c52L376-R378) [[3]](diffhunk://#diff-b1e9313d3d8c145724abb970751701e666554c5a2a5df4f9210be1b750045c52L410-R403) [[4]](diffhunk://#diff-b1e9313d3d8c145724abb970751701e666554c5a2a5df4f9210be1b750045c52L425-R414) [[5]](diffhunk://#diff-b1e9313d3d8c145724abb970751701e666554c5a2a5df4f9210be1b750045c52L701-L720)

**Utility and logging cleanups:**

* Unused imports and unnecessary logging have been removed from `JacksonExchangeStrategyUtil`, and the code has been simplified by using `Objects.nonNull` and more concise ternary expressions. [[1]](diffhunk://#diff-552b62b2acd40ae72573e469ec1f05c37a40a38ea37a3920774ba157fb13e03cL5) [[2]](diffhunk://#diff-552b62b2acd40ae72573e469ec1f05c37a40a38ea37a3920774ba157fb13e03cL14-R14) [[3]](diffhunk://#diff-552b62b2acd40ae72573e469ec1f05c37a40a38ea37a3920774ba157fb13e03cL26-R27) [[4]](diffhunk://#diff-552b62b2acd40ae72573e469ec1f05c37a40a38ea37a3920774ba157fb13e03cL39-R39)

**Data transfer object adjustments:**

* In `PersonDTO`, the `id2032` field has been changed from a primitive `boolean` to a boxed `Boolean` for better nullability handling, and an unused method has been removed. [[1]](diffhunk://#diff-fafd3adae30ac97bcdf68c48c765c2532fa08f9b9e100557c00dbbb671efe103L40-R40) [[2]](diffhunk://#diff-fafd3adae30ac97bcdf68c48c765c2532fa08f9b9e100557c00dbbb671efe103L350-L352)

**Business logic adjustment in address service:**

* The condition for setting a default `UtenlandskAdresseDTO` in `BostedAdresseService` has been relaxed: it now only checks if the address count is zero, instead of also checking for empty residence and contact addresses.

**Configuration tweak:**

* The default response timeout for the reactive web client has been increased from 10 seconds to 15 seconds.