### PR TITLE
Fix: 500 on personer-soek ved feil i bestilling-indeks-soek

### DIFF
--- a/apps/dolly-search-service/src/main/java/no/nav/testnav/dollysearchservice/service/BestillingQueryService.java
+++ b/apps/dolly-search-service/src/main/java/no/nav/testnav/dollysearchservice/service/BestillingQueryService.java
@@ -109,7 +109,7 @@ public class BestillingQueryService {
 
         } catch (IOException | OpenSearchException e) {
             log.error("Feil ved henting av identer", e);
-            identer = Set.of("99999999999");
+            identer = Set.of();
         }
 
         log.info("Uthenting av {} identer tok {} ms", identer.size(), System.currentTimeMillis() - now);

--- a/apps/dolly-search-service/src/main/java/no/nav/testnav/dollysearchservice/service/BestillingQueryService.java
+++ b/apps/dolly-search-service/src/main/java/no/nav/testnav/dollysearchservice/service/BestillingQueryService.java
@@ -8,7 +8,9 @@ import no.nav.testnav.dollysearchservice.dto.SearchRequest;
 import no.nav.testnav.dollysearchservice.utils.FagsystemQueryUtils;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch._types.FieldSort;
+import org.opensearch.client.opensearch._types.OpenSearchException;
 import org.opensearch.client.opensearch._types.SortOptions;
+import org.opensearch.client.opensearch._types.mapping.FieldType;
 import org.opensearch.client.opensearch._types.query_dsl.BoolQuery;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
 import org.opensearch.client.opensearch._types.query_dsl.QueryBuilders;
@@ -81,7 +83,7 @@ public class BestillingQueryService {
             var searchResponse = opensearchClient.search(new org.opensearch.client.opensearch.core.SearchRequest.Builder()
                     .index(bestillingIndex)
                     .query(query)
-                    .sort(SortOptions.of(s -> s.field(FieldSort.of(fs -> fs.field("id")))))
+                    .sort(SortOptions.of(s -> s.field(FieldSort.of(fs -> fs.field("id").unmappedType(FieldType.Long)))))
                     .size(QUERY_SIZE)
                     .timeout("3s")
                     .build(), BestillingIdenter.class);
@@ -98,14 +100,14 @@ public class BestillingQueryService {
                 searchResponse = opensearchClient.search(new org.opensearch.client.opensearch.core.SearchRequest.Builder()
                         .index(bestillingIndex)
                         .query(query)
-                        .sort(SortOptions.of(s -> s.field(FieldSort.of(fs -> fs.field("id")))))
+                        .sort(SortOptions.of(s -> s.field(FieldSort.of(fs -> fs.field("id").unmappedType(FieldType.Long)))))
                         .size(QUERY_SIZE)
                         .searchAfter(lastHit.sort())
                         .timeout("3s")
                         .build(), BestillingIdenter.class);
             }
 
-        } catch (IOException e) {
+        } catch (IOException | OpenSearchException e) {
             log.error("Feil ved henting av identer", e);
             identer = Set.of("99999999999");
         }


### PR DESCRIPTION
Produksjonssøk mot /api/v1/personer feilet med 500 fordi BestillingQueryService.execQuery kun fanget IOException, mens den faktiske feilen var en OpenSearchException ("all shards failed") fra sortering på "id"-feltet i bestilling-indeksen. Dette tyder på at "id"-feltet mangler/er feil mappet på enkelte shards i prod-indeksen, i motsetning til den mindre bestilling-dev-indeksen.

- Fanger nå også OpenSearchException, slik at søket degraderer til tom traeff-liste i stedet for å kaste et ubehandlet 500.
- Setter unmappedType(Long) på sorteringen slik at shards uten "id"-feltet ikke feiler søket.

Merk: den underliggende mapping-drifta i OpenSearch-indeksen "bestilling" bør fortsatt undersøkes/rettes av teamet (reindeksering eller mapping-fix), denne endringen gjør kun søket robust mot feilen.

#deploy-test-dolly-search-service