### PR TITLE
Bugfix/inntektstub 500 post

### DIFF
--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/inntektstub/domain/Inntektsinformasjon.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/inntektstub/domain/Inntektsinformasjon.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 import no.nav.testnav.libs.reactivecore.web.WebClientError;
 import reactor.core.publisher.Flux;
 
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -34,7 +34,7 @@ public class Inntektsinformasjon {
     @EqualsAndHashCode.Exclude
     private List<Forskuddstrekk> forskuddstrekksliste;
 
-    private LocalDateTime rapporteringsdato;
+    private OffsetDateTime rapporteringsdato;
 
     private Integer versjon;
 

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/inntektstub/mapper/InntektsinformasjonMappingStrategy.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/inntektstub/mapper/InntektsinformasjonMappingStrategy.java
@@ -13,11 +13,13 @@ import no.nav.dolly.mapper.MappingStrategy;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
 
 @Component
 public class InntektsinformasjonMappingStrategy implements MappingStrategy {
@@ -50,6 +52,10 @@ public class InntektsinformasjonMappingStrategy implements MappingStrategy {
 
                                         inntektsinformasjon1.setAarMaaned(yearMonth.get().format(YEAR_MONTH_FORMAT));
                                         inntektsinformasjon1.setNorskIdent((String) context.getProperty("ident"));
+                                        if (nonNull(inntektsinformasjon.getRapporteringsdato())) {
+                                            inntektsinformasjon1.setRapporteringsdato(
+                                                    inntektsinformasjon.getRapporteringsdato().atOffset(ZoneOffset.UTC));
+                                        }
 
                                         inntektsinformasjonWrapper.getInntektsinformasjon().add(inntektsinformasjon1);
 
@@ -65,7 +71,8 @@ public class InntektsinformasjonMappingStrategy implements MappingStrategy {
                                                         .fradragsliste(mapperFacade.mapAsList(historikk.getFradragsliste(), Fradrag.class))
                                                         .forskuddstrekksliste(mapperFacade.mapAsList(historikk.getForskuddstrekksliste(), Forskuddstrekk.class))
                                                         .versjon(versjon.addAndGet(1))
-                                                        .rapporteringsdato(historikk.getRapporteringsdato())
+                                                        .rapporteringsdato(nonNull(historikk.getRapporteringsdato()) ?
+                                                                historikk.getRapporteringsdato().atOffset(ZoneOffset.UTC) : null)
                                                         .build())
                                         );
 

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/domain/resultset/inntektstub/RsInntektsinformasjon.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/domain/resultset/inntektstub/RsInntektsinformasjon.java
@@ -7,7 +7,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.time.OffsetDateTime;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -47,7 +47,7 @@ public class RsInntektsinformasjon {
 
     private List<Historikk> historikk;
 
-    private OffsetDateTime rapporteringsdato;
+    private LocalDateTime rapporteringsdato;
 
     private Integer versjon;
 
@@ -115,6 +115,6 @@ public class RsInntektsinformasjon {
 
         private List<Forskuddstrekk> forskuddstrekksliste;
 
-        private OffsetDateTime rapporteringsdato;
+        private LocalDateTime rapporteringsdato;
     }
 }

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/domain/resultset/inntektstub/RsInntektsinformasjon.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/domain/resultset/inntektstub/RsInntektsinformasjon.java
@@ -7,7 +7,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -47,7 +47,7 @@ public class RsInntektsinformasjon {
 
     private List<Historikk> historikk;
 
-    private LocalDateTime rapporteringsdato;
+    private OffsetDateTime rapporteringsdato;
 
     private Integer versjon;
 
@@ -115,6 +115,6 @@ public class RsInntektsinformasjon {
 
         private List<Forskuddstrekk> forskuddstrekksliste;
 
-        private LocalDateTime rapporteringsdato;
+        private OffsetDateTime rapporteringsdato;
     }
 }


### PR DESCRIPTION
This pull request updates how reporting dates are handled in the `Inntektsinformasjon` domain and its mapping strategy. The main change is switching from `LocalDateTime` to `OffsetDateTime` for the `rapporteringsdato` field, ensuring all reporting dates are timezone-aware (specifically set to UTC). This improves consistency and clarity when dealing with date and time data across systems.

**Date/time handling improvements:**

* Changed the type of `rapporteringsdato` in `Inntektsinformasjon` from `LocalDateTime` to `OffsetDateTime`, making reporting dates timezone-aware. [[1]](diffhunk://#diff-40d156c64dd56259c35d09f4e7d582adf3c58deb7fead5ad4d237fc11c470650L11-R11) [[2]](diffhunk://#diff-40d156c64dd56259c35d09f4e7d582adf3c58deb7fead5ad4d237fc11c470650L37-R37)
* Updated `InntektsinformasjonMappingStrategy` to convert `LocalDateTime` values to UTC `OffsetDateTime` when mapping, both for the main object and for historical data. [[1]](diffhunk://#diff-74d5182a28871944baf61a6194e16c3f87dc1acfb7c5417ff9c8d2a694d2b093R55-R58) [[2]](diffhunk://#diff-74d5182a28871944baf61a6194e16c3f87dc1acfb7c5417ff9c8d2a694d2b093L68-R75)
* Added imports for `ZoneOffset` and `nonNull` to support the new date conversion logic in the mapping strategy.