### PR TITLE
Bugfix/kelvin visning manglende data

### DIFF
--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/kelvin/visning/KelvinAapVisning.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/kelvin/visning/KelvinAapVisning.tsx
@@ -22,6 +22,9 @@ export const KelvinAapVisning = ({
 
 	const manglerFagsystemdata = harKelvinAapBestilling && !data
 
+	const soeknad = data?.soeknad
+	const andreUtbetalinger = soeknad?.andreUtbetalinger
+
 	return (
 		<div>
 			<SubOverskrift label="Kelvin AAP-ytelse" iconKind="arena" isWarning={manglerFagsystemdata} />
@@ -36,37 +39,38 @@ export const KelvinAapVisning = ({
 						<TitleValue title="Behandlingsstatus" value={codeToNorskLabel(data.behandlingStatus)} />
 						<TitleValue title="Ferdig" value={oversettBoolean(data.ferdig)} />
 					</div>
-					<h4 style={{ width: '100%', marginTop: '0' }}>Generelt</h4>
-					<div className="person-visning_content">
-						<TitleValue title="Er student" value={oversettBoolean(data.soeknad.erStudent)} />
-						<TitleValue
-							title="Har medlemskap i folketrygden"
-							value={oversettBoolean(data.soeknad.harMedlemskap)}
-						/>
-						<TitleValue
-							title="Har yrkesskade"
-							value={oversettBoolean(data.soeknad.harYrkesskade)}
-						/>
-					</div>
-					<h4 style={{ width: '100%', marginTop: '0' }}>Andre ytelser/utbetalinger (samordning)</h4>
-					<div className="person-visning_content">
-						<TitleValue
-							title="Stønad"
-							value={arrayToString(
-								data.soeknad.andreUtbetalinger.stoenad?.map((stoenad) =>
-									showLabel('kelvinAapStoenad', stoenad),
-								),
-							)}
-						/>
-						<TitleValue
-							title="Hvem betaler (AFP)"
-							value={data.soeknad.andreUtbetalinger.afp?.hvemBetaler}
-						/>
-						<TitleValue
-							title="Lønn"
-							value={showLabel('jaNei', data.soeknad.andreUtbetalinger.loenn)}
-						/>
-					</div>
+					{soeknad && (
+						<>
+							<h4 style={{ width: '100%', marginTop: '0' }}>Generelt</h4>
+							<div className="person-visning_content">
+								<TitleValue title="Er student" value={oversettBoolean(soeknad.erStudent)} />
+								<TitleValue
+									title="Har medlemskap i folketrygden"
+									value={oversettBoolean(soeknad.harMedlemskap)}
+								/>
+								<TitleValue title="Har yrkesskade" value={oversettBoolean(soeknad.harYrkesskade)} />
+							</div>
+						</>
+					)}
+					{andreUtbetalinger && (
+						<>
+							<h4 style={{ width: '100%', marginTop: '0' }}>
+								Andre ytelser/utbetalinger (samordning)
+							</h4>
+							<div className="person-visning_content">
+								<TitleValue
+									title="Stønad"
+									value={arrayToString(
+										andreUtbetalinger.stoenad?.map((stoenad) =>
+											showLabel('kelvinAapStoenad', stoenad),
+										),
+									)}
+								/>
+								<TitleValue title="Hvem betaler (AFP)" value={andreUtbetalinger.afp?.hvemBetaler} />
+								<TitleValue title="Lønn" value={showLabel('jaNei', andreUtbetalinger.loenn)} />
+							</div>
+						</>
+					)}
 				</ErrorBoundary>
 			)}
 		</div>


### PR DESCRIPTION
This pull request improves the structure and readability of the `KelvinAapVisning` component by refactoring how `soeknad` and `andreUtbetalinger` data are accessed and displayed. Conditional rendering is introduced to ensure that sections related to "Generelt" and "Andre ytelser/utbetalinger" are only shown when relevant data is present, reducing unnecessary UI elements and potential errors.

**Refactoring and UI improvements:**

* Introduced local variables `soeknad` and `andreUtbetalinger` for cleaner access to nested data properties.
* Added conditional rendering for the "Generelt" section, displaying it only if `soeknad` exists, and updated field access to use the new variable.
* Added conditional rendering for the "Andre ytelser/utbetalinger (samordning)" section, displaying it only if `andreUtbetalinger` exists, and refactored field access accordingly.
* Updated the section title from "informasjon fra bruker" to "samordning" for clarity.