### PR TITLE
Update Admin group ID for frontend and backend configurations

### DIFF
--- a/apps/dolly-backend/config.test.yml
+++ b/apps/dolly-backend/config.test.yml
@@ -67,7 +67,7 @@ spec:
       claims:
         groups:
           - id: '2d7f1c0d-5784-4f81-8bb2-8f3a79f8f949' #everyone else
-          - id: '9c7efec1-1599-4216-a67e-6fd53a6a951c' #admins
+          - id: '728ae02e-04e8-48b9-ab65-ee6233b5003f' #admins
   image: "{{image}}"
   openSearch:
     instance: bestillinger

--- a/apps/dolly-backend/config.yml
+++ b/apps/dolly-backend/config.yml
@@ -73,7 +73,7 @@ spec:
       claims:
         groups:
           - id: '2d7f1c0d-5784-4f81-8bb2-8f3a79f8f949' #everyone else
-          - id: '9c7efec1-1599-4216-a67e-6fd53a6a951c' #admins
+          - id: '728ae02e-04e8-48b9-ab65-ee6233b5003f' #admins
   image: "{{image}}"
   openSearch:
     instance: bestillinger

--- a/apps/dolly-frontend/src/main/js/src/utils/DollyAdmin.tsx
+++ b/apps/dolly-frontend/src/main/js/src/utils/DollyAdmin.tsx
@@ -9,6 +9,6 @@ type CurrentBrukerType = {
 export const useErDollyAdmin = () => {
 	const { currentBruker }: CurrentBrukerType = useCurrentBruker()
 	const grupper = currentBruker?.grupper
-	const teamDollyGruppe = '728ae02e-04e8-48b9-ab65-ee6233b5003f'
-	return grupper?.includes(teamDollyGruppe)
+	const adminGruppe = '728ae02e-04e8-48b9-ab65-ee6233b5003f'
+	return grupper?.includes(adminGruppe)
 }

--- a/apps/dolly-frontend/src/main/js/src/utils/DollyAdmin.tsx
+++ b/apps/dolly-frontend/src/main/js/src/utils/DollyAdmin.tsx
@@ -9,6 +9,6 @@ type CurrentBrukerType = {
 export const useErDollyAdmin = () => {
 	const { currentBruker }: CurrentBrukerType = useCurrentBruker()
 	const grupper = currentBruker?.grupper
-	const teamDollyGruppe = '9c7efec1-1599-4216-a67e-6fd53a6a951c'
+	const teamDollyGruppe = '728ae02e-04e8-48b9-ab65-ee6233b5003f'
 	return grupper?.includes(teamDollyGruppe)
 }


### PR DESCRIPTION
This pull request updates the admin group ID across both backend configuration files and frontend logic to ensure consistency and proper access control. The main change is replacing the old admin group ID with a new one in all relevant places.

**Admin group ID update:**

* Updated the admin group ID from `'9c7efec1-1599-4216-a67e-6fd53a6a951c'` to `'728ae02e-04e8-48b9-ab65-ee6233b5003f'` in `apps/dolly-backend/config.yml` and `apps/dolly-backend/config.test.yml` to reflect the new group for admin access. [[1]](diffhunk://#diff-2776b9d92a2eaf7c5bb0b8ab9af4e45bf72d644206fc2b4a6e2e7d4bce2f9769L76-R76) [[2]](diffhunk://#diff-4233b6c2c5f8abba10ddad695af9db496675d6424dc12ac23484a452a3bc8bfdL70-R70)
* Updated the `teamDollyGruppe` identifier in the `useErDollyAdmin` hook in `apps/dolly-frontend/src/main/js/src/utils/DollyAdmin.tsx` to use the new admin group ID, ensuring frontend logic matches backend configuration.