### PR TITLE
Refactor AdresseServiceConsumer and VegadresseServiceCommand for impr…

### DIFF
--- a/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/consumer/AdresseServiceConsumer.java
+++ b/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/consumer/AdresseServiceConsumer.java
@@ -18,7 +18,7 @@ import java.util.Map;
 
 import static java.lang.System.currentTimeMillis;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
-import static org.apache.commons.lang3.StringUtils.remove;
+import static org.apache.commons.lang3.Strings.CS;
 
 @Slf4j
 @Service
@@ -67,9 +67,10 @@ public class AdresseServiceConsumer {
                         .flatMap(token ->
                                 new VegadresseServiceCommand(webClient, vegadresseDTO, matrikkelId, token.getTokenValue()).call())
                         .flatMapMany(Flux::fromArray)
+                        .filter(adresse -> isNotBlank(adresse.getAdressenavn()))
                         .next()
                         .switchIfEmpty(Mono.defer(() -> Mono.just(VegadresseServiceCommand.defaultAdresse())))
-                        .doOnNext(adresse -> log.info("Oppslag til adresseservice tok {} ms", currentTimeMillis() - startTime))
+                        .doOnNext(_ -> log.info("Oppslag til adresseservice tok {} ms", currentTimeMillis() - startTime))
                         .map(adresse -> {
                             if (isNotBlank(vegadresseDTO.getKommunenummer()) &&
                                 isNotBlank(vegadresse.getKommunenummer()) &&
@@ -103,7 +104,7 @@ public class AdresseServiceConsumer {
                         .flatMapMany(Flux::fromArray)
                         .next()
                         .switchIfEmpty(Mono.defer(() -> Mono.just(MatrikkeladresseServiceCommand.defaultAdresse())))
-                        .doOnNext(adresseDTO -> log.info("Oppslag til adresseservice tok {} ms", currentTimeMillis() - startTime))
+                        .doOnNext(_ -> log.info("Oppslag til adresseservice tok {} ms", currentTimeMillis() - startTime))
                         .map(adresseDTO -> {
                             if (isNotBlank(matrikkeladresseDTO.getKommunenummer()) &&
                                 isNotBlank(adresse.getKommunenummer()) &&
@@ -121,7 +122,7 @@ public class AdresseServiceConsumer {
             return kodeverkConsumer.getKommunerMedHistoriske()
                     .flatMap(historiske -> Mono.just(historiske.get(kommunenummer))
                             .filter(kommunenavn -> isNotBlank(kommunenavn) && kommunenavn.endsWith(HISTORISK))
-                            .map(kommunenavn -> remove(kommunenavn, HISTORISK).trim())
+                            .map(kommunenavn -> CS.remove(kommunenavn, HISTORISK).trim())
                             .map(this::historiskeKommunerMedNyttNavn)
                             .zipWith(Mono.just(historiske)))
                     .flatMap(tuple -> Mono.just(tuple.getT2())

--- a/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/consumer/command/VegadresseServiceCommand.java
+++ b/apps/pdl-forvalter/src/main/java/no/nav/pdl/forvalter/consumer/command/VegadresseServiceCommand.java
@@ -36,7 +36,7 @@ public class VegadresseServiceCommand implements Callable<Mono<VegadresseDTO[]>>
         return webClient
                 .get()
                 .uri(builder -> builder.path(ADRESSER_VEG_URL).queryParams(getQuery()).build())
-                .header("antall", "1")
+                .header("antall", "5")
                 .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                 .headers(WebClientHeader.bearer(token))
                 .retrieve()
@@ -45,7 +45,7 @@ public class VegadresseServiceCommand implements Callable<Mono<VegadresseDTO[]>>
                 .onErrorResume(throwable -> throwable instanceof WebClientResponseException.NotFound ||
                                 throwable instanceof WebClientResponseException.BadRequest ||
                                 Exceptions.isRetryExhausted(throwable),
-                        throwable -> Mono.just(new VegadresseDTO[]{defaultAdresse()}));
+                        _ -> Mono.just(new VegadresseDTO[]{defaultAdresse()}));
     }
 
     public static VegadresseDTO defaultAdresse() {

--- a/apps/pdl-forvalter/src/test/java/no/nav/pdl/forvalter/consumer/AdresseServiceConsumerTest.java
+++ b/apps/pdl-forvalter/src/test/java/no/nav/pdl/forvalter/consumer/AdresseServiceConsumerTest.java
@@ -424,6 +424,159 @@ class AdresseServiceConsumerTest {
                 .verifyComplete();
     }
 
+    @Test
+    void shouldReturnDefaultVegadresseWhenServiceReturnsResultWithBlankAdressenavn()
+            throws JsonProcessingException {
+
+        var inputVegadresse = VegadresseDTO.builder()
+                .kommunenummer("0301")
+                .build();
+        var mappedVegadresse = VegadresseDTO.builder()
+                .kommunenummer("0301")
+                .build();
+
+        when(mapperFacade.map(inputVegadresse, VegadresseDTO.class)).thenReturn(mappedVegadresse);
+        when(kodeverkConsumer.getKommunerMedHistoriske())
+                .thenReturn(Mono.just(Map.of("0301", "Oslo")));
+
+        var responseAdresse = no.nav.testnav.libs.dto.adresseservice.v1.VegadresseDTO.builder()
+                .matrikkelId("12345")
+                .adressenavn(null)
+                .kommunenummer("0301")
+                .postnummer("0101")
+                .build();
+
+        mockExchangeResponse(new no.nav.testnav.libs.dto.adresseservice.v1.VegadresseDTO[]{responseAdresse});
+
+        StepVerifier.create(adresseServiceConsumer.getVegadresse(inputVegadresse, null))
+                .assertNext(result -> {
+                    assertThat(result.getAdressenavn()).isEqualTo("FYRSTIKKALLÉEN");
+                    assertThat(result.getPostnummer()).isEqualTo("0661");
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void shouldReturnDefaultVegadresseWhenServiceReturns404() {
+
+        var inputVegadresse = VegadresseDTO.builder()
+                .kommunenummer("0301")
+                .build();
+        var mappedVegadresse = VegadresseDTO.builder()
+                .kommunenummer("0301")
+                .build();
+
+        when(mapperFacade.map(inputVegadresse, VegadresseDTO.class)).thenReturn(mappedVegadresse);
+        when(kodeverkConsumer.getKommunerMedHistoriske())
+                .thenReturn(Mono.just(Map.of("0301", "Oslo")));
+        when(exchangeFunction.exchange(any()))
+                .thenReturn(Mono.just(ClientResponse.create(HttpStatus.NOT_FOUND)
+                        .header("Content-Type", "application/json")
+                        .body("")
+                        .build()));
+
+        StepVerifier.create(adresseServiceConsumer.getVegadresse(inputVegadresse, null))
+                .assertNext(result -> {
+                    assertThat(result.getAdressenavn()).isEqualTo("FYRSTIKKALLÉEN");
+                    assertThat(result.getKommunenummer()).isEqualTo("0301");
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void shouldNotOverrideKommunenummerWhenServiceExplicitlyReturnsFyrstikkalleen()
+            throws JsonProcessingException {
+
+        var inputVegadresse = VegadresseDTO.builder()
+                .kommunenummer("4601")
+                .build();
+        var mappedVegadresse = VegadresseDTO.builder()
+                .kommunenummer("4601")
+                .build();
+
+        when(mapperFacade.map(inputVegadresse, VegadresseDTO.class)).thenReturn(mappedVegadresse);
+        when(kodeverkConsumer.getKommunerMedHistoriske())
+                .thenReturn(Mono.just(Map.of("4601", "Bergen")));
+
+        var responseAdresse = no.nav.testnav.libs.dto.adresseservice.v1.VegadresseDTO.builder()
+                .matrikkelId("285693617")
+                .adressenavn("FYRSTIKKALLÉEN")
+                .postnummer("0661")
+                .kommunenummer("0301")
+                .build();
+
+        mockExchangeResponse(new no.nav.testnav.libs.dto.adresseservice.v1.VegadresseDTO[]{responseAdresse});
+
+        StepVerifier.create(adresseServiceConsumer.getVegadresse(inputVegadresse, null))
+                .assertNext(result -> {
+                    assertThat(result.getAdressenavn()).isEqualTo("FYRSTIKKALLÉEN");
+                    assertThat(result.getKommunenummer()).isEqualTo("0301");
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void shouldNotOverrideKommunenummerWhenServiceExplicitlyReturnsValen()
+            throws JsonProcessingException {
+
+        var inputAdresse = MatrikkeladresseDTO.builder()
+                .kommunenummer("4601")
+                .build();
+
+        when(mapperFacade.map(inputAdresse, MatrikkeladresseDTO.class)).thenReturn(inputAdresse);
+        when(kodeverkConsumer.getKommunerMedHistoriske())
+                .thenReturn(Mono.just(Map.of("4601", "Bergen")));
+
+        var responseAdresse = no.nav.testnav.libs.dto.adresseservice.v1.MatrikkeladresseDTO.builder()
+                .matrikkelId("24867173")
+                .tilleggsnavn("VALEN")
+                .kommunenummer("4626")
+                .build();
+
+        mockExchangeResponse(new no.nav.testnav.libs.dto.adresseservice.v1.MatrikkeladresseDTO[]{responseAdresse});
+
+        StepVerifier.create(adresseServiceConsumer.getMatrikkeladresse(inputAdresse, null))
+                .assertNext(result -> {
+                    assertThat(result.getTilleggsnavn()).isEqualTo("VALEN");
+                    assertThat(result.getKommunenummer()).isEqualTo("4626");
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void shouldResolveHistoriskKommuneForMatrikkeladresse() throws JsonProcessingException {
+
+        var inputAdresse = MatrikkeladresseDTO.builder()
+                .kommunenummer("0624")
+                .build();
+        var mappedAdresse = MatrikkeladresseDTO.builder()
+                .kommunenummer("0624")
+                .build();
+
+        when(mapperFacade.map(inputAdresse, MatrikkeladresseDTO.class)).thenReturn(mappedAdresse);
+        when(kodeverkConsumer.getKommunerMedHistoriske())
+                .thenReturn(Mono.just(Map.of(
+                        "0624", "Numedal(historisk)",
+                        "3817", "Numedal"
+                )));
+
+        var responseAdresse = no.nav.testnav.libs.dto.adresseservice.v1.MatrikkeladresseDTO.builder()
+                .matrikkelId("44444")
+                .kommunenummer("3817")
+                .gaardsnummer("12")
+                .bruksnummer("3")
+                .build();
+
+        mockExchangeResponse(new no.nav.testnav.libs.dto.adresseservice.v1.MatrikkeladresseDTO[]{responseAdresse});
+
+        StepVerifier.create(adresseServiceConsumer.getMatrikkeladresse(inputAdresse, null))
+                .assertNext(result -> {
+                    assertThat(result.getMatrikkelId()).isEqualTo("44444");
+                    assertThat(result.getKommunenummer()).isEqualTo("0624");
+                })
+                .verifyComplete();
+    }
+
     private <T> void mockExchangeResponse(T body) throws JsonProcessingException {
 
         var json = OBJECT_MAPPER.writeValueAsString(body);


### PR DESCRIPTION
This pull request introduces several improvements and minor code cleanups to the address service consumer and command classes. The main changes focus on improving filtering logic, increasing the number of address results fetched, and simplifying some code constructs.

**Address Service Logic Improvements:**

* Added a filter to exclude addresses with blank `adressenavn` in `AdresseServiceConsumer#getVegadresse`, ensuring only valid addresses are processed.
* Increased the number of addresses requested from the address service from 1 to 5 in `VegadresseServiceCommand#call`, allowing for broader result sets and better matching.

**Code Simplification and Cleanup:**

* Replaced usage of `StringUtils.remove` with `Strings.CS.remove` in `AdresseServiceConsumer`, standardizing string manipulation methods. [[1]](diffhunk://#diff-839082830a882344557e029fd46a5e8b72e2b3b84aa22b9e13cd8c931e9a52eaL21-R21) [[2]](diffhunk://#diff-839082830a882344557e029fd46a5e8b72e2b3b84aa22b9e13cd8c931e9a52eaL124-R125)
* Updated lambda parameters in logging and error handling to use `_` for unused variables, improving code readability in both `AdresseServiceConsumer` and `VegadresseServiceCommand`. [[1]](diffhunk://#diff-839082830a882344557e029fd46a5e8b72e2b3b84aa22b9e13cd8c931e9a52eaR70-R73) [[2]](diffhunk://#diff-839082830a882344557e029fd46a5e8b72e2b3b84aa22b9e13cd8c931e9a52eaL106-R107) [[3]](diffhunk://#diff-d534d78d474341097727e9a14f00bbac294dd801dd191e37f0cadcdc18a2920aL48-R48)