### PR TITLE
Bugfix/bestillinger som feiler

### DIFF
--- a/apps/dolly-backend/src/main/java/no/nav/dolly/service/BestillingService.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/service/BestillingService.java
@@ -59,6 +59,7 @@ public class BestillingService {
     private static final String FINNES_IKKE = "Finner ikke gruppe med id %d";
     private static final String SEARCH_STRING = "info:";
     private static final String DEFAULT_VALUE = "";
+    private static final String EMPTY_JSON = "{}";
 
     private final BestillingKontrollRepository bestillingKontrollRepository;
     private final BestillingProgressRepository bestillingProgressRepository;
@@ -348,7 +349,7 @@ public class BestillingService {
                             .sistOppdatert(now())
                             .miljoer(filterAvailable(isNotBlank(miljoer) ? miljoer : tuple.getT1().getMiljoer(), tuple.getT3()))
                             .opprettetFraId(bestillingId)
-                            .bestKriterier("{}")
+                            .bestKriterier(EMPTY_JSON)
                             .bruker(tuple.getT2())
                             .brukerId(tuple.getT2().getId())
                             .build());
@@ -375,7 +376,7 @@ public class BestillingService {
                         .gruppeId(tuple.getT1().getGruppeId())
                         .ident(ident)
                         .antallIdenter(1)
-                        .bestKriterier("{}")
+                        .bestKriterier(EMPTY_JSON)
                         .sistOppdatert(now())
                         .miljoer(filterAvailable(miljoer, tuple.getT3()))
                         .gjenopprettetFraIdent(ident)
@@ -411,7 +412,7 @@ public class BestillingService {
                 .map(tuple -> Bestilling.builder()
                         .gruppeId(gruppeId)
                         .antallIdenter(tuple.getT2().size())
-                        .bestKriterier("{}")
+                        .bestKriterier(EMPTY_JSON)
                         .sistOppdatert(now())
                         .miljoer(filterAvailable(miljoer, tuple.getT3()))
                         .opprettetFraGruppeId(gruppeId)

--- a/apps/dolly-backend/src/test/java/no/nav/dolly/service/BestillingServiceTest.java
+++ b/apps/dolly-backend/src/test/java/no/nav/dolly/service/BestillingServiceTest.java
@@ -6,21 +6,28 @@ import no.nav.dolly.domain.jpa.BestillingKontroll;
 import no.nav.dolly.domain.jpa.BestillingProgress;
 import no.nav.dolly.domain.jpa.Bruker;
 import no.nav.dolly.domain.jpa.Testgruppe;
+import no.nav.dolly.domain.jpa.Testident;
 import no.nav.dolly.domain.resultset.RsDollyBestilling;
 import no.nav.dolly.exceptions.DollyFunctionalException;
 import no.nav.dolly.exceptions.NotFoundException;
+import no.nav.dolly.opensearch.service.OpenSearchService;
 import no.nav.dolly.repository.BestillingKontrollRepository;
 import no.nav.dolly.repository.BestillingProgressRepository;
 import no.nav.dolly.repository.BestillingRepository;
+import no.nav.dolly.repository.DokumentRepository;
+import no.nav.dolly.repository.IdentRepository;
 import no.nav.dolly.repository.TestgruppeRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
+import tools.jackson.databind.ObjectMapper;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -30,6 +37,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -40,22 +48,40 @@ class BestillingServiceTest {
     private static final long BEST_ID = 1L;
 
     @Mock
-    private BestillingRepository bestillingRepository;
-
-    @Mock
     private BestillingKontrollRepository bestillingKontrollRepository;
 
     @Mock
     private BestillingProgressRepository bestillingProgressRepository;
 
     @Mock
-    private TestgruppeRepository testgruppeRepository;
+    private BestillingRepository bestillingRepository;
 
     @Mock
     private BrukerService brukerService;
 
     @Mock
+    private DokumentRepository dokumentRepository;
+
+    @Mock
+    private DokumentService dokumentService;
+
+    @Mock
+    private IdentRepository identRepository;
+
+    @Mock
+    private MalBestillingService malBestillingService;
+
+    @Mock
     private MiljoerConsumer miljoerConsumer;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @Mock
+    private OpenSearchService openSearchService;
+
+    @Mock
+    private TestgruppeRepository testgruppeRepository;
 
     @InjectMocks
     private BestillingService bestillingService;
@@ -227,5 +253,98 @@ class BestillingServiceTest {
         StepVerifier.create(bestillingService.createBestillingForGjenopprettFraBestilling(BEST_ID, miljoe))
                 .expectError(NotFoundException.class)
                 .verify();
+    }
+
+    @Test
+    void shouldSetBestKriterierToEmptyJsonForGjenopprettFraBestilling() {
+
+        var miljoe = "q2";
+        var gruppeId = 1L;
+        var bestilling = Bestilling.builder()
+                .id(BEST_ID)
+                .miljoer(miljoe)
+                .gruppeId(gruppeId)
+                .ferdig(true)
+                .brukerId(27L)
+                .build();
+
+        when(bestillingRepository.findById(BEST_ID)).thenReturn(Mono.just(bestilling));
+        when(bestillingProgressRepository.findAllByBestillingId(any())).thenReturn(Flux.just(BestillingProgress.builder()
+                .ident("12345678901")
+                .build()));
+        when(brukerService.fetchOrCreateBruker()).thenReturn(Mono.just(Bruker.builder().build()));
+        when(miljoerConsumer.getMiljoer()).thenReturn(Mono.just(List.of(miljoe)));
+        when(bestillingRepository.save(any())).thenReturn(Mono.just(bestilling));
+        when(brukerService.findById(any())).thenReturn(Mono.just(Bruker.builder().build()));
+
+        StepVerifier.create(bestillingService.createBestillingForGjenopprettFraBestilling(BEST_ID, miljoe))
+                .expectNextCount(1)
+                .verifyComplete();
+
+        var captor = ArgumentCaptor.forClass(Bestilling.class);
+        verify(bestillingRepository).save(captor.capture());
+        assertThat(captor.getValue().getBestKriterier(), is("{}"));
+    }
+
+    @Test
+    void shouldSetBestKriterierToEmptyJsonForGjenopprettFraIdent() {
+
+        var ident = "12345678901";
+        var gruppeId = 1L;
+        var miljoe = "q2";
+        var testident = Testident.builder()
+                .ident(ident)
+                .gruppeId(gruppeId)
+                .build();
+        var savedBestilling = Bestilling.builder()
+                .id(BEST_ID)
+                .gruppeId(gruppeId)
+                .bestKriterier("{}")
+                .build();
+
+        when(identRepository.findByIdent(ident)).thenReturn(Mono.just(testident));
+        when(brukerService.fetchOrCreateBruker()).thenReturn(Mono.just(Bruker.builder().build()));
+        when(miljoerConsumer.getMiljoer()).thenReturn(Mono.just(List.of(miljoe)));
+        when(bestillingRepository.save(any())).thenReturn(Mono.just(savedBestilling));
+        when(bestillingProgressRepository.findAllByBestillingId(any())).thenReturn(Flux.empty());
+
+        StepVerifier.create(bestillingService.createBestillingForGjenopprettFraIdent(ident, List.of(miljoe)))
+                .expectNextCount(1)
+                .verifyComplete();
+
+        var captor = ArgumentCaptor.forClass(Bestilling.class);
+        verify(bestillingRepository).save(captor.capture());
+        assertThat(captor.getValue().getBestKriterier(), is("{}"));
+    }
+
+    @Test
+    void shouldSetBestKriterierToEmptyJsonForGjenopprettFraGruppe() {
+
+        var gruppeId = 1L;
+        var miljoe = "q2";
+        var testident = Testident.builder()
+                .ident("12345678901")
+                .gruppeId(gruppeId)
+                .build();
+        var savedBestilling = Bestilling.builder()
+                .id(BEST_ID)
+                .gruppeId(gruppeId)
+                .bestKriterier("{}")
+                .build();
+
+        when(testgruppeRepository.findById(gruppeId)).thenReturn(Mono.just(Testgruppe.builder().id(gruppeId).build()));
+        when(brukerService.fetchOrCreateBruker()).thenReturn(Mono.just(Bruker.builder().build()));
+        when(identRepository.findByGruppeId(eq(gruppeId), any(Pageable.class))).thenReturn(Flux.just(testident));
+        when(miljoerConsumer.getMiljoer()).thenReturn(Mono.just(List.of(miljoe)));
+        when(bestillingRepository.save(any())).thenReturn(Mono.just(savedBestilling));
+        when(bestillingProgressRepository.findAllByBestillingId(any())).thenReturn(Flux.empty());
+
+        StepVerifier.create(bestillingService.createBestillingForGjenopprettFraGruppe(gruppeId, miljoe))
+                .expectNextCount(1)
+                .verifyComplete();
+
+        var captor = ArgumentCaptor.forClass(Bestilling.class);
+        verify(bestillingRepository).save(captor.capture());
+        assertThat(captor.getValue().getBestKriterier(), is("{}"));
     }
 }

--- a/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/service/AdresseService.java
+++ b/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/service/AdresseService.java
@@ -118,24 +118,35 @@ public abstract class AdresseService<T extends AdresseDTO, R> implements BiValid
         return Mono.empty();
     }
 
-    protected Mono<String> genererCoNavn(AdresseDTO.CoNavnDTO coNavn) {
+    protected Mono<AdresseDTO> genererCoNavn(AdresseDTO adresse) {
+
+        var coNavn = adresse.getOpprettCoAdresseNavn();
 
         if (nonNull(coNavn)) {
-            if (StringUtils.isBlank(coNavn.getFornavn()) || StringUtils.isBlank(coNavn.getEtternavn()) ||
-                (StringUtils.isBlank(coNavn.getMellomnavn()) && isTrue(coNavn.getHasMellomnavn()))) {
+            return Mono.defer(() -> {
+                        if (StringUtils.isBlank(coNavn.getFornavn()) || StringUtils.isBlank(coNavn.getEtternavn()) ||
+                            (StringUtils.isBlank(coNavn.getMellomnavn()) && isTrue(coNavn.getHasMellomnavn()))) {
 
-                return genererNavnServiceConsumer.getNavn()
-                        .doOnNext(nyttNavn -> {
-                            coNavn.setFornavn(blankCheck(coNavn.getFornavn(), nyttNavn.getAdjektiv()));
-                            coNavn.setEtternavn(blankCheck(coNavn.getEtternavn(), nyttNavn.getSubstantiv()));
-                            coNavn.setMellomnavn(blankCheck(coNavn.getMellomnavn(),
-                                    isTrue(coNavn.getHasMellomnavn()) ? nyttNavn.getAdverb() : null));
-                        })
-                        .map(nyttNavn -> buildNavn(coNavn));
-            }
-            return Mono.just(buildNavn(coNavn));
+                            return genererNavnServiceConsumer.getNavn()
+                                    .map(nyttNavn -> {
+                                        coNavn.setFornavn(blankCheck(coNavn.getFornavn(), nyttNavn.getAdjektiv()));
+                                        coNavn.setEtternavn(blankCheck(coNavn.getEtternavn(), nyttNavn.getSubstantiv()));
+                                        coNavn.setMellomnavn(blankCheck(coNavn.getMellomnavn(),
+                                                isTrue(coNavn.getHasMellomnavn()) ? nyttNavn.getAdverb() : null));
+                                        return coNavn;
+                                    });
+                        } else {
+                            return Mono.just(coNavn);
+                        }
+                    })
+                    .doOnNext(navn -> {
+
+                        adresse.setCoAdressenavn(buildNavn(navn));
+                        adresse.setOpprettCoAdresseNavn(null);
+                    })
+                    .thenReturn(adresse);
         }
-        return Mono.empty();
+        return Mono.just(adresse);
     }
 
     protected void oppdaterAdressedatoer(List<? extends AdresseDTO> adresser, PersonDTO person) {

--- a/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/service/BostedAdresseService.java
+++ b/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/service/BostedAdresseService.java
@@ -133,11 +133,8 @@ public class BostedAdresseService extends AdresseService<BostedadresseDTO, Perso
                     return Mono.just(bostedadresse);
                 })
                 .flatMap(bostedadresse1 -> buildBoadresse(bostedadresse1, person))
-                .flatMap(boadresse -> genererCoNavn(boadresse.getOpprettCoAdresseNavn()))
+                .flatMap(this::genererCoNavn)
                 .doOnNext(adressseNavn -> {
-
-                    bostedadresse.setCoAdressenavn(adressseNavn);
-                    bostedadresse.setOpprettCoAdresseNavn(null);
 
                     if (isNull(bostedadresse.getAngittFlyttedato())) {
                         bostedadresse.setAngittFlyttedato(bostedadresse.getGyldigFraOgMed());

--- a/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/service/KontaktAdresseService.java
+++ b/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/service/KontaktAdresseService.java
@@ -58,7 +58,6 @@ public class KontaktAdresseService extends AdresseService<KontaktadresseDTO, Per
         return Flux.fromIterable(dbPerson.getPerson().getKontaktadresse())
                 .filter(adresse -> isTrue(adresse.getIsNew()) && (isNotTrue(relaxed)))
                 .flatMap(adresse -> handle(adresse, dbPerson.getPerson()))
-                .filter(Objects::nonNull)
                 .doOnNext(adresse -> {
                     adresse.setKilde(getKilde(adresse));
                     adresse.setMaster(getMaster(adresse, dbPerson.getPerson()));
@@ -108,9 +107,7 @@ public class KontaktAdresseService extends AdresseService<KontaktadresseDTO, Per
                         kontaktadresse.setGyldigTilOgMed(nonNull(kontaktadresse.getGyldigTilOgMed()) ? kontaktadresse.getGyldigTilOgMed() :
                                 kontaktadresse.getGyldigFraOgMed().plusYears(1));
                     }
-                    return genererCoNavn(kontaktadresse.getOpprettCoAdresseNavn())
-                            .doOnNext(kontaktadresse::setCoAdressenavn)
-                            .doOnNext(navn -> kontaktadresse.setOpprettCoAdresseNavn(null))
+                    return genererCoNavn(kontaktadresse)
                             .thenReturn(kontaktadresse);
                 });
     }

--- a/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/service/MetadataTidspunkterService.java
+++ b/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/service/MetadataTidspunkterService.java
@@ -137,8 +137,16 @@ public class MetadataTidspunkterService {
 
     private static void fixAddrOpphoert(List<? extends AdresseDTO> adresseopplysning) {
 
-        adresseopplysning.forEach(adresse ->
-                adresse.getFolkeregistermetadata().setOpphoerstidspunkt(adresse.getGyldigTilOgMed()));
+        adresseopplysning.forEach(adresse -> {
+
+            if (nonNull(adresse.getGyldigFraOgMed()) && nonNull(adresse.getGyldigTilOgMed()) &&
+                adresse.getGyldigFraOgMed().isBefore(adresse.getGyldigTilOgMed())) {
+                adresse.getFolkeregistermetadata().setOpphoerstidspunkt(adresse.getGyldigTilOgMed());
+            } else {
+                adresse.setGyldigTilOgMed(null);
+                adresse.getFolkeregistermetadata().setOpphoerstidspunkt(null);
+            }
+        });
     }
 
     private static void fixOpphoert(List<? extends DbVersjonDTO> opplysningstype) {

--- a/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/service/MetadataTidspunkterService.java
+++ b/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/service/MetadataTidspunkterService.java
@@ -157,6 +157,13 @@ public class MetadataTidspunkterService {
                             subtractADay(opplysningstype.get(i - 1).getFolkeregistermetadata().getGyldighetstidspunkt()) :
                             null);
         }
+        opplysningstype.forEach(opplysning -> {
+            if (nonNull(opplysning.getFolkeregistermetadata().getOpphoerstidspunkt()) &&
+                nonNull(opplysning.getFolkeregistermetadata().getGyldighetstidspunkt()) &&
+                opplysning.getFolkeregistermetadata().getOpphoerstidspunkt().isBefore(opplysning.getFolkeregistermetadata().getGyldighetstidspunkt())) {
+                opplysning.getFolkeregistermetadata().setOpphoerstidspunkt(null);
+            }
+        });
     }
 
     private static LocalDateTime subtractADay(LocalDateTime tidspunkt) {

--- a/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/service/OppholdsadresseService.java
+++ b/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/service/OppholdsadresseService.java
@@ -56,7 +56,6 @@ public class OppholdsadresseService extends AdresseService<OppholdsadresseDTO, P
         return Flux.fromIterable(dbPerson.getPerson().getOppholdsadresse())
                 .filter(adresse -> isTrue(adresse.getIsNew()))
                 .flatMap(adresse -> handle(adresse, dbPerson.getPerson()))
-                .filter(Objects::nonNull)
                 .doOnNext(adresse -> {
                     adresse.setKilde(getKilde(adresse));
                     adresse.setMaster(getMaster(adresse, dbPerson.getPerson()));
@@ -101,10 +100,7 @@ public class OppholdsadresseService extends AdresseService<OppholdsadresseDTO, P
 
         return getOppholdsadresse(oppholdsadresse, person)
                 .flatMap(adresse ->
-
-                        genererCoNavn(oppholdsadresse.getOpprettCoAdresseNavn())
-                                .doOnNext(oppholdsadresse::setCoAdressenavn)
-                                .doOnNext(navn -> oppholdsadresse.setOpprettCoAdresseNavn(null))
+                        genererCoNavn(oppholdsadresse)
                                 .thenReturn(oppholdsadresse));
     }
 

--- a/libs/data-transfer-objects/src/main/java/no/nav/testnav/libs/dto/pdlforvalter/v1/PersonDTO.java
+++ b/libs/data-transfer-objects/src/main/java/no/nav/testnav/libs/dto/pdlforvalter/v1/PersonDTO.java
@@ -37,7 +37,7 @@ public class PersonDTO implements Serializable {
 
     private String ident;
     private Identtype identtype;
-    private Boolean id2032;
+    private boolean id2032;
     private Boolean standalone;
 
     @JsonIgnore


### PR DESCRIPTION
This pull request primarily ensures that the `bestKriterier` field is consistently set to an empty JSON object (`{}`) when creating new "gjenopprett" (restore) orders in the `BestillingService`, and adds tests to verify this behavior. It also includes a fix for address metadata handling in another service and a minor type change in a DTO.

**BestillingService improvements:**

- Refactored `BestillingService` to use a constant `EMPTY_JSON` for `bestKriterier` instead of hardcoding `"{}"` in multiple places, improving maintainability and consistency when creating new orders for "gjenopprett" operations. [[1]](diffhunk://#diff-b1e9313d3d8c145724abb970751701e666554c5a2a5df4f9210be1b750045c52R62) [[2]](diffhunk://#diff-b1e9313d3d8c145724abb970751701e666554c5a2a5df4f9210be1b750045c52L351-R352) [[3]](diffhunk://#diff-b1e9313d3d8c145724abb970751701e666554c5a2a5df4f9210be1b750045c52L378-R379) [[4]](diffhunk://#diff-b1e9313d3d8c145724abb970751701e666554c5a2a5df4f9210be1b750045c52L414-R415)
- Added comprehensive unit tests in `BestillingServiceTest` to verify that `bestKriterier` is set to `{}` for all relevant "gjenopprett" methods: from bestilling, ident, and gruppe.
- Updated test setup in `BestillingServiceTest` to include additional required mocks and imports for new and existing dependencies. [[1]](diffhunk://#diff-9b39d0b17b298560e74e9470d77afbef5dc6e9d1fe65fd3c56a7cea3ba4ab722R9-R30) [[2]](diffhunk://#diff-9b39d0b17b298560e74e9470d77afbef5dc6e9d1fe65fd3c56a7cea3ba4ab722R40) [[3]](diffhunk://#diff-9b39d0b17b298560e74e9470d77afbef5dc6e9d1fe65fd3c56a7cea3ba4ab722L42-R85)

**Other fixes:**

- Improved address metadata handling in `MetadataTidspunkterService` by only setting `opphoerstidspunkt` if `gyldigFraOgMed` is before `gyldigTilOgMed`; otherwise, clears these fields to avoid inconsistent state.
- Changed the `id2032` field in `PersonDTO` from `Boolean` to primitive `boolean`, likely to ensure a default value and avoid nulls.