### PR TITLE
Update URL for Samboerregisteret

### DIFF
--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/pensjonforvalter/command/HentSamboerCommand.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/pensjonforvalter/command/HentSamboerCommand.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import no.nav.dolly.bestilling.pensjonforvalter.domain.PensjonSamboerResponse;
 import no.nav.dolly.bestilling.pensjonforvalter.domain.PensjonforvalterResponse;
+import no.nav.dolly.bestilling.pensjonforvalter.domain.SamboerRequest;
 import no.nav.testnav.libs.reactivecore.web.WebClientError;
 import no.nav.testnav.libs.reactivecore.web.WebClientHeader;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -19,7 +20,7 @@ import static no.nav.dolly.util.CallIdUtil.generateCallId;
 @Slf4j
 @RequiredArgsConstructor
 public class HentSamboerCommand implements Callable<Mono<PensjonSamboerResponse>> {
-    private static final String PEN_SAMBOER_URL = "/pensjon/{miljoe}/api/samboer/{ident}";
+    private static final String PEN_SAMBOER_URL = "/pensjon/{miljoe}/api/samboer/hentSamboerforhold";
 
     private final WebClient webClient;
     private final String ident;
@@ -28,14 +29,14 @@ public class HentSamboerCommand implements Callable<Mono<PensjonSamboerResponse>
 
     public Mono<PensjonSamboerResponse> call() {
         return webClient
-                .get()
+                .post()
                 .uri(uriBuilder -> uriBuilder
                         .path(PEN_SAMBOER_URL)
-                        .queryParam("historikk", true)
-                        .build(miljoe, ident))
+                        .build(miljoe))
                 .headers(WebClientHeader.bearer(token))
                 .header(HEADER_NAV_CALL_ID, generateCallId())
                 .header(HEADER_NAV_CONSUMER_ID, CONSUMER)
+                .bodyValue(new SamboerRequest(ident))
                 .retrieve()
                 .bodyToMono(PensjonSamboerResponse.class)
                 .doOnError(error -> !(error instanceof WebClientResponseException.NotFound), WebClientError.logTo(log))

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/pensjonforvalter/domain/SamboerRequest.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/pensjonforvalter/domain/SamboerRequest.java
@@ -1,0 +1,15 @@
+package no.nav.dolly.bestilling.pensjonforvalter.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SamboerRequest {
+
+    private String pid;
+}


### PR DESCRIPTION
This pull request updates how the `HentSamboerCommand` fetches "samboer" (cohabitant) information from the pension system, switching from a GET to a POST request and introducing a new request payload. It also adds a new `SamboerRequest` class to encapsulate the request data.

**API request changes:**

* Changed the endpoint in `HentSamboerCommand` from `/pensjon/{miljoe}/api/samboer/{ident}` (GET) to `/pensjon/{miljoe}/api/samboer/hentSamboerforhold` (POST), and moved the identifier (`ident`) from a URL parameter to the request body. The request now uses a `SamboerRequest` object containing the `pid`. (`[[1]](diffhunk://#diff-3141156c4e5ccea41fc62ae457cb8573888e232f4cb2ded289e00b1488a2178cL22-R23)`, `[[2]](diffhunk://#diff-3141156c4e5ccea41fc62ae457cb8573888e232f4cb2ded289e00b1488a2178cL31-R39)`)
* Removed the `historikk` query parameter from the request. (`[apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/pensjonforvalter/command/HentSamboerCommand.javaL31-R39](diffhunk://#diff-3141156c4e5ccea41fc62ae457cb8573888e232f4cb2ded289e00b1488a2178cL31-R39)`)

**Codebase additions:**

* Added a new `SamboerRequest` class with Lombok annotations to encapsulate the `pid` sent in the POST request body. (`[apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/pensjonforvalter/domain/SamboerRequest.javaR1-R15](diffhunk://#diff-aa625bcdf29f36bb98649c363fb4fac9bcd7285ce7fa419e01182acf0353d495R1-R15)`)
* Updated imports in `HentSamboerCommand` to include the new `SamboerRequest` class. (`[apps/dolly-backend/src/main/java/no/nav/dolly/bestilling/pensjonforvalter/command/HentSamboerCommand.javaR7](diffhunk://#diff-3141156c4e5ccea41fc62ae457cb8573888e232f4cb2ded289e00b1488a2178cR7)`)