### PR TITLE
Kelvin AAP nye felter

### DIFF
--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/kelvin/bestilling/KelvinAap.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/kelvin/bestilling/KelvinAap.tsx
@@ -4,7 +4,7 @@ import {
 	BestillingTitle,
 } from '@/components/bestillingsveileder/stegVelger/steg/steg3/Bestillingsvisning'
 import { TitleValue } from '@/components/ui/titleValue/TitleValue'
-import { arrayToString, oversettBoolean, showLabel } from '@/utils/DataFormatter'
+import { arrayToString, formatDate, oversettBoolean, showLabel } from '@/utils/DataFormatter'
 import { isEmpty } from '@/components/fagsystem/pdlf/form/partials/utils'
 import { KelvinAapTypes } from '@/components/fagsystem/kelvin/initialValues'
 
@@ -20,6 +20,11 @@ export const KelvinAap = ({ kelvinAap }: { kelvinAap: KelvinAapTypes }) => {
 				<div className="bestilling-blokk">
 					<h3>Generelt</h3>
 					<BestillingData>
+						<TitleValue title="Søknadsdato" value={formatDate(kelvinAap.soeknadsdato)} />
+						<TitleValue
+							title="Automatisk meldekort"
+							value={oversettBoolean(kelvinAap.automatiskMeldekort)}
+						/>
 						<TitleValue title="Er student" value={oversettBoolean(kelvinAap.erStudent)} />
 						<TitleValue
 							title="Har medlemskap i folketrygden"

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/kelvin/form/Form.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/kelvin/form/Form.tsx
@@ -12,6 +12,7 @@ import * as Yup from 'yup'
 import { ifPresent, requiredBoolean } from '@/utils/YupValidations'
 import styled from 'styled-components'
 import { useEffect } from 'react'
+import { FormDatepicker } from '@/components/ui/form/inputs/datepicker/Datepicker'
 
 const CheckboxWrapper = styled.div`
 	display: flex;
@@ -51,7 +52,13 @@ export const KelvinAapForm = () => {
 				informasjonstekst="Feltene gjelder hva bruker fyller ut i søknaden."
 			>
 				<h3 style={{ marginTop: 0 }}>Generelt</h3>
+				<FormDatepicker name={`${kelvinAapPath}.soeknadsdato`} label="Søknadsdato" />
 				<CheckboxWrapper>
+					<FormCheckbox
+						name={`${kelvinAapPath}.automatiskMeldekort`}
+						label="Automatisk meldekort"
+						size="small"
+					/>
 					<FormCheckbox name={`${kelvinAapPath}.erStudent`} label="Er student" size="small" />
 					<FormCheckbox
 						name={`${kelvinAapPath}.harMedlemskap`}
@@ -104,6 +111,8 @@ KelvinAapForm.validation = {
 				loenn: Yup.string().nullable(),
 				stoenad: Yup.array().of(Yup.string()).min(1, 'Velg minst én stønad'),
 			}),
+			soeknadsdato: Yup.date().nullable(),
+			automatiskMeldekort: requiredBoolean,
 			erStudent: requiredBoolean,
 			harMedlemskap: requiredBoolean,
 			harYrkesskade: requiredBoolean,

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/kelvin/initialValues.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/kelvin/initialValues.tsx
@@ -1,5 +1,3 @@
-import { date } from 'yup'
-
 export const kelvinAapPath = 'kelvinAap'
 
 export const initialKelvinAap = {

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/kelvin/initialValues.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/kelvin/initialValues.tsx
@@ -1,3 +1,5 @@
+import { date } from 'yup'
+
 export const kelvinAapPath = 'kelvinAap'
 
 export const initialKelvinAap = {
@@ -8,6 +10,8 @@ export const initialKelvinAap = {
 		loenn: '',
 		stoenad: ['NEI'],
 	},
+	soeknadsdato: new Date(),
+	automatiskMeldekort: false,
 	erStudent: false,
 	harMedlemskap: false,
 	harYrkesskade: false,
@@ -21,6 +25,8 @@ export type KelvinAapTypes = {
 		loenn?: string
 		stoenad: Array<string>
 	}
+	soeknadsdato: Date
+	automatiskMeldekort: boolean
 	erStudent: boolean
 	harMedlemskap: boolean
 	harYrkesskade: boolean

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/kelvin/visning/KelvinAapVisning.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/kelvin/visning/KelvinAapVisning.tsx
@@ -3,7 +3,13 @@ import SubOverskrift from '@/components/ui/subOverskrift/SubOverskrift'
 import { Alert } from '@navikt/ds-react'
 import { TitleValue } from '@/components/ui/titleValue/TitleValue'
 import { ErrorBoundary } from '@/components/ui/appError/ErrorBoundary'
-import { arrayToString, codeToNorskLabel, oversettBoolean, showLabel } from '@/utils/DataFormatter'
+import {
+	arrayToString,
+	codeToNorskLabel,
+	formatDate,
+	oversettBoolean,
+	showLabel,
+} from '@/utils/DataFormatter'
 import React from 'react'
 import { KelvinAapVisningTypes } from '@/components/fagsystem/kelvin/initialValues'
 
@@ -43,6 +49,11 @@ export const KelvinAapVisning = ({
 						<>
 							<h4 style={{ width: '100%', marginTop: '0' }}>Generelt</h4>
 							<div className="person-visning_content">
+								<TitleValue title="Søknadsdato" value={formatDate(soeknad?.soeknadsdato)} />
+								<TitleValue
+									title="Automatisk meldekort"
+									value={oversettBoolean(soeknad?.automatiskMeldekort)}
+								/>
 								<TitleValue title="Er student" value={oversettBoolean(soeknad?.erStudent)} />
 								<TitleValue
 									title="Har medlemskap i folketrygden"


### PR DESCRIPTION
This pull request adds two new fields, "Søknadsdato" (Application Date) and "Automatisk meldekort" (Automatic Report Card), to the Kelvin AAP form and its related views. These fields are now included in the form, validation schema, initial values, type definitions, and all relevant display components.

**Form and Validation Enhancements:**

- Added `soeknadsdato` (date picker) and `automatiskMeldekort` (checkbox) fields to the Kelvin AAP form UI, including their validation with Yup. [[1]](diffhunk://#diff-d294938494acb945cef8222d823844b839bbf7f1d18c6f5919a12de71bd45231R55-R61) [[2]](diffhunk://#diff-d294938494acb945cef8222d823844b839bbf7f1d18c6f5919a12de71bd45231R114-R115)

**Initial Values and Types:**

- Updated `initialKelvinAap` to include default values for `soeknadsdato` and `automatiskMeldekort`, and extended the `KelvinAapTypes` type accordingly. [[1]](diffhunk://#diff-9cc87886f7be24895540ad3dc88df19160446022914a403bec23b309e5ac6afdR13-R14) [[2]](diffhunk://#diff-9cc87886f7be24895540ad3dc88df19160446022914a403bec23b309e5ac6afdR28-R29)

**Data Display Updates:**

- Updated the bestilling (order) and visning (view) components to display the new fields, using `formatDate` for date formatting and `oversettBoolean` for boolean values. [[1]](diffhunk://#diff-f107cbaec74341dad2a09980f21c20b01df77764c4be52d324429e6c3d584779R23-R27) [[2]](diffhunk://#diff-d26d0e4bf1ef5a36d0826b7d353a6deac6e99aa2ebef3ce3d35ea72dc8d28dfbR52-R56)

**Utility and Import Adjustments:**

- Imported `formatDate` where necessary to support the new date field in display components. [[1]](diffhunk://#diff-f107cbaec74341dad2a09980f21c20b01df77764c4be52d324429e6c3d584779L7-R7) [[2]](diffhunk://#diff-d26d0e4bf1ef5a36d0826b7d353a6deac6e99aa2ebef3ce3d35ea72dc8d28dfbL6-R12)
- Added the `FormDatepicker` import for the new date input in the form.

**Other Minor Changes:**

- Added an unused import of `date` from `yup` (can be removed in a follow-up).