### PR TITLE
Feature/div kelvin fix

### DIFF
--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/kelvin/bestilling/KelvinAap.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/kelvin/bestilling/KelvinAap.tsx
@@ -27,7 +27,7 @@ export const KelvinAap = ({ kelvinAap }: { kelvinAap: KelvinAapTypes }) => {
 						/>
 						<TitleValue title="Har yrkesskade" value={oversettBoolean(kelvinAap.harYrkesskade)} />
 					</BestillingData>
-					<h3>Andre ytelser/utbetalinger (samordning)</h3>
+					<h3>Andre ytelser/utbetalinger (informasjon fra bruker)</h3>
 					<BestillingData>
 						<TitleValue
 							title="Stønad"

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/kelvin/form/Form.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/kelvin/form/Form.tsx
@@ -64,7 +64,7 @@ export const KelvinAapForm = () => {
 						size="small"
 					/>
 				</CheckboxWrapper>
-				<h3>Andre ytelser/utbetalinger (samordning)</h3>
+				<h3>Andre ytelser/utbetalinger (informasjon fra bruker)</h3>
 				<div className={'flexbox--full-width'}>
 					<FormSelect
 						name={`${andreUtbetalingerPath}.stoenad`}

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/kelvin/initialValues.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/kelvin/initialValues.tsx
@@ -6,7 +6,7 @@ export const initialKelvinAap = {
 			hvemBetaler: '',
 		},
 		loenn: '',
-		stoenad: [],
+		stoenad: ['NEI'],
 	},
 	erStudent: false,
 	harMedlemskap: false,

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/kelvin/visning/KelvinAapVisning.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/kelvin/visning/KelvinAapVisning.tsx
@@ -38,14 +38,14 @@ export const KelvinAapVisning = ({
 					</div>
 					<h4 style={{ width: '100%', marginTop: '0' }}>Generelt</h4>
 					<div className="person-visning_content">
-						<TitleValue title="Er student" value={oversettBoolean(data.soeknad.erStudent)} />
+						<TitleValue title="Er student" value={oversettBoolean(data.soeknad?.erStudent)} />
 						<TitleValue
 							title="Har medlemskap i folketrygden"
-							value={oversettBoolean(data.soeknad.harMedlemskap)}
+							value={oversettBoolean(data.soeknad?.harMedlemskap)}
 						/>
 						<TitleValue
 							title="Har yrkesskade"
-							value={oversettBoolean(data.soeknad.harYrkesskade)}
+							value={oversettBoolean(data.soeknad?.harYrkesskade)}
 						/>
 					</div>
 					<h4 style={{ width: '100%', marginTop: '0' }}>Andre ytelser/utbetalinger (samordning)</h4>
@@ -53,18 +53,18 @@ export const KelvinAapVisning = ({
 						<TitleValue
 							title="Stønad"
 							value={arrayToString(
-								data.soeknad.andreUtbetalinger.stoenad?.map((stoenad) =>
+								data.soeknad?.andreUtbetalinger.stoenad?.map((stoenad) =>
 									showLabel('kelvinAapStoenad', stoenad),
 								),
 							)}
 						/>
 						<TitleValue
 							title="Hvem betaler (AFP)"
-							value={data.soeknad.andreUtbetalinger.afp?.hvemBetaler}
+							value={data.soeknad?.andreUtbetalinger.afp?.hvemBetaler}
 						/>
 						<TitleValue
 							title="Lønn"
-							value={showLabel('jaNei', data.soeknad.andreUtbetalinger.loenn)}
+							value={showLabel('jaNei', data.soeknad?.andreUtbetalinger.loenn)}
 						/>
 					</div>
 				</ErrorBoundary>

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/kelvin/visning/KelvinAapVisning.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/kelvin/visning/KelvinAapVisning.tsx
@@ -48,7 +48,9 @@ export const KelvinAapVisning = ({
 							value={oversettBoolean(data.soeknad?.harYrkesskade)}
 						/>
 					</div>
-					<h4 style={{ width: '100%', marginTop: '0' }}>Andre ytelser/utbetalinger (samordning)</h4>
+					<h4 style={{ width: '100%', marginTop: '0' }}>
+						Andre ytelser/utbetalinger (informasjon fra bruker)
+					</h4>
 					<div className="person-visning_content">
 						<TitleValue
 							title="Stønad"

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/kelvin/visning/KelvinAapVisning.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/kelvin/visning/KelvinAapVisning.tsx
@@ -55,18 +55,18 @@ export const KelvinAapVisning = ({
 						<TitleValue
 							title="Stønad"
 							value={arrayToString(
-								data.soeknad?.andreUtbetalinger.stoenad?.map((stoenad) =>
+								data.soeknad?.andreUtbetalinger?.stoenad?.map((stoenad) =>
 									showLabel('kelvinAapStoenad', stoenad),
 								),
 							)}
 						/>
 						<TitleValue
 							title="Hvem betaler (AFP)"
-							value={data.soeknad?.andreUtbetalinger.afp?.hvemBetaler}
+							value={data.soeknad?.andreUtbetalinger?.afp?.hvemBetaler}
 						/>
 						<TitleValue
 							title="Lønn"
-							value={showLabel('jaNei', data.soeknad?.andreUtbetalinger.loenn)}
+							value={showLabel('jaNei', data.soeknad?.andreUtbetalinger?.loenn)}
 						/>
 					</div>
 				</ErrorBoundary>


### PR DESCRIPTION
This pull request updates the Kelvin AAP (arbeidsavklaringspenger) components to improve clarity in the UI and enhance code robustness. The most notable changes are the rewording of section headings for better user understanding, improved handling of optional data in the visning component, and a change to the default initial value for the "stoenad" field.

**UI Text Improvements:**

* Updated section headings from "Andre ytelser/utbetalinger (samordning)" to "Andre ytelser/utbetalinger (informasjon fra bruker)" in `KelvinAap.tsx`, `Form.tsx`, and `KelvinAapVisning.tsx` to clarify that the information comes from the user and not from coordination with other benefits. [[1]](diffhunk://#diff-f107cbaec74341dad2a09980f21c20b01df77764c4be52d324429e6c3d584779L30-R30) [[2]](diffhunk://#diff-d294938494acb945cef8222d823844b839bbf7f1d18c6f5919a12de71bd45231L67-R67) [[3]](diffhunk://#diff-d26d0e4bf1ef5a36d0826b7d353a6deac6e99aa2ebef3ce3d35ea72dc8d28dfbL41-R69)

**Code Robustness and Defaults:**

* Made all references to `soeknad` and its nested fields optional in `KelvinAapVisning.tsx` to prevent runtime errors when data is missing.
* Changed the initial value of the `stoenad` field in `initialKelvinAap` from an empty array to `['NEI']`, ensuring a default selection is present.