### PR TITLE
Add access policy for inbound rules in dolly-auth-local config

### DIFF
--- a/.nais/dolly-auth-local.yml
+++ b/.nais/dolly-auth-local.yml
@@ -13,6 +13,10 @@ spec:
     path: "/internal/healthz"
   readiness:
     path: "/internal/healthz"
+  accessPolicy:
+    inbound:
+      rules:
+        - application: testnav-oversikt-frontend
   resources:
     limits:
       memory: "256Mi"

--- a/libs/testing/src/main/java/no/nav/dolly/libs/nais/NaisEnvironmentApplicationContextInitializer.java
+++ b/libs/testing/src/main/java/no/nav/dolly/libs/nais/NaisEnvironmentApplicationContextInitializer.java
@@ -14,7 +14,6 @@ public class NaisEnvironmentApplicationContextInitializer implements Application
     // Konfigurasjon for lokal kjøring er hentet herfra: https://github.com/navikt/localauth
 
     private static final String APP_CLIENT_ID = "3a974fc8-2295-4a7c-ba67-5b2603d07419";
-    private static final String AUDIENCE = "3cbdd4cb-d048-420f-889e-2b32b7add652";
     private static final String DOLLY_AUTH_LOCAL = "https://dolly-auth-local.intern.dev.nav.no";
     private static final String DUMMY = "dummy";
     private static final String FALSE = "false";
@@ -46,10 +45,6 @@ public class NaisEnvironmentApplicationContextInitializer implements Application
         properties.putIfAbsent("dolly.texas.url.token", "https://dolly-texas-proxy.intern.dev.nav.no/api/v1/token");
         properties.putIfAbsent("dolly.texas.url.exchange", "https://dolly-texas-proxy.intern.dev.nav.no/api/v1/token/exchange");
         properties.putIfAbsent("dolly.texas.url.introspect", "https://dolly-texas-proxy.intern.dev.nav.no/api/v1/introspect");
-
-        // backend
-        properties.putIfAbsent("spring.security.oauth2.resourceserver.aad.accepted-audience",
-                "%s, api://%s".formatted(AUDIENCE, AUDIENCE));
 
         // Emulating NAIS provided environment variables.
         properties.putIfAbsent("AZURE_APP_CLIENT_ID", APP_CLIENT_ID);


### PR DESCRIPTION
This pull request makes adjustments to both the local NAIS configuration and the local application context initializer. The main changes involve updating access policies for local authorization and removing an unused audience variable and related configuration for OAuth2 resource server audiences.

Configuration and Access Policy Updates:

* [`.nais/dolly-auth-local.yml`](diffhunk://#diff-3fe714b90b002f92617ca1be595bd3ab047a873477588989d94514cbd841256dR16-R19): Added an `accessPolicy` section to allow inbound requests from the `testnav-oversikt-frontend` application.

Code Cleanup and OAuth2 Audience Configuration:

* [`NaisEnvironmentApplicationContextInitializer.java`](diffhunk://#diff-1fa22ac727fb8c1e3442737b7f95c0ee9d93c8f09ea7f89b20fe42c01bb7a877L17): Removed the unused `AUDIENCE` constant, which was previously used for OAuth2 audience configuration.
* [`NaisEnvironmentApplicationContextInitializer.java`](diffhunk://#diff-1fa22ac727fb8c1e3442737b7f95c0ee9d93c8f09ea7f89b20fe42c01bb7a877L50-L53): Removed the code setting the `spring.security.oauth2.resourceserver.aad.accepted-audience` property, as it is no longer needed.