### PR TITLE
Fix/dont cache opensearch error fallback

### DIFF
--- a/apps/dolly-search-service/src/main/java/no/nav/testnav/dollysearchservice/service/BestillingQueryService.java
+++ b/apps/dolly-search-service/src/main/java/no/nav/testnav/dollysearchservice/service/BestillingQueryService.java
@@ -8,7 +8,9 @@ import no.nav.testnav.dollysearchservice.dto.SearchRequest;
 import no.nav.testnav.dollysearchservice.utils.FagsystemQueryUtils;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch._types.FieldSort;
+import org.opensearch.client.opensearch._types.OpenSearchException;
 import org.opensearch.client.opensearch._types.SortOptions;
+import org.opensearch.client.opensearch._types.mapping.FieldType;
 import org.opensearch.client.opensearch._types.query_dsl.BoolQuery;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
 import org.opensearch.client.opensearch._types.query_dsl.QueryBuilders;
@@ -81,7 +83,7 @@ public class BestillingQueryService {
             var searchResponse = opensearchClient.search(new org.opensearch.client.opensearch.core.SearchRequest.Builder()
                     .index(bestillingIndex)
                     .query(query)
-                    .sort(SortOptions.of(s -> s.field(FieldSort.of(fs -> fs.field("id")))))
+                    .sort(SortOptions.of(s -> s.field(FieldSort.of(fs -> fs.field("id").unmappedType(FieldType.Long)))))
                     .size(QUERY_SIZE)
                     .timeout("3s")
                     .build(), BestillingIdenter.class);
@@ -98,14 +100,14 @@ public class BestillingQueryService {
                 searchResponse = opensearchClient.search(new org.opensearch.client.opensearch.core.SearchRequest.Builder()
                         .index(bestillingIndex)
                         .query(query)
-                        .sort(SortOptions.of(s -> s.field(FieldSort.of(fs -> fs.field("id")))))
+                        .sort(SortOptions.of(s -> s.field(FieldSort.of(fs -> fs.field("id").unmappedType(FieldType.Long)))))
                         .size(QUERY_SIZE)
                         .searchAfter(lastHit.sort())
                         .timeout("3s")
                         .build(), BestillingIdenter.class);
             }
 
-        } catch (IOException e) {
+        } catch (IOException | OpenSearchException e) {
             log.error("Feil ved henting av identer", e);
             identer = Set.of("99999999999");
         }

--- a/apps/dolly-search-service/src/main/java/no/nav/testnav/dollysearchservice/service/BestillingQueryService.java
+++ b/apps/dolly-search-service/src/main/java/no/nav/testnav/dollysearchservice/service/BestillingQueryService.java
@@ -38,11 +38,13 @@ public class BestillingQueryService {
 
     private static final int QUERY_SIZE = 1000;
     private static final String TESTNORGE_FORMAT = "\\d{2}[8-9]\\d{8}";
+    private static final String OPENSEARCH_ERROR_FALLBACK_IDENT = "99999999999";
     private final OpenSearchClient opensearchClient;
     @Value("${open.search.index}")
     private String bestillingIndex;
 
-    @Cacheable(cacheNames = CACHE_REGISTRE, key = "{#request.registreRequest, #request.miljoer}")
+    @Cacheable(cacheNames = CACHE_REGISTRE, key = "{#request.registreRequest, #request.miljoer}",
+            unless = "#result.contains('" + OPENSEARCH_ERROR_FALLBACK_IDENT + "')")
     public Set<String> execRegisterCacheQuery(SearchRequest request) {
 
         var queryBuilder = getFagsystemAndMiljoerQuery(request);
@@ -109,7 +111,7 @@ public class BestillingQueryService {
 
         } catch (IOException | OpenSearchException e) {
             log.error("Feil ved henting av identer", e);
-            identer = Set.of("99999999999");
+            identer = Set.of(OPENSEARCH_ERROR_FALLBACK_IDENT);
         }
 
         log.info("Uthenting av {} identer tok {} ms", identer.size(), System.currentTimeMillis() - now);


### PR DESCRIPTION
This pull request introduces improvements to error handling and query robustness in the `BestillingQueryService` class. The main changes focus on handling OpenSearch-specific exceptions, ensuring type safety in sorting, and refining cache behavior to avoid storing error results.

**Error handling and fallback improvements:**
* Updated exception handling in `execQuery` to catch both `IOException` and `OpenSearchException`, ensuring that OpenSearch-specific errors are handled gracefully. The fallback identifier is now referenced via a constant for maintainability.
* Introduced the `OPENSEARCH_ERROR_FALLBACK_IDENT` constant to centralize the fallback identifier value and updated all references to use this constant.

**Query and cache robustness:**
* Modified the sort logic in OpenSearch queries to explicitly specify the field type as `Long` for the `id` field. This prevents errors when the field type is ambiguous or unmapped. [[1]](diffhunk://#diff-847c9fd330ff6c4978e97b8f58932b23aca62f28de2b60b63feed55400671620L84-R88) [[2]](diffhunk://#diff-847c9fd330ff6c4978e97b8f58932b23aca62f28de2b60b63feed55400671620L101-R114)
* Enhanced the `@Cacheable` annotation to exclude caching of error fallback results by using the `unless` parameter, which checks for the presence of the fallback identifier in the result.

**Dependency updates:**
* Added imports for `OpenSearchException` and `FieldType` to support the above changes.