### PR TITLE
bugfix/datepicker_format

### DIFF
--- a/apps/dolly-frontend/src/main/js/src/__tests__/components/ui/form/inputs/datepicker/Datepicker.test.tsx
+++ b/apps/dolly-frontend/src/main/js/src/__tests__/components/ui/form/inputs/datepicker/Datepicker.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { FormProvider, useForm, useWatch } from 'react-hook-form'
+import { vi } from 'vitest'
+import type { ReactNode } from 'react'
+import { DollyDatepicker } from '@/components/ui/form/inputs/datepicker/Datepicker'
+
+vi.mock('@navikt/ds-react', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('@navikt/ds-react')>()
+
+	return {
+		...actual,
+		Button: ({ children, ...props }: { children: ReactNode }) => <button {...props}>{children}</button>,
+		DatePicker: ({ children }: { children: ReactNode }) => <>{children}</>,
+		Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+		useDatepicker: () => ({
+			datepickerProps: {},
+			setSelected: vi.fn(),
+		}),
+	}
+})
+
+const TestHarness = () => {
+	const formMethods = useForm({
+		defaultValues: {
+			date: '',
+		},
+	})
+	const value = useWatch({
+		control: formMethods.control,
+		name: 'date',
+	})
+
+	return (
+		<FormProvider {...formMethods}>
+			<form>
+				<DollyDatepicker name="date" label="Rapporteringstidspunkt" format="DD.MM.YYYY HH:mm" />
+				<div data-testid="stored-value">{value ?? ''}</div>
+			</form>
+		</FormProvider>
+	)
+}
+
+describe('DollyDatepicker', () => {
+	it('should not store localized date text in form state', async () => {
+		const user = userEvent.setup()
+
+		render(<TestHarness />)
+
+		await user.type(screen.getByRole('textbox', { name: 'Rapporteringstidspunkt' }), '05.06.2025')
+
+		expect(
+			(screen.getByRole('textbox', { name: 'Rapporteringstidspunkt' }) as HTMLInputElement).value,
+		).toBe('05.06.2025')
+		expect(screen.getByTestId('stored-value').textContent).toBe('')
+	})
+})

--- a/apps/dolly-frontend/src/main/js/src/components/ui/form/inputs/datepicker/DateInput.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/ui/form/inputs/datepicker/DateInput.tsx
@@ -63,7 +63,7 @@ export const DateInput = ({
 	...props
 }: DateInputProps) => {
 	'use no memo'
-	const { register, formState, watch, setValue } = useFormContext() || {}
+	const { register, formState, watch } = useFormContext() || {}
 	const { showError } = React.useContext(ShowErrorContext) || {}
 
 	const fieldValue = name ? watch(name) : ''
@@ -100,7 +100,6 @@ export const DateInput = ({
 	const shouldShowError = (error && (showError || isTouched)) || !!props.manualError
 
 	const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-		setValue(name, e.target.value, { shouldTouch: true })
 		props.onChange?.(e)
 		setFormattedValue(e.target.value)
 	}

--- a/apps/dolly-frontend/src/main/js/src/components/ui/form/inputs/datepicker/Datepicker.tsx
+++ b/apps/dolly-frontend/src/main/js/src/components/ui/form/inputs/datepicker/Datepicker.tsx
@@ -99,7 +99,12 @@ export const DollyDatepicker = ({
 		const value = e.target.value
 		setInput(value)
 
-		if (value && value.length >= 10) {
+		if (!value) {
+			setFormDate(null)
+			return
+		}
+
+		if (value.length >= 10) {
 			try {
 				const date = convertInputToDate(value, false, dateFormat)
 				if (date?.isValid?.()) {


### PR DESCRIPTION
This pull request improves the handling of date input in the `DollyDatepicker` component to ensure that only valid, non-localized date values are stored in form state. It also adds a new test to verify this behavior and removes unnecessary code from the date input logic.

**Testing improvements:**

* Added a test (`Datepicker.test.tsx`) to confirm that the `DollyDatepicker` does not store localized date text in the form state when a user types a date, ensuring only valid dates are saved.

**Form input handling changes:**

* Updated the `DollyDatepicker` component to clear the form state when the input is empty, preventing invalid or partial dates from being stored.
* Removed the unused `setValue` import and its usage from `DateInput.tsx`, simplifying the input change handler and preventing unnecessary form state updates on every keystroke. [[1]](diffhunk://#diff-7d5d3a9df8527dea1a788217e2fef41f8930141a9a31665cec5dacc6b5c40029L66-R66) [[2]](diffhunk://#diff-7d5d3a9df8527dea1a788217e2fef41f8930141a9a31665cec5dacc6b5c40029L103)