### PR TITLE
Bugfix/div fix kdi

### DIFF
--- a/apps/dolly-frontend/src/main/js/src/api/index.ts
+++ b/apps/dolly-frontend/src/main/js/src/api/index.ts
@@ -35,9 +35,9 @@ export const multiFetcherInst = (miljoUrlListe, headers = null, path = null) =>
 		),
 	)
 
-export const postFetcher = (url, body) =>
+export const postFetcher = (url, body, headers = { 'Content-Type': 'application/json' }) =>
 	axios
-		.post(url, body, { headers: { 'Content-Type': 'application/json' } })
+		.post(url, body, { headers: headers })
 		.then((res) => {
 			if (res.status === 404) {
 				return null

--- a/apps/dolly-frontend/src/main/js/src/components/fagsystem/kdi/form/Form.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/fagsystem/kdi/form/Form.tsx
@@ -108,12 +108,11 @@ export const KdiForm = () => {
 		() =>
 			meldingstyper
 				.flatMap(({ key, header, Form }) =>
-					fieldArrays[key].fields.map((field: any, idx: number) => ({
+					fieldArrays[key].fields.map((_field: any, idx: number) => ({
 						...formMethods.getValues(`instdataKdi.${key}[${idx}]`),
 						key,
 						header,
 						Form,
-						fieldId: field.id,
 						idx,
 					})),
 				)
@@ -164,7 +163,7 @@ export const KdiForm = () => {
 				<ErrorBoundary>
 					<Kategori title={'KDI-meldinger'}>
 						<DollyFieldArrayWrapper>
-							{meldinger.map(({ key, header, Form, fieldId, idx }, meldingNr) => {
+							{meldinger.map(({ key, header, Form, idx }, meldingNr) => {
 								const hendelse = formMethods.getValues(`instdataKdi.${key}[${idx}]`)
 								const meldingId = formMethods.getValues(`instdataKdi.${key}[${idx}].meldingId`)
 								const hendelseId = formMethods.getValues(`instdataKdi.${key}[${idx}].hendelseId`)
@@ -177,7 +176,7 @@ export const KdiForm = () => {
 
 								return (
 									<DollyFaBlokk
-										key={fieldId}
+										key={`${key}-${idx}`}
 										idx={idx}
 										number={meldingNr + 1}
 										header={header}

--- a/apps/dolly-frontend/src/main/js/src/utils/hooks/useKelvin.tsx
+++ b/apps/dolly-frontend/src/main/js/src/utils/hooks/useKelvin.tsx
@@ -1,5 +1,5 @@
 import useSWR from 'swr'
-import axios from 'axios'
+import { postFetcher } from '@/api'
 
 const kelvinAapBaseUrl = '/testnav-dolly-proxy/kelvin-aap/api/test/'
 
@@ -8,25 +8,7 @@ export const useKelvinAapBehandlingStatus = (ident: string, harKelvinAapBestilli
 
 	const { data, isLoading, error } = useSWR<any, Error>(
 		shouldFetch ? [`${kelvinAapBaseUrl}behandlingStatus`, ident] : null,
-		async ([url, ident]: [string, string]) => {
-			try {
-				const res = await axios.post(
-					url,
-					{ ident },
-					{
-						headers: {
-							'Content-Type': 'application/json',
-						},
-					},
-				)
-				return res.data
-			} catch (e: unknown) {
-				if (axios.isAxiosError(e) && e.response?.status === 404) {
-					return null
-				}
-				throw e
-			}
-		},
+		([url, ident]: [string, string]) => postFetcher(url, { ident }),
 		{ errorRetryCount: 0, revalidateOnFocus: false },
 	)
 

--- a/apps/dolly-frontend/src/main/js/src/utils/hooks/useNom.tsx
+++ b/apps/dolly-frontend/src/main/js/src/utils/hooks/useNom.tsx
@@ -1,26 +1,15 @@
 import useSWR from 'swr'
-import axios from 'axios'
+import { postFetcher } from '@/api'
 
 const baseUrl = '/testnav-nom-proxy'
 
 export const useNomData = (ident: string) => {
 	const { data, isLoading, error } = useSWR<any, Error>(
 		ident ? [`${baseUrl}/api/v1/dolly/hentRessurs`, ident] : null,
-		async ([url, identValue]: [string, string]) => {
-			try {
-				const res = await axios.post(url, identValue, {
-					headers: {
-						'Content-Type': 'text/plain',
-					},
-				})
-				return res.data
-			} catch (e: any) {
-				if (axios.isAxiosError(e) && e.response?.status === 404) {
-					return null
-				}
-				throw e
-			}
-		},
+		([url, identValue]: [string, string]) =>
+			postFetcher(url, identValue, {
+				'Content-Type': 'text/plain',
+			}),
 		{ errorRetryCount: 0, revalidateOnFocus: false },
 	)
 

--- a/apps/dolly-frontend/src/main/js/src/utils/hooks/useSkattekort.tsx
+++ b/apps/dolly-frontend/src/main/js/src/utils/hooks/useSkattekort.tsx
@@ -1,8 +1,7 @@
 import useSWR from 'swr'
-import axios from 'axios'
+import { postFetcher } from '@/api'
 
-const skattekortUrl = (miljoe: string) =>
-	`/testnav-dolly-proxy/skattekort/${miljoe}/api/v1/person`
+const skattekortUrl = (miljoe: string) => `/testnav-dolly-proxy/skattekort/${miljoe}/api/v1/person`
 
 const SKATTEKORT_MILJOER = ['q1', 'q2']
 
@@ -71,25 +70,8 @@ const SKATTEKORT_KODEVERK: Record<string, Record<string, string>> = {
 	},
 }
 
-const fetchSkattekortFromMiljoe = async (miljoe: string, fnr: string) => {
-	try {
-		const res = await axios.post(
-			`${skattekortUrl(miljoe)}/hent-skattekort`,
-			{ fnr },
-			{
-				headers: {
-					'Content-Type': 'application/json',
-				},
-			},
-		)
-		return res.data || []
-	} catch (e: unknown) {
-		if (axios.isAxiosError(e) && e.response?.status === 404) {
-			return []
-		}
-		throw e
-	}
-}
+const fetchSkattekortFromMiljoe = async (miljoe: string, fnr: string) =>
+	postFetcher(`${skattekortUrl(miljoe)}/hent-skattekort`, { fnr })
 
 interface MiljoSkattekortData {
 	miljo: string


### PR DESCRIPTION
This pull request refactors several API hooks and utilities to use a shared `postFetcher` function, improving code consistency and maintainability. Additionally, it makes small improvements to the `KdiForm` component to streamline how field keys are handled.

**API Hook Refactoring:**

* Introduced and standardized usage of a shared `postFetcher` utility for POST requests across multiple hooks, replacing direct `axios` usage and simplifying error handling. (`apps/dolly-frontend/src/main/js/src/utils/hooks/useKelvin.tsx` [[1]](diffhunk://#diff-760beb5dcea0734f95d7f256b6d0e9e38057979993f7ae1525e1ededc60ff172L2-R2) [[2]](diffhunk://#diff-760beb5dcea0734f95d7f256b6d0e9e38057979993f7ae1525e1ededc60ff172L11-R11); `apps/dolly-frontend/src/main/js/src/utils/hooks/useNom.tsx` [[3]](diffhunk://#diff-09aa4b7b500981b412c0d687aa7b56e15e16bf872e19fe58024a9dfd81286968L2-R12); `apps/dolly-frontend/src/main/js/src/utils/hooks/useSkattekort.tsx` [[4]](diffhunk://#diff-26cdf383b4c0d6898245e7084f13029786a23c12b743d4a98db62e3dbd85802dL2-R4) [[5]](diffhunk://#diff-26cdf383b4c0d6898245e7084f13029786a23c12b743d4a98db62e3dbd85802dL74-R74)
* Updated `postFetcher` to accept custom headers, allowing for flexible content types in different API calls. (`apps/dolly-frontend/src/main/js/src/api/index.ts` [apps/dolly-frontend/src/main/js/src/api/index.tsL38-R40](diffhunk://#diff-5646f504929598c66db8abe597b5eb5b67bb1d83e3de6df6de24cfee3e4a3c22L38-R40))

**KDI Form Improvements:**

* Removed the unused `fieldId` property from the `meldinger` mapping and updated the `key` prop for list rendering to use a combination of `key` and `idx` for uniqueness. (`apps/dolly-frontend/src/main/js/src/components/fagsystem/kdi/form/Form.tsx` [[1]](diffhunk://#diff-7b0a3af03b53cf7b191320eefa61537a0970664acef442fb53e988709cd57765L111-L116) [[2]](diffhunk://#diff-7b0a3af03b53cf7b191320eefa61537a0970664acef442fb53e988709cd57765L167-R166) [[3]](diffhunk://#diff-7b0a3af03b53cf7b191320eefa61537a0970664acef442fb53e988709cd57765L180-R179)