### PR TITLE
Legg til harBestilling prop i SigrunstubVisning komponentene for bedre error handling

### DIFF
--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/sigrunstubPensjonsgivende/visning/Visning.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/sigrunstubPensjonsgivende/visning/Visning.tsx
@@ -24,7 +24,7 @@ const InntektVisning = ({ pensjonsgivendeInntekt, id }) => {
 	})
 }
 
-export const SigrunstubPensjonsgivendeVisning = ({ data, loading }) => {
+export const SigrunstubPensjonsgivendeVisning = ({ data, loading, harBestilling = false }) => {
 	if (loading) return <Loading label="Laster sigrunstub-data" />
 	if (!data) {
 		return null
@@ -33,6 +33,9 @@ export const SigrunstubPensjonsgivendeVisning = ({ data, loading }) => {
 		return null
 	}
 	const manglerFagsystemdata = data.length < 1
+	if (manglerFagsystemdata && !harBestilling) {
+		return null
+	}
 
 	return (
 		<>

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/sigrunstubSummertSkattegrunnlag/visning/Visning.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/sigrunstubSummertSkattegrunnlag/visning/Visning.tsx
@@ -93,7 +93,7 @@ const SummertSkattegrunnlagVisning = ({ summertSkattegrunnlag, idx, whiteBackgro
 		})
 }
 
-export const SigrunstubSummertSkattegrunnlagVisning = ({ data, loading }) => {
+export const SigrunstubSummertSkattegrunnlagVisning = ({ data, loading, harBestilling = false }) => {
 	if (loading) {
 		return <Loading label="Laster sigrunstub-data" />
 	}
@@ -104,6 +104,9 @@ export const SigrunstubSummertSkattegrunnlagVisning = ({ data, loading }) => {
 		return null
 	}
 	const manglerFagsystemdata = data.length < 1
+	if (manglerFagsystemdata && !harBestilling) {
+		return null
+	}
 
 	return (
 		<>

--- a/apps/dolly-frontend/src/main/js/src/pages/gruppe/PersonVisning/PersonVisning.tsx
+++ b/apps/dolly-frontend/src/main/js/src/pages/gruppe/PersonVisning/PersonVisning.tsx
@@ -608,10 +608,12 @@ const PersonVisning = (props: PersonVisningProps) => {
 				<SigrunstubPensjonsgivendeVisning
 					data={sigrunstubPensjonsgivendeInntekt}
 					loading={loadingSigrunstubPensjonsgivendeInntekt}
+					harBestilling={harSigrunstubPensjonsgivendeInntekt(bestillingerFagsystemer)}
 				/>
 				<SigrunstubSummertSkattegrunnlagVisning
 					data={sigrunstubSummertSkattegrunnlag}
 					loading={loadingSigrunstubSummertSkattegrunnlag}
+					harBestilling={harSigrunstubSummertSkattegrunnlag(bestillingerFagsystemer)}
 				/>
 				<InntektstubVisning
 					liste={inntektstub}


### PR DESCRIPTION
This pull request improves the conditional rendering logic for Sigrunstub-related components in the frontend. The main goal is to ensure that the views for pensjonsgivende inntekt and summert skattegrunnlag are only displayed when relevant data exists or when a corresponding bestilling (order) is present. This prevents unnecessary rendering of empty components and enhances the user experience.

**Conditional rendering improvements:**

* `SigrunstubPensjonsgivendeVisning` and `SigrunstubSummertSkattegrunnlagVisning` components now accept a new prop, `harBestilling`, which defaults to `false`. This prop is used to determine whether to render the component when there is no data. [[1]](diffhunk://#diff-3c7dfd69c1b6d47f5efa6c42a3cea891e8629df88cc2cad384447e1e731e841eL27-R27) [[2]](diffhunk://#diff-ce7ee3dc464082d186c72dd4dce59bf01b0832981ed36aa565541da8bc671296L96-R96)
* The components return `null` (render nothing) if both the data is missing and there is no bestilling, preventing empty views from being shown. [[1]](diffhunk://#diff-3c7dfd69c1b6d47f5efa6c42a3cea891e8629df88cc2cad384447e1e731e841eR36-R38) [[2]](diffhunk://#diff-ce7ee3dc464082d186c72dd4dce59bf01b0832981ed36aa565541da8bc671296R107-R109)

**Integration in parent component:**

* In `PersonVisning.tsx`, the `harBestilling` prop is now passed to both Sigrunstub components by evaluating whether a bestilling exists using `harSigrunstubPensjonsgivendeInntekt` and `harSigrunstubSummertSkattegrunnlag`.