### PR TITLE
bugfix/jsonmapper_modules

### DIFF
--- a/libs/reactive-core/src/main/java/no/nav/testnav/libs/reactivecore/web/WebClientAutoConfiguration.java
+++ b/libs/reactive-core/src/main/java/no/nav/testnav/libs/reactivecore/web/WebClientAutoConfiguration.java
@@ -31,6 +31,7 @@ class WebClientAutoConfiguration {
 
     private static JsonMapper createDefaultJsonMapper() {
         return JsonMapper.builder()
+                .findAndAddModules()
                 .changeDefaultPropertyInclusion(incl -> incl.withValueInclusion(JsonInclude.Include.NON_NULL))
                 .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
                 .configure(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES, false)


### PR DESCRIPTION
tl;dr - fikser problemer som

```
Java 8 date/time type `java.time.LocalDate` not supported by default: add Module "com.fasterxml.jackson.datatype:jackson-datatype-jsr310" to enable handling (or disable `MapperFeature.REQUIRE_HANDLERS_FOR_JAVA8_TIMES`)
```

som eksempelvis skjer når `synt-vedtakshistorikk-service` kaller `dolly-search-service`.

---

This pull request updates the default JSON mapper configuration in `WebClientAutoConfiguration` to improve serialization and deserialization handling. The most important change is the addition of automatic discovery and registration of Jackson modules, which enhances support for various data types (such as Java time types).

**JSON Mapper Improvements:**

* [`libs/reactive-core/src/main/java/no/nav/testnav/libs/reactivecore/web/WebClientAutoConfiguration.java`](diffhunk://#diff-c2ef20daa1e9231ea5267eb93ca79c3957bb947526122a208d704c64e0cb9362R34): Configured the default `JsonMapper` to automatically find and register all available Jackson modules by adding `.findAndAddModules()`. This ensures better compatibility with additional data types and features provided by Jackson extensions.