### PR TITLE
Fix/opensearch backfill full scan

### DIFF
--- a/apps/dolly-backend/src/main/java/no/nav/dolly/opensearch/utils/OpensearchImport.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/opensearch/utils/OpensearchImport.java
@@ -33,6 +33,7 @@ public class OpensearchImport implements ApplicationListener<ContextRefreshedEve
             "{\"settings\":{\"index\":{\"mapping\":{\"total_fields\":{\"limit\":\"%s\"}}," +
                     "\"number_of_shards\":4," +
                     "\"number_of_replicas\":1}}}";
+    private static final int EXISTS_CHECK_CONCURRENCY = 20;
 
     private final BestillingProgressRepository bestillingProgressRepository;
     private final BestillingRepository bestillingRepository;
@@ -84,7 +85,7 @@ public class OpensearchImport implements ApplicationListener<ContextRefreshedEve
                 .filter(bestilling -> isNotBlank(bestilling.getBestKriterier()) &&
                         !"{}".equals(bestilling.getBestKriterier()))
                 .flatMap(bestilling -> openSearchService.exists(bestilling.getId())
-                        .zipWith(Mono.just(bestilling)))
+                        .zipWith(Mono.just(bestilling)), EXISTS_CHECK_CONCURRENCY)
                 .filter(tuple -> BooleanUtils.isNotTrue(tuple.getT1()))
                 .flatMap(tuple ->
                         bestillingProgressRepository.findAllByBestillingId(tuple.getT2().getId())

--- a/apps/dolly-backend/src/main/java/no/nav/dolly/opensearch/utils/OpensearchImport.java
+++ b/apps/dolly-backend/src/main/java/no/nav/dolly/opensearch/utils/OpensearchImport.java
@@ -85,7 +85,7 @@ public class OpensearchImport implements ApplicationListener<ContextRefreshedEve
                         !"{}".equals(bestilling.getBestKriterier()))
                 .flatMap(bestilling -> openSearchService.exists(bestilling.getId())
                         .zipWith(Mono.just(bestilling)))
-                .takeWhile(tuple -> BooleanUtils.isNotTrue(tuple.getT1()))
+                .filter(tuple -> BooleanUtils.isNotTrue(tuple.getT1()))
                 .flatMap(tuple ->
                         bestillingProgressRepository.findAllByBestillingId(tuple.getT2().getId())
                                 .collectList()

--- a/apps/dolly-search-service/src/main/java/no/nav/testnav/dollysearchservice/service/BestillingQueryService.java
+++ b/apps/dolly-search-service/src/main/java/no/nav/testnav/dollysearchservice/service/BestillingQueryService.java
@@ -67,6 +67,7 @@ public class BestillingQueryService {
         queryBuilder.must(q -> q.regexp(regexpQuery("identer", TESTNORGE_FORMAT)));
 
         return execQuery(queryBuilder).stream()
+                .filter(ident -> !ident.equals(OPENSEARCH_ERROR_FALLBACK_IDENT))
                 .filter(ident -> ident.matches(TESTNORGE_FORMAT))
                 .collect(Collectors.toSet());
     }

--- a/apps/dolly-search-service/src/main/java/no/nav/testnav/dollysearchservice/service/BestillingQueryService.java
+++ b/apps/dolly-search-service/src/main/java/no/nav/testnav/dollysearchservice/service/BestillingQueryService.java
@@ -8,7 +8,9 @@ import no.nav.testnav.dollysearchservice.dto.SearchRequest;
 import no.nav.testnav.dollysearchservice.utils.FagsystemQueryUtils;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch._types.FieldSort;
+import org.opensearch.client.opensearch._types.OpenSearchException;
 import org.opensearch.client.opensearch._types.SortOptions;
+import org.opensearch.client.opensearch._types.mapping.FieldType;
 import org.opensearch.client.opensearch._types.query_dsl.BoolQuery;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
 import org.opensearch.client.opensearch._types.query_dsl.QueryBuilders;
@@ -81,7 +83,7 @@ public class BestillingQueryService {
             var searchResponse = opensearchClient.search(new org.opensearch.client.opensearch.core.SearchRequest.Builder()
                     .index(bestillingIndex)
                     .query(query)
-                    .sort(SortOptions.of(s -> s.field(FieldSort.of(fs -> fs.field("id")))))
+                    .sort(SortOptions.of(s -> s.field(FieldSort.of(fs -> fs.field("id").unmappedType(FieldType.Long)))))
                     .size(QUERY_SIZE)
                     .timeout("3s")
                     .build(), BestillingIdenter.class);
@@ -98,14 +100,14 @@ public class BestillingQueryService {
                 searchResponse = opensearchClient.search(new org.opensearch.client.opensearch.core.SearchRequest.Builder()
                         .index(bestillingIndex)
                         .query(query)
-                        .sort(SortOptions.of(s -> s.field(FieldSort.of(fs -> fs.field("id")))))
+                        .sort(SortOptions.of(s -> s.field(FieldSort.of(fs -> fs.field("id").unmappedType(FieldType.Long)))))
                         .size(QUERY_SIZE)
                         .searchAfter(lastHit.sort())
                         .timeout("3s")
                         .build(), BestillingIdenter.class);
             }
 
-        } catch (IOException e) {
+        } catch (IOException | OpenSearchException e) {
             log.error("Feil ved henting av identer", e);
             identer = Set.of("99999999999");
         }

--- a/apps/dolly-search-service/src/main/java/no/nav/testnav/dollysearchservice/service/BestillingQueryService.java
+++ b/apps/dolly-search-service/src/main/java/no/nav/testnav/dollysearchservice/service/BestillingQueryService.java
@@ -38,11 +38,13 @@ public class BestillingQueryService {
 
     private static final int QUERY_SIZE = 1000;
     private static final String TESTNORGE_FORMAT = "\\d{2}[8-9]\\d{8}";
+    private static final String OPENSEARCH_ERROR_FALLBACK_IDENT = "99999999999";
     private final OpenSearchClient opensearchClient;
     @Value("${open.search.index}")
     private String bestillingIndex;
 
-    @Cacheable(cacheNames = CACHE_REGISTRE, key = "{#request.registreRequest, #request.miljoer}")
+    @Cacheable(cacheNames = CACHE_REGISTRE, key = "{#request.registreRequest, #request.miljoer}",
+            unless = "#result.contains('" + OPENSEARCH_ERROR_FALLBACK_IDENT + "')")
     public Set<String> execRegisterCacheQuery(SearchRequest request) {
 
         var queryBuilder = getFagsystemAndMiljoerQuery(request);
@@ -109,7 +111,7 @@ public class BestillingQueryService {
 
         } catch (IOException | OpenSearchException e) {
             log.error("Feil ved henting av identer", e);
-            identer = Set.of("99999999999");
+            identer = Set.of(OPENSEARCH_ERROR_FALLBACK_IDENT);
         }
 
         log.info("Uthenting av {} identer tok {} ms", identer.size(), System.currentTimeMillis() - now);


### PR DESCRIPTION
This pull request introduces improvements to error handling and query robustness in the `BestillingQueryService`, as well as a small logic change in the OpenSearch import utility. The main focus is on handling OpenSearch errors more gracefully, ensuring consistent fallback behavior, and improving type safety in queries.

**Error handling and fallback improvements:**

* Introduced a constant `OPENSEARCH_ERROR_FALLBACK_IDENT` to centralize the fallback ident used when OpenSearch errors occur, and updated all relevant error handling to use this constant. [[1]](diffhunk://#diff-847c9fd330ff6c4978e97b8f58932b23aca62f28de2b60b63feed55400671620R41-R47) [[2]](diffhunk://#diff-847c9fd330ff6c4978e97b8f58932b23aca62f28de2b60b63feed55400671620L101-R114)
* Updated the `@Cacheable` annotation in `execRegisterCacheQuery` to avoid caching results containing the fallback ident, preventing error states from being cached.
* Expanded exception handling in `execQuery` to include `OpenSearchException` in addition to `IOException`, improving resilience to OpenSearch-related failures.

**Query robustness:**

* Updated the sorting logic in OpenSearch queries to explicitly set `unmappedType` to `FieldType.Long` for the `id` field, improving type safety and preventing errors when the field is missing or has an unexpected type. [[1]](diffhunk://#diff-847c9fd330ff6c4978e97b8f58932b23aca62f28de2b60b63feed55400671620L84-R88) [[2]](diffhunk://#diff-847c9fd330ff6c4978e97b8f58932b23aca62f28de2b60b63feed55400671620L101-R114)

**Logic change in import utility:**

* Changed a `takeWhile` operation to a `filter` in the `importAll` method of `OpensearchImport`, which may affect how items are processed in the import pipeline.